### PR TITLE
Fix #1, custom prompt not showing

### DIFF
--- a/raw-svo.controllers.lua
+++ b/raw-svo.controllers.lua
@@ -346,6 +346,7 @@ end)
 
 signals.gmcpcharname:connect(function()
   innews = nil
+  sk.logged_in = true
 end)
 
 signals.gmcpcharstatus:connect(function()


### PR DESCRIPTION
Variable tracking whenever you're logged in or not was accidentally deleted. This would have been causing other issues in places it's used as well.