### PR TITLE
remove enchanter addon from magi build

### DIFF
--- a/generate.lua
+++ b/generate.lua
@@ -43,12 +43,12 @@ local doall           = args.release
 local name            = args.name
 local release         = not args.debug
 local own             = args.own
-local version         = "3"
+local version         = "4"
 local defaultaddons   = {
   "dragonlimbcounter", "elistsorter", "enchanter", "fishdist", "inker", "logger",  "mindnet", "offering", "peopletracker", "reboundingsileristracker", "refiller", "runeidentifier", "namedb",
   druid = "refiller", sylvan = "refiller", sentinel = "refiller",
   priest = {"priestreport", "priesthealing", "priestlimbcounter"},
-  magi = {"enchanter", "burncounter", "magilimbcounter", "stormhammertarget"},
+  magi = {"burncounter", "magilimbcounter", "stormhammertarget"},
   monk = {"mindnet", "metalimbcounter"}, blademaster = "mindnet",
   infernal = {"knightlimbcounter"},
   runewarden = {"knightlimbcounter"},


### PR DESCRIPTION
The enchanter is included by default so it's not necessary to add it to magi.