### PR TITLE
Added Vertigo for Madness

### DIFF
--- a/raw-svo.dict.lua
+++ b/raw-svo.dict.lua
@@ -1926,7 +1926,7 @@ dict = {
       spriority = 0,
 
       isadvisable = function ()
-        return (affs.vertigo and
+        return (affs.vertigo and not affs.madness and
           not doingaction("vertigo")) or false
       end,
 
@@ -1949,7 +1949,7 @@ dict = {
       spriority = 0,
 
       isadvisable = function ()
-        return (affs.vertigo and
+        return (affs.vertigo and not affs.madness and
           not doingaction("vertigo")) or false
       end,
 

--- a/raw-svo.empty.lua
+++ b/raw-svo.empty.lua
@@ -47,7 +47,7 @@ end
 
 )
 
-#madness_affs = {"addiction", "confusion", "dementia", "hallucinations", "hypersomnia", "illness", "impatience", "lethargy", "loneliness", "madness", "masochism", "paranoia", "recklessness", "stupidity"}
+#madness_affs = {"addiction", "confusion", "dementia", "hallucinations", "hypersomnia", "illness", "impatience", "lethargy", "loneliness", "madness", "masochism", "paranoia", "recklessness", "stupidity", "vertigo"}
 
 #for herbname, herb in pairs({
 #goldenseal = {"dissonance", "impatience", "stupidity", "dizziness", "epilepsy", "shyness"},


### PR DESCRIPTION
After the latest classleads, Vertigo is now a valid affliction for
Whispering Madness/Enlighten, and so the files are updated to reflect
this.

As per the Developer readme, vertigo was added to the raw-svo.empty.lua
madness list, and both the herb and focus parts of the vertigo dict were
updated to check for madness.