### PR TITLE
Add Travis config to generate a release and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: c
+sudo: required
+install:
+- sudo apt-get update
+- sudo apt-get install lua5.1 luarocks p7zip-full python-sphinx
+- sudo luarocks install penlight
+script:
+- bash travis.sh
+notifications:
+  email:
+    on_failure: always
+    on_success: change
+env:
+  global:
+  - GH_REF=github.com/keneanung/svof.git
+  - GH_USER=keneanung
+  - secure: C+qbpZIJp5bpattFoF457Kb7srcfnoX5Rb857Pi2R8UXBxMASLcWV6awCND26Crwm4tEPTs7qupRMeItE19b3PraJcLj3yfl2aipFfJEMflO7CcTkMG20pHlqIbdtr9bQZZRgRRY1N08JOYQF/w4eU/aYNJELApW3wBz7v9T4ONmkRKZtzlJGLD44Fna1Q6Kkdfv92GfusFLb8QZcbZMw3hX1HerHlYazPGwmQsDngPOhk2zbiHUX0cXzHcGRyIijrh7/Bs50XRybOizHjDUqlpcPefdgo6ck0SeenYoWKwTvi2/NBDRXSC8APB6Q0bZ1Q2Zabgeykss0wFx4BYD4xsnBqSAHm5dYRYRRAby63cjUm5or7ht0CEk48dLy3E6FW+8g+KAtb0K5TVYgdWEucml9fJL9bVb1d0N3Exz/94gcI3dwfa0kU0795TfI6P9LCa5AKpukf/Ip9Fgb1Az54U0YnVtz2zJMB7negBEukODv5PWc8mcrgCB7n3bqX4jnMQ0qm8QwhanJgePSlBXaEvlnK4zI9EyepbZ9GPPO/WngvF1fv4iCvcYWDtUzhGMwCCNEFCKEUovCqmJff/bwe20qEoIXVsBVLsTNzuilHUBoMrnLfcRekcx6D9h+jj5e/4GtUKcj223zDPPqGK65YQGn1yzKFLs5NwZljLMVIM=
+deploy:
+  provider: releases
+  api_key:
+    secure: kZ+HEFjXY0YalKVCQhyksvhssdumfaVAXD+U9mBBGp7BbWx5UQ35ZyEQxF5wyZGjst54ByJa1CcEkdvx5DqwwtrCaHIWBj9+SjLz/UStqYjUK3NZA0bqEaRnGCsx+puOg08x+4a8Aya4JgsYmhlv5E3NIrn65et8GPvhYudQGv26aG96I5uGr2zn5/BlbCwMMAfV2y8vU7xwEyH4I5SLEyIzQXGi+obq8Qhvni5GM5YqzyIDeYuK1eIgAcgOWXJYHw2NSBaVIXU1Bao7Nr3Y85vmPkOfqlmo++TjCsfdR7Q6X6SmK4Vq68UWh/X6PJAEs8p3QjZgHZJ/+z8cTG8qh6Dcf5Z3BW29XJtvkSHnW3qY8m1KqOemBNPuIUKsYFDQlrR1hPrEcuFrSBk6wggem4C+VHHyFt8XpOtwWDrz9gXHbU2FkgN4fXjF7PDUY8Hd1hgXkFsvcy2litTNgtTB4KQGvjGfCiPSlpVPiru8BGqB874XsWPUAfhqT6iMzqgpdP9cdG6xstxdLiDmKgFikllisF+9u+1jlrKRw7RgO9UZ4sleU7bzSH6uSGi2+2seSCI7TE+/o0SP43XaihpLTU48gOiadtivCIbgHdpyI5ofvYvDXKsANkJ5G3VfmkgPoVguRDOvKQgDTEZKXEO/NArOUE7+lPfLrPmBCt1ik2M=
+  file_glob: true
+  file: "output/*.zip"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/generate.lua
+++ b/generate.lua
@@ -23,27 +23,21 @@ local cwd = lfs.currentdir()
 
 local args = lapp [[
 -d,--debug  Build with debugging information enabled
--r,--release  Build all systems
+-r,--release (string)  Build all systems
 -o,--own  Build a Svof for yourself
  <name...> (default infernal )  Class to build a system for
 ]]
 
 --[[
- To build a new update, do:
-- commit whatever is left first
-- increment the version in this file
-- run ./precommit.lua
-- bzr commit -m "<new version> update"
-- bzr tag <new version>
-- finally, run ./generate.lua -r && ./generate.lua -u
+  Building new updates is done by creating a new release on GitHub. The rest is done by travis.
 ]]
 
 local builder         = "lua" -- or "luajit"
-local doall           = args.release
+local doall           = not not args.release -- make doall a bool
 local name            = args.name
 local release         = not args.debug
 local own             = args.own
-local version         = "3"
+local version         = args.release
 local defaultaddons   = {
   "dragonlimbcounter", "elistsorter", "enchanter", "fishdist", "inker", "logger", "offering", "peopletracker", "reboundingsileristracker", "refiller", "runeidentifier", "namedb",
   druid = "refiller", sylvan = "refiller", sentinel = "refiller",

--- a/precommit.lua
+++ b/precommit.lua
@@ -8,38 +8,32 @@
 -- You should have received a copy of the license along with this
 -- work. If not, see <http://creativecommons.org/licenses/by-nc-sa/4.0/>.
 
+-- get release version from command line
+local args = {...}
+local systemversion = args[1]
 
 -- copy to template
-os.execute([[cp '/home/vadi/Games/Mudlet/svo (install the zip, not me).xml' '/home/vadi/Games/Mudlet/svo template/svo (install the zip, not me).xml']])
-
--- docs
-assert(io.input("/home/vadi/Games/Mudlet/svo/generate.lua"))
-t = io.read("*all")
-systemversion = string.match(t, [[version *= "(.-)"]])
+os.execute([[cp 'svo (install the zip, not me).xml' 'svo template/svo (install the zip, not me).xml']])
 
 -- update version in docs
-io.input("/home/vadi/Games/Mudlet/svo/doc/conf.py")
+io.input("doc/conf.py")
 t = io.read("*all")
 t = string.gsub(t, [[version = '.-']], string.format("version = '%s'", systemversion))
 t = string.gsub(t, [[release = '.-']], string.format("release = '%s'", systemversion))
-io.output("/home/vadi/Games/Mudlet/svo/doc/conf.py")
+io.output("doc/conf.py")
 io.write(t)
 
 
 -- make
-os.execute([[cd ~/Games/Mudlet/svo/doc && sphinx-build -j 4 -b html -d _build/doctrees   . _build/html]])
+os.execute([[cd doc && sphinx-build -b html -d _build/doctrees . _build/html]])
 
 -- update ndb cache listing
-package.path = package.path .. ";../mm/doc/?.lua"
+package.path = package.path .. ";./doc/?.lua"
 gl     = require"parse_glossary"
 pretty = require"pl.pretty"
 
 local data = gl.striptrailinglines(gl.readfile("doc/namedb.rst"))
 
-local f = io.open([[/home/vadi/Games/Mudlet/svo template/ndb-help.lua]], "w+")
-f:write(pretty.write(data))
-f:close()
-
-f = io.open([[/home/vadi/mudlet-data/profiles/svo/Vadimuses svo/ndb-help.lua]], "w+")
+local f = io.open([[svo template/ndb-help.lua]], "w+")
 f:write(pretty.write(data))
 f:close()

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,25 @@
+if [ -z "$TRAVIS_TAG" ]
+then
+  echo "No tag, no release."
+  exit 0
+fi
+
+lua generate.lua -r "$TRAVIS_TAG"
+lua precommit.lua "$TRAVIS_TAG"
+
+cd doc/_build/html
+touch .nojekyll
+
+git init
+
+git config user.name "Travis CI"
+git config user.email "keneanung@googlemail.com"
+
+git add .
+git commit -m "Deploy to GitHub Pages"
+
+# Force push from the current repo's master branch to the remote
+# repo's gh-pages branch. (All previous history on the gh-pages branch
+# will be lost, since we are overwriting it.) We redirect any output to
+# /dev/null to hide any sensitive credential data that might otherwise be exposed.
+git push --force --quiet "https://${GH_USER}:${GH_TOKEN}@${GH_REF}" master:gh-pages > /dev/null 1>&2


### PR DESCRIPTION
The travis.yml will not work after commit into the svof repo as each encryption
key is bound to each repo. My preference would be to create a machine account
and record the credentials in a special helpfile in the svof clan with read
permissions for a special clan position which corresponds to the owner group in
the org. I'd be willing to set everything up with that bot.

This fixes #36 