### PR TITLE
fix dragon form detection

### DIFF
--- a/raw-svo.dict.lua
+++ b/raw-svo.dict.lua
@@ -14872,7 +14872,7 @@ signals.dragonform:connect(function ()
 end)
 signals.systemstart:connect(function () signals.dragonform:emit() end)
 signals.gmcpcharstatus:connect(function ()
-  if gmcp.Char.Status.race == "Dragon" then
+  if gmcp.Char.Status.race:find("Dragon") then
     defences.got("dragonform")
   else
     defences.lost("dragonform")


### PR DESCRIPTION
Colors were added to the value of gmcp.Char.Status.race. This changes it to look for Dragon instead of checking if it's equal to Dragon.