### PR TITLE
Don't use ftps for upload

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -79,8 +79,8 @@ echo "${TRAVIS_TAG}" > current_version.txt
 for f in *
 do
   echo "Uploading ${f}"
-  curl -3 -k --disable-epsv --ftp-skip-pasv-ip \
-  --ftp-ssl -u "svof-machine-account:${FTP_PASS}" -T "${f}" "ftp://ftp.pathurs.com" &> /dev/null
+  curl -3 --disable-epsv --ftp-skip-pasv-ip \
+  -u "svof-machine-account:${FTP_PASS}" -T "${f}" "ftp://ftp.pathurs.com" &> /dev/null
   stat=$?
   if [ "$stat" -ne 0 ]; then
     echo "Could not upload ${f}: Return code was ${stat}"


### PR DESCRIPTION
Seems like curl on Travis still verifies the FTPs cert even though the option -k
was used. Disabling the use of SSL for now.

@vadi2 can you review it?
