### PR TITLE
Remove weariness from focus_cured_* functions

### DIFF
--- a/raw-svo.valid.main.lua
+++ b/raw-svo.valid.main.lua
@@ -2775,7 +2775,7 @@ end
 
 -- focus
 #do
-#local afflist = {"claustrophobia", "weakness", "masochism", "dizziness", "confusion", "stupidity", "generosity", "loneliness", "agoraphobia", "recklessness", "epilepsy", "pacifism", "anorexia", "shyness", "vertigo", "fear", "airdisrupt", "firedisrupt", "waterdisrupt"}
+#local afflist = {"claustrophobia", "masochism", "dizziness", "confusion", "stupidity", "generosity", "loneliness", "agoraphobia", "recklessness", "epilepsy", "pacifism", "anorexia", "shyness", "vertigo", "fear", "airdisrupt", "firedisrupt", "waterdisrupt"}
 #local checkany_string = ""
 #local temp = {}
 


### PR DESCRIPTION
This fixes svof/svof#144. It caused the "checkany" function to error out and
thus clear all focusable afflictions.

Signed-off-by: keneanung <keneanung@googlemail.com>