### PR TITLE
Update .travis.yml to use a higher ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: c
+language: ruby
+rvm: 
+- 2.2.5
 sudo: required
 install:
 - sudo apt-get update


### PR DESCRIPTION
looks like one dependency for the github_changelog_generator requires ruby
2.2.2 or higher, while travis only supplies 2.2.0 by default. This should
hopefully fix the error.