### PR TITLE
Make sure howMany parameter of getSameItems is a number

### DIFF
--- a/svo (enchanter).xml
+++ b/svo (enchanter).xml
@@ -1038,6 +1038,8 @@ end
 
 -- gets howMany unworn items with the same short desc as what for enchanting
 local function getSameItems(howMany, what)
+  howMany = tonumber(howMany)
+
   -- lets get the short desc first
   local shortDesc
   for _, item in ipairs(svo.me.inventory) do


### PR DESCRIPTION
Earlier we compared numbers to strings (`string.match` with `%w` returns a string) and thus never stopped returning items for enchanting.