### PR TITLE
Fix the ndb cheat sheet

### DIFF
--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -2645,7 +2645,7 @@ send(matches[2]..&quot; enemies&quot;, false)</script>
 
 -- load help data in
 if not ndb.help then
-  local path = getMudletHomeDir()..&quot;/&quot;..class..&quot; svo&quot;
+  local path = getMudletHomeDir()..&quot;/&quot;..class..&quot; svo/ndb-help.lua&quot;
   if not lfs.attributes(path) then
   -- not found? Lets try the dev version
     local svo_location = getMudletHomeDir() .. _sep .. &quot;svo_location&quot;


### PR DESCRIPTION
Formerly `path` only contained the actual path, no cheat sheet file, which of course can't be opened as a file. This fixes this by checking the path inclusive file for existance.