### PR TITLE
Move release zips to GitHub pages

### DIFF
--- a/raw-svo.config.lua
+++ b/raw-svo.config.lua
@@ -1887,7 +1887,39 @@ config_dict = pl.OrderedMap {
     onenabled = function () echof("<0,250,0>Will%s notify you when GMCP updates your defences.", getDefaultColor()) end,
     ondisabled = function () echof("<250,0,0>Won't%s notify you when GMCP updates your defences.", getDefaultColor()) end,
   }},
+#conf_name = "releasechannel"
+  {$(conf_name) = {
+    type = "string",
+    vconfig2string = true,
+    onshow = function (defaultcolour)
+      fg(defaultcolour)
+      echo("Will use the ")
+      fg("a_cyan")
+      echoLink(tostring(conf.releasechannel),
+        'printCmdLine("vconfig releasechannel ")',
+        "Set the release channel to use for updates.",
+        true
+      )
+      fg(defaultcolour)
+      echo(" channel for downloading updates.\n")
+    end,
+    check = function (what)
+      if what == "stable" or what == "testing" then return true end
+    end,
+    onset = function ()
+      conf.releasechannel = conf.releasechannel:lower()
+      echof("Will use the '%s' release channel for updates.",
+        conf.releasechannel)
+    end,
+    installstart = function ()
+      conf.releasechannel = "stable"
+    end
+  }},
 }
+
+if not conf.releasechannel then
+  conf.releasechannel = "stable"
+end
 
 do
   local conf_t = {}

--- a/svo (install the zip, not me).xml
+++ b/svo (install the zip, not me).xml
@@ -55086,6 +55086,7 @@ end</script>
                     <name>Check for updates</name>
                     <packageName></packageName>
                     <script>local downloadfolder = getMudletHomeDir()..&quot;/svo/downloads/&quot;
+local baseUrl = string.format(&quot;http://svof.github.io/svof/%s/&quot;, &quot;stable&quot;)
 
 -- this should get called at start and every hour after that
 function svo.checkforupdate(type)
@@ -55106,7 +55107,7 @@ function svo.checkforupdate(type)
     end
 
     svo.checkingupdates = true
-    downloadFile(svo.versionfile, &quot;http://svof.pathurs.com/current_version&quot;)
+    downloadFile(svo.versionfile, baseUrl .. &quot;current_version.txt&quot;)
 
     if type == &quot;checking&quot; then
       svo.echof(&quot;Checking for updates...&quot;)
@@ -55137,7 +55138,7 @@ end
 -- downloads the system &amp; updates the system version saved
 function svo.downloadnewsystem(newversion)
   svo.downloadedsystem = downloadfolder..string.format(&quot;%s.Svof.current.zip&quot;, svo.me.class)
-  local downloadurl = [[http://svof.pathurs.com/]]..svo.me.class..[[.Svof.v]]..newversion..[[.zip]]
+  local downloadurl = baseUrl..svo.me.class..[[.Svof.v]]..newversion..[[.zip]]
 
   downloadFile(svo.downloadedsystem, downloadurl)
   svo.newdownloadedversion = newversion

--- a/svo (install the zip, not me).xml
+++ b/svo (install the zip, not me).xml
@@ -55086,7 +55086,7 @@ end</script>
                     <name>Check for updates</name>
                     <packageName></packageName>
                     <script>local downloadfolder = getMudletHomeDir()..&quot;/svo/downloads/&quot;
-local baseUrl = string.format(&quot;http://svof.github.io/svof/%s/&quot;, &quot;stable&quot;)
+local baseUrl = string.format(&quot;http://svof.github.io/svof/%s/&quot;, svo.conf.releasechannel)
 
 -- this should get called at start and every hour after that
 function svo.checkforupdate(type)

--- a/travis.sh
+++ b/travis.sh
@@ -17,6 +17,19 @@ fi
 # Create current_version file
 echo "${TRAVIS_TAG}" > output/current_version.txt
 
+# upload everything here.
+for f in *
+do
+  echo "Uploading ${f}"
+  curl -3 --disable-epsv --ftp-skip-pasv-ip \
+  -u "svof-machine-account:${FTP_PASS}" -T "${f}" "ftp://ftp.pathurs.com" &> /dev/null
+  stat=$?
+  if [ "$stat" -ne 0 ]; then
+    echo "Could not upload ${f}: Return code was ${stat}"
+    exit 1
+  fi
+done
+
 # Create documentation for the release
 cd doc/_build/html
 touch .nojekyll

--- a/travis.sh
+++ b/travis.sh
@@ -14,9 +14,18 @@ then
   exit 0
 fi
 
+# Create current_version file
+echo "${TRAVIS_TAG}" > output/current_version.txt
+
 # Create documentation for the release
 cd doc/_build/html
 touch .nojekyll
+
+mkdir stable
+cp ../../../output/* stable/
+
+mkdir testing
+cp ../../../output/* testing/
 
 git init
 
@@ -73,24 +82,3 @@ then
   echo "Updating release body failed:" "$http_code"
   exit 1
 fi
-
-# Upload release zip files via sftp so automatic updates work
-
-# Change to output directory
-cd output
-
-# Create current_version file
-echo "${TRAVIS_TAG}" > current_version.txt
-
-# upload everything here.
-for f in *
-do
-  echo "Uploading ${f}"
-  curl -3 --disable-epsv --ftp-skip-pasv-ip \
-  -u "svof-machine-account:${FTP_PASS}" -T "${f}" "ftp://ftp.pathurs.com" &> /dev/null
-  stat=$?
-  if [ "$stat" -ne 0 ]; then
-    echo "Could not upload ${f}: Return code was ${stat}"
-    exit 1
-  fi
-done


### PR DESCRIPTION
As per announcement on the Achaean forums:

> First of all, I am planning to move away from the server Pathers kindly allowed us to use. The most important reason is that it allows me some more flexibility.
> 
> Which leads directly tp my next point. I'd like to offer two release channels in the future. One default "stable" channel is for all normal releases right now. The second one will be "testing", which will see certain changes earlier, but may run into issues because... Well it's testing. There may be more channels in the future, when I need more.
>
> Third has to do with the point above as well. I will streatch the release cycle. Stable release will be released around the 1st of each month, while new releases in "testing" will probably start appearing around the 15th each month. At that point, there will be a feature freeze and new code will only be added to fix bugs that appear through testing. This is, because I plan bigger changes in the near future that may help implementing multiclass, and because it gives me a little leeway on other projects I'd like to follow.