### PR TITLE
Fix sk.canfocus function to return false if it shouldn't focus

### DIFF
--- a/raw-svo.config.lua
+++ b/raw-svo.config.lua
@@ -2093,7 +2093,7 @@ tntf_tbl = {
       sendcuring("afflictions on")
       sendcuring("sipping on")
       sendcuring("defences on")
-      sendcuring("focus on")
+      sendcuring("focus " .. (conf.focus and "on" or "off"))
       sendcuring("batch on")
       sendc("config advancedcuring on")
       sendcuring("reporting on")

--- a/raw-svo.serverside.lua
+++ b/raw-svo.serverside.lua
@@ -481,7 +481,11 @@ signals["svo config changed"]:connect(function(config)
   if config ~= "serverside" then return end
 
   if conf.serverside then
-    sk.priochangecache = { special = {} }
+    sk.priochangecache = {
+      special = {
+        focustoggle = conf.focus
+      }
+    }
     -- sync everything
     sk.priosbeforechange = sk.getblankbeforestateprios()
     sendcuring("PRIORITY RESET")

--- a/raw-svo.serverside.lua
+++ b/raw-svo.serverside.lua
@@ -729,7 +729,7 @@ signals["svo config changed"]:connect(function(config)
 end)
 
 
--- if we've got cadmus, and have one of of the me.cadmusaffs afflictions, then we should focus
+-- if we've got cadmus, and have one of the me.cadmusaffs afflictions, then we should focus
 function sk.canfocus()
   -- check if we haven't got cadmus
   if not affs.cadmus then return true end
@@ -742,7 +742,7 @@ function sk.canfocus()
     end
   end
 
-  return true
+  return false
 end
 
 function sk.togglefocusserver()


### PR DESCRIPTION
While svof was prepared to toggle server side focus on cadmus, the can focus never returned false and thus never turned focus off.

This fixes svof/svof#265 when merged