### PR TITLE
Track current morph via gmcp

### DIFF
--- a/raw-svo.customprompt.lua
+++ b/raw-svo.customprompt.lua
@@ -303,15 +303,8 @@ end
 
 #if skills.metamorphosis then
 cpp.compute_morph = function()
-  local morphs = {"hydra", "wyvern", "icewyrm", "gorilla", "eagle", "jaguar", "wolverine", "elephant", "nightingale", "bear", "basilisk", "sloth", "gopher", "condor", "hyena", "owl", "cheetah", "jackdaw", "turtle", "wolf", "wildcat", "squirrel"}
+  return me.morph or ""
 
-  for i = 1, #morphs do
-    local morph = morphs[i]
-
-    if defc[morph] then return morph end
-  end
-
-  return ''
 end
 #end
 

--- a/raw-svo.defs.lua
+++ b/raw-svo.defs.lua
@@ -969,8 +969,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "Your heart beats faster and you look about anxiously as the spirit of the Squirrel inhabits your soul.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A squirrel spirit co-habits your body." })
   defs_data:set("wildcat", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -983,8 +981,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You feel quick and alert as you receive the gifts of the Wildcat.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A wildcat spirit co-habits your body." })
   defs_data:set("wolf", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -997,8 +993,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You cast your eyes upwards towards the moon, as the howl of the Wolf rings in your ears.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A wolf spirit co-habits your body." })
   defs_data:set("turtle", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1011,7 +1005,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You feel the power of the oceans as the spirit of the Turtle enters you.",
     def = "A turtle spirit co-habits your body." })
   defs_data:set("jackdaw", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1024,8 +1017,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You feel the spirit of the Jackdaw peering cautiously out from behind your beady eyes.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A jackdaw spirit co-habits your body." })
   defs_data:set("cheetah", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1038,7 +1029,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You welcome the spirit of the Cheetah into your soul.",
     def = "A cheetah spirit co-habits your body." })
   defs_data:set("owl", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1051,8 +1041,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "A sense of inner wisdom and peace spreads through your mind as the spirit of the Owl works its influence.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "An owl spirit co-habits your body." })
   defs_data:set("hyena", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1065,8 +1053,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You gaze impassionately at the world through cold eyes as the Hyena takes hold.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A hyena spirit co-habits your body." })
   defs_data:set("condor", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1079,8 +1065,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "Your soul soars as the buoyant spirit of the Condor joins you.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A condor spirit co-habits your body." })
   defs_data:set("gopher", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1093,8 +1077,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "As the spirit of the Gopher enters you, the ground begins to look quite tempting.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A gopher spirit co-habits your body." })
   defs_data:set("sloth", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1107,8 +1089,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You yawn and slouch about as the spirit of the Sloth permeates your being.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A sloth spirit co-habits your body." })
 #if class == "sentinel" then
   defs_data:set("basilisk", { type = "metamorphosis",
@@ -1122,7 +1102,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "Your breathing slows to a gentle whisper as the stealthy spirit of the Basilisk approaches and takes form within you.",
     def = "A basilisk spirit co-habits your body." })
 #end
   defs_data:set("bear", { type = "metamorphosis",
@@ -1136,8 +1115,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You feel the spirit of the mighty Grizzly enter your body as your limbs grow in massive power.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A bear spirit co-habits your body." })
   defs_data:set("nightingale", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1150,8 +1127,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "Strains of birdsong fill your ears as the spirit of the Nightingale is summoned to you.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A nightingale spirit co-habits your body." })
   defs_data:set("elephant", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1164,8 +1139,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "The spirit of the massive Elephant enters your body, and all obstacles seem as nothing.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "An elephant spirit co-habits your body." })
   defs_data:set("wolverine", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1178,8 +1151,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "Your muscles feel like taut steel as the spirit of the Wolverine enters you.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A wolverine spirit co-habits your body." })
 #if class == "sentinel" then
   defs_data:set("jaguar", { type = "metamorphosis",
@@ -1193,8 +1164,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You settle back on your haunches, revelling in the natural power and confidence of the spirit of the Jaguar.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A jaguar spirit co-habits your body." })
 #end
   defs_data:set("eagle", { type = "metamorphosis",
@@ -1208,8 +1177,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "Your soul dwells resplendent in companion with the majesty of the spirit of the Eagle.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "An eagle spirit co-habits your body." })
   defs_data:set("gorilla", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1222,8 +1189,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "Your arms fill with power and you feel nimbleness and strength imbue you as the spirit of the Gorilla enters you.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A gorilla spirit co-habits your body." })
   defs_data:set("icewyrm", { type = "metamorphosis",
     onenable = function (mode, newdef, whereto, echoback)
@@ -1236,7 +1201,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "Images of cold, unseen lands drift before your mind's eye as the mysterious spirit of the Icewyrm dwells within your uneasy soul.",
     def = "An icewyrm spirit co-habits your body." })
 #if class == "druid" then
   defs_data:set("wyvern", { type = "metamorphosis",
@@ -1250,8 +1214,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You raise your arms aloft and roar aloud a challenge to the heavens as you take on the form of ultimate power - the spirit of the Wyvern.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A wyvern spirit co-habits your body." })
 
   defs_data:set("hydra", { type = "metamorphosis",
@@ -1265,8 +1227,6 @@ defs_data = pl.OrderedMap {}
 
       return true
     end,
-    on = "You are overcome with power as the monstrous spirit of the Hydra enters you.",
-    offr = {[[^Your soul quakes and shifts as the spirits depart, leaving you .+ once more\.$]], [[^You remain in .+ form, dolt\.$]]},
     def = "A hydra spirit co-habits your body."})
 #end
 #end

--- a/raw-svo.setup.lua
+++ b/raw-svo.setup.lua
@@ -253,6 +253,29 @@ signals.gmcpcharvitals:connect(function()
     stats.battlerage = tonumber(val:match("^Rage: (%d+)$") or stats.battlerage or 0)
   end
 end)
+#if skills.metamorphosis then
+signals.gmcpcharvitals:connect(function()
+  if gmcp.Char.Vitals.charstats then
+    for index, val in ipairs(gmcp.Char.Vitals.charstats) do
+      local morph = val:match("^Morph: (%w+)$")
+      if morph then
+        morph = morph:lower()
+        me.morph = morph
+        if not defc[morph] then
+          sk.clearmorphs()
+          if morph ~= "none" then
+            defences.got(morph)
+          end
+        end
+        break
+      end
+    end
+  end
+  if not me.morph then
+    me.morph = ""
+  end
+end)
+#end
 signals.gmcpiretimelist = luanotify.signal.new()
 signals.gmcpiretimelist:connect(function()
   me.gametime = deepcopy(gmcp.IRE.Time.List)

--- a/raw-svo.skeleton.lua
+++ b/raw-svo.skeleton.lua
@@ -1882,7 +1882,9 @@ function sk.clearmorphs()
     {"squirrel", "wildcat", "wolf", "turtle", "jackdaw", "cheetah", "owl", "hyena", "condor", "gopher", "sloth", "basilisk", "bear", "nightingale", "elephant", "wolverine", "jaguar", "eagle", "gorilla", "icewyrm"}
 #end
      do
-    defences.lost(morph)
+    if defc[morph] then
+      defences.lost(morph)
+    end
   end
 end
 


### PR DESCRIPTION
Tracking morphs with gmcp instead of triggers makes it more reliable and illusion proof.