### PR TITLE
Add exception of "mount figurehead" to riding tracking

### DIFF
--- a/svo (install the zip, not me).xml
+++ b/svo (install the zip, not me).xml
@@ -53848,7 +53848,15 @@ svo.toggle_ignore(matches[2])</script>
             </Alias>
             <Alias isActive="yes" isFolder="no">
                 <name>Remember vault/mount</name>
-                <script>if matches[3] == &quot;ship&quot; then send(cmd, false) end
+                <script>if matches[3] == &quot;ship&quot; then
+  send(command, false)
+  return
+end
+
+if string.starts(matches[3]:lower(), &quot;figurehead&quot;) then
+  send(command, false)
+  return
+end
 
 if svo.conf.ridingskill ~= matches[2] then
   svo.echof(&quot;Remembered your riding skill at '%s'&quot;, matches[2])


### PR DESCRIPTION
When using "mount figurehead", svof would set your riding ability to "mount" and the mount to use to "figurehead". This includes an exception for that case now.

Also "board ship" would be triggered and sent unchanged, but the same things as above would have been done.

Fixes svof/svof#186