### PR TITLE
Move to trusty VMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm: 
 - 2.2.5
+dist: trusty
 sudo: required
 install:
 - sudo apt-get update


### PR DESCRIPTION
This will move our CI infastructure to Ubuntu trusty, because precise (which we used before) went out of support.