### PR TITLE
Shikudo Additions, Part Deux

### DIFF
--- a/classlist.lua
+++ b/classlist.lua
@@ -17,7 +17,7 @@ skills = {
   infernal     = {"necromancy", "chivalry", "weaponmastery"},
   jester       = {"tarot", "pranks", "puppetry"},
   magi         = {"elementalism", "crystalism", "artificing"},
-  monk         = {"tekura", "kaido", "telepathy"},
+  monk         = {"tekura", "kaido", "telepathy", "shikudo"},
   none         = {},
   occultist    = {"occultism", "tarot", "domination"},
   paladin      = {"chivalry", "devotion", "weaponmastery"},
@@ -26,6 +26,5 @@ skills = {
   sentinel     = {"metamorphosis", "woodlore", "skirmishing"},
   serpent      = {"subterfuge", "venom", "hypnosis"},
   shaman       = {"runelore", "curses", "vodun"},
-  shikudo      = {"shikudo", "kaido", "telepathy"},
   sylvan       = {"weatherweaving", "groves", "propagation"},
 }

--- a/classlist.lua
+++ b/classlist.lua
@@ -26,5 +26,6 @@ skills = {
   sentinel     = {"metamorphosis", "woodlore", "skirmishing"},
   serpent      = {"subterfuge", "venom", "hypnosis"},
   shaman       = {"runelore", "curses", "vodun"},
+  shikudo      = {"shikudo", "kaido", "telepathy"},
   sylvan       = {"weatherweaving", "groves", "propagation"},
 }

--- a/raw-svo.customprompt.lua
+++ b/raw-svo.customprompt.lua
@@ -314,6 +314,24 @@ cpp.compute_sunlight = function()
 end
 #end
 
+#if skills.tekura then
+cpp.compute_monkpath = function()
+  return me.path or ""
+end
+
+cpp.compute_stanceform = function()
+  return me.stance or me.form or ""
+end
+
+cpp.compute_stanceform_verbose = function()
+  return string.format(
+    "%s: %s", 
+    cpp.compute_monkpath(), 
+    cpp.compute_stanceform()
+  )
+end
+#end
+
 cpp.compute_promptstring = function()
  return ("<LightSlateGrey>")..
         (defc.cloak and "c" or "") ..
@@ -452,6 +470,11 @@ cp.definitions = {
 #end
 #if skills.venom then
   ["@shrugging"]     = "svo.cpp.compute_shruggingbal()",
+#end
+#if skills.tekura or skills.shikudo then
+  ["@monkpath"]      = "svo.cpp.compute_monkpath()",
+  ["@monkstance"]        = "svo.cpp.compute_stanceform()",
+  ["@monkfull"]      = "svo.cpp.compute_stanceform_verbose()",
 #end
 #if skills.kaido then
   ["@kai"]           = "svo.cpp.compute_kai()",

--- a/raw-svo.defs.lua
+++ b/raw-svo.defs.lua
@@ -1799,42 +1799,42 @@ defs_data = pl.OrderedMap {}
     onenable = onenable_shikudo,
     def = "You are enacting the Tykonos form.",
     on = "You spin your staff in the opening sequence of the form of Tykonos, snapping into a ready stance.",
-    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+    off = [[^You clumsily transition from the form of \w+ into the form of]]
   })
   defs_data:set("willow", { 
     type = "shikudo",
     onenable = onenable_shikudo,
     def = "You are enacting the Willows shaken by the Wind form..",
     on = "Twirling your staff, you sink into the calm required for the form of Willows Shaken by the Wind.",
-    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+    off = [[^You clumsily transition from the form of \w+ into the form of]]
   })
   defs_data:set("rain", { 
     type = "shikudo",
     onenable = onenable_shikudo,
     def = "You are enacting the Willows in Rain Storm form.",
     on = "Dropping into a lower stance, you snap your weapon into an offensive position, tensing your muscles in preparation for the form of Willows in Rain Storm.",
-    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+    off = [[^You clumsily transition from the form of \w+ into the form of]]
   })
   defs_data:set("oak", { 
     type = "shikudo",
     onenable = onenable_shikudo,
     def = "You are enacting the the Live Oak form.",
     on = "Rising onto the balls of your feet, you prepare to begin the deadly form of the Live Oak.",
-    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+    off = [[^You clumsily transition from the form of \w+ into the form of]]
   })
   defs_data:set("gaital", { 
     type = "shikudo",
     onenable = onenable_shikudo,
     def = "You are enacting the Gaital form.",
     on = "You let your eyes fall closed and instinct guide you as you flow into the form of Gaital.",
-    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+    off = [[^You clumsily transition from the form of \w+ into the form of]]
   })
   defs_data:set("maelstrom", { 
     type = "shikudo",
     onenable = onenable_shikudo,
     def = "You are enacting the the Unrelenting Storm form.",
     on = "You allow your kai to flow through you, circulating throughout your limbs and down your weapon in preparation to begin the form of the Unrelenting Storm.",
-    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+    off = [[^You clumsily transition from the form of \w+ into the form of]]
   })
   defs_data:set("grip", { 
     type = "shikudo",

--- a/raw-svo.defs.lua
+++ b/raw-svo.defs.lua
@@ -1804,7 +1804,7 @@ defs_data = pl.OrderedMap {}
   defs_data:set("willow", { 
     type = "shikudo",
     onenable = onenable_shikudo,
-    def = "You are enacting the Willows shaken by the Wind form..",
+    def = "You are enacting the Willows shaken by the Wind form.",
     on = "Twirling your staff, you sink into the calm required for the form of Willows Shaken by the Wind.",
     off = [[^You clumsily transition from the form of \w+ into the form of]]
   })

--- a/raw-svo.defs.lua
+++ b/raw-svo.defs.lua
@@ -1784,10 +1784,10 @@ defs_data = pl.OrderedMap {}
     local fail_string =
       "Removed %s from %s, it's incompatible with %s to have simultaneously up."
 
-    for _, morph in ipairs(shikudo_forms) do
-      if morph ~= newdef and svo["def"..whereto][mode][morph] then
-        svo["def"..whereto][mode][morph] = false
-        if echoback then echof(fail_string, morph, whereto, newdef) end
+    for _, shikudo_form in ipairs(shikudo_forms) do
+      if shikudo_form ~= newdef and svo["def"..whereto][mode][shikudo_form] then
+        svo["def"..whereto][mode][shikudo_form] = false
+        if echoback then echof(fail_string, shikudo_form, whereto, newdef) end
       end
     end
 

--- a/raw-svo.defs.lua
+++ b/raw-svo.defs.lua
@@ -1793,7 +1793,7 @@ defs_data = pl.OrderedMap {}
 
     return true
   end
-
+  
   defs_data:set("tykonos", { 
     type = "shikudo",
     onenable = onenable_shikudo,
@@ -1804,7 +1804,7 @@ defs_data = pl.OrderedMap {}
   defs_data:set("willow", { 
     type = "shikudo",
     onenable = onenable_shikudo,
-    def = "You are enacting the Willow form.",
+    def = "You are enacting the Willows shaken by the Wind form..",
     on = "Twirling your staff, you sink into the calm required for the form of Willows Shaken by the Wind.",
     off = [[^You clumsily transition from the form of \w+ into the form of .+]]
   })
@@ -1836,6 +1836,11 @@ defs_data = pl.OrderedMap {}
     on = "You allow your kai to flow through you, circulating throughout your limbs and down your weapon in preparation to begin the form of the Unrelenting Storm.",
     off = [[^You clumsily transition from the form of \w+ into the form of .+]]
   })
+  defs_data:set("grip", { 
+    type = "shikudo",
+    on = {"You concentrate on gripping tightly with your hands.", "You are already tightly gripping with your hands."},
+    def = "Your hands are gripping your wielded items tightly.",
+    off = "You relax your grip."})
 #end
 
 #if skills.tekura then

--- a/raw-svo.defs.lua
+++ b/raw-svo.defs.lua
@@ -1770,6 +1770,74 @@ defs_data = pl.OrderedMap {}
     off = "You cease concentrating on immunity."})
 #end
 
+#if skills.shikudo then
+  local onenable_shikudo = function (mode, newdef, whereto, echoback)
+    local shikudo_forms = {
+      "tykonos", 
+      "willow", 
+      "rain", 
+      "oak", 
+      "gaital", 
+      "maelstrom"
+    }
+
+    local fail_string =
+      "Removed %s from %s, it's incompatible with %s to have simultaneously up."
+
+    for _, morph in ipairs(shikudo_forms) do
+      if morph ~= newdef and svo["def"..whereto][mode][morph] then
+        svo["def"..whereto][mode][morph] = false
+        if echoback then echof(fail_string, morph, whereto, newdef) end
+      end
+    end
+
+    return true
+  end
+
+  defs_data:set("tykonos", { 
+    type = "shikudo",
+    onenable = onenable_shikudo,
+    def = "You are enacting the Tykonos form.",
+    on = "You spin your staff in the opening sequence of the form of Tykonos, snapping into a ready stance.",
+    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+  })
+  defs_data:set("willow", { 
+    type = "shikudo",
+    onenable = onenable_shikudo,
+    def = "You are enacting the Willow form.",
+    on = "Twirling your staff, you sink into the calm required for the form of Willows Shaken by the Wind.",
+    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+  })
+  defs_data:set("rain", { 
+    type = "shikudo",
+    onenable = onenable_shikudo,
+    def = "You are enacting the Willows in Rain Storm form.",
+    on = "Dropping into a lower stance, you snap your weapon into an offensive position, tensing your muscles in preparation for the form of Willows in Rain Storm.",
+    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+  })
+  defs_data:set("oak", { 
+    type = "shikudo",
+    onenable = onenable_shikudo,
+    def = "You are enacting the the Live Oak form.",
+    on = "Rising onto the balls of your feet, you prepare to begin the deadly form of the Live Oak.",
+    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+  })
+  defs_data:set("gaital", { 
+    type = "shikudo",
+    onenable = onenable_shikudo,
+    def = "You are enacting the Gaital form.",
+    on = "You let your eyes fall closed and instinct guide you as you flow into the form of Gaital.",
+    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+  })
+  defs_data:set("maelstrom", { 
+    type = "shikudo",
+    onenable = onenable_shikudo,
+    def = "You are enacting the the Unrelenting Storm form.",
+    on = "You allow your kai to flow through you, circulating throughout your limbs and down your weapon in preparation to begin the form of the Unrelenting Storm.",
+    off = [[^You clumsily transition from the form of \w+ into the form of .+]]
+  })
+#end
+
 #if skills.tekura then
   defs_data:set("guarding", { nodef = true,
     ondef = function ()

--- a/raw-svo.dict.lua
+++ b/raw-svo.dict.lua
@@ -6290,13 +6290,13 @@ dict = {
       isadvisable = function ()
         return (not sys.sp_satisfied and not sys.blockparry and not affs.paralysis
           and not doingaction "doparry" and (
-#if class == "monk" then
+#if skills.tekura then
             conf.guarding
 #else
             conf.parry
 #end
            ) and not codepaste.balanceful_codepaste()
-#if class ~= "blademaster" and class ~= "monk" then
+#if class ~= "blademaster" and not skills.tekura then
           -- blademasters can parry with their sword sheathed
           and ((not sys.enabledgmcp or defc.dragonform) or (next(me.wielded) and sk.have_parryable()))
 #end
@@ -14139,6 +14139,177 @@ affinity = {
         sendAll("outd 1 devil","fling devil at ground","ind 1 devil", conf.commandecho)
       end
     }
+  },
+#end
+
+#if skills.shikudo then
+  tykonos = {
+    physical = {
+      aspriority = 0,
+      spriority = 0,
+      balanceful_act = true,
+      def = true,
+      undeffable = true,
+      action = "adopt tykonos form",
+
+      isadvisable = function ()
+        return (((sys.deffing and defdefup[defs.mode].tykonos and not defc.tykonos) or (conf.keepup and defkeepup[defs.mode].tykonos and not defc.tykonos)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
+      end,
+
+      oncompleted = function ()
+        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
+
+        for _, stance in ipairs(shikudo_forms) do
+          defences.lost(stance)
+        end
+
+        defences.got("tykonos")
+      end,
+
+      onstart = function ()
+        send("adopt tykonos form", conf.commandecho)
+      end
+    },
+  },
+  willow = {
+    physical = {
+      aspriority = 0,
+      spriority = 0,
+      balanceful_act = true,
+      def = true,
+      undeffable = true,
+      action = "adopt willow form",
+
+      isadvisable = function ()
+        return (((sys.deffing and defdefup[defs.mode].willow and not defc.willow) or (conf.keepup and defkeepup[defs.mode].willow and not defc.willow)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
+      end,
+
+      oncompleted = function ()
+        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
+
+        for _, stance in ipairs(shikudo_forms) do
+          defences.lost(stance)
+        end
+
+        defences.got("willow")
+      end,
+
+      onstart = function ()
+        send("adopt willow form", conf.commandecho)
+      end
+    },
+  },
+  rain = {
+    physical = {
+      aspriority = 0,
+      spriority = 0,
+      balanceful_act = true,
+      def = true,
+      undeffable = true,
+      action = "adopt rain form",
+
+      isadvisable = function ()
+        return (((sys.deffing and defdefup[defs.mode].rain and not defc.rain) or (conf.keepup and defkeepup[defs.mode].rain and not defc.rain)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
+      end,
+
+      oncompleted = function ()
+        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
+
+        for _, stance in ipairs(shikudo_forms) do
+          defences.lost(stance)
+        end
+
+        defences.got("rain")
+      end,
+
+      onstart = function ()
+        send("adopt rain form", conf.commandecho)
+      end
+    },
+  },
+  oak = {
+    physical = {
+      aspriority = 0,
+      spriority = 0,
+      balanceful_act = true,
+      def = true,
+      undeffable = true,
+      action = "adopt oak form",
+
+      isadvisable = function ()
+        return (((sys.deffing and defdefup[defs.mode].oak and not defc.oak) or (conf.keepup and defkeepup[defs.mode].oak and not defc.oak)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
+      end,
+
+      oncompleted = function ()
+        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
+
+        for _, stance in ipairs(shikudo_forms) do
+          defences.lost(stance)
+        end
+
+        defences.got("oak")
+      end,
+
+      onstart = function ()
+        send("adopt oak form", conf.commandecho)
+      end
+    },
+  },
+  gaital = {
+    physical = {
+      aspriority = 0,
+      spriority = 0,
+      balanceful_act = true,
+      def = true,
+      undeffable = true,
+      action = "adopt gaital form",
+
+      isadvisable = function ()
+        return (((sys.deffing and defdefup[defs.mode].gaital and not defc.gaital) or (conf.keepup and defkeepup[defs.mode].gaital and not defc.gaital)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
+      end,
+
+      oncompleted = function ()
+        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
+
+        for _, stance in ipairs(shikudo_forms) do
+          defences.lost(stance)
+        end
+
+        defences.got("gaital")
+      end,
+
+      onstart = function ()
+        send("adopt gaital form", conf.commandecho)
+      end
+    },
+  },
+  maelstrom = {
+    physical = {
+      aspriority = 0,
+      spriority = 0,
+      balanceful_act = true,
+      def = true,
+      undeffable = true,
+      action = "adopt maelstrom form",
+
+      isadvisable = function ()
+        return (((sys.deffing and defdefup[defs.mode].maelstrom and not defc.maelstrom) or (conf.keepup and defkeepup[defs.mode].maelstrom and not defc.maelstrom)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
+      end,
+
+      oncompleted = function ()
+        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
+
+        for _, stance in ipairs(shikudo_forms) do
+          defences.lost(stance)
+        end
+
+        defences.got("maelstrom")
+      end,
+
+      onstart = function ()
+        send("adopt maelstrom form", conf.commandecho)
+      end
+    },
   },
 #end
 

--- a/raw-svo.dict.lua
+++ b/raw-svo.dict.lua
@@ -89,6 +89,80 @@ local dict_smoke_def = {}
 
 local codepaste = {}
 
+local tekura_stance_oncompleted = function (new_stance)
+  local stances = {
+    "horse", 
+    "eagle", 
+    "cat", 
+    "bear", 
+    "rat", 
+    "scorpion", 
+    "dragon"
+  }
+
+  for _, stance in ipairs(stances) do
+    defences.lost(stance)
+  end
+
+  defences.got(new_stance)
+end
+
+local tekura_stance_isadvisable = function (new_stance)
+  return (
+    (
+      (
+        sys.deffing 
+        and defdefup[defs.mode][new_stance] 
+        and not defc[new_stance]  
+      ) 
+      or (
+        conf.keepup 
+        and defkeepup[defs.mode][new_stance] 
+        and not defc[new_stance] 
+      )
+    ) 
+    and me.path == "tekura" 
+    and not codepaste.balanceful_defs_codepaste() 
+    and not defc.riding
+  ) or false
+end
+
+local shikudo_form_isadvisable = function (new_form)
+  return (
+    (
+      (
+        sys.deffing 
+        and defdefup[defs.mode][new_form] 
+        and not defc[new_form]  
+      ) 
+      or (
+        conf.keepup 
+        and defkeepup[defs.mode][new_form] 
+        and not defc[new_form] 
+      )
+    ) 
+    and me.path == "shikudo" 
+    and not codepaste.balanceful_defs_codepaste() 
+    and not defc.riding
+  ) or false
+end
+
+local shikudo_form_oncompleted = function (new_form)
+  local shikudo_forms = {
+    "tykonos", 
+    "willow", 
+    "rain", 
+    "oak", 
+    "gaital", 
+    "maelstrom"
+  }
+
+  for _, form in ipairs(shikudo_forms) do
+    defences.lost(form)
+  end
+
+  defences.got(new_form)
+end
 
 -- used to check if we're writhing from something already
 --impale stacks below other writhes
@@ -14143,6 +14217,39 @@ affinity = {
 #end
 
 #if skills.shikudo then
+  grip = {
+    gamename = "gripping",
+    physical = {
+      balanceless_act = true,
+      aspriority = 0,
+      spriority = 0,
+      def = true,
+      action = "grip",
+
+      isadvisable = function()
+        return (
+          not defc.grip 
+          and (
+            (sys.deffing and defdefup[defs.mode].grip) 
+            or (conf.keepup and defkeepup[defs.mode].grip)
+          ) 
+          and me.path == "shikudo" 
+          and not codepaste.balanceful_defs_codepaste() 
+          and sys.canoutr 
+          and not affs.paralysis 
+          and not affs.prone
+        ) or false
+      end,
+
+      oncompleted = function()
+        defences.got("grip")
+      end,
+
+      onstart = function() 
+        send("grip", conf.commandecho)
+      end
+    }
+  },
   tykonos = {
     physical = {
       aspriority = 0,
@@ -14151,20 +14258,8 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt tykonos form",
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].tykonos and not defc.tykonos) or (conf.keepup and defkeepup[defs.mode].tykonos and not defc.tykonos)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
-
-        for _, stance in ipairs(shikudo_forms) do
-          defences.lost(stance)
-        end
-
-        defences.got("tykonos")
-      end,
+      isadvisable = function() return shikudo_form_isadvisable("tykonos") end,
+      oncompleted = function() return shikudo_form_oncompleted("tykonos") end,
 
       onstart = function ()
         send("adopt tykonos form", conf.commandecho)
@@ -14179,20 +14274,8 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt willow form",
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].willow and not defc.willow) or (conf.keepup and defkeepup[defs.mode].willow and not defc.willow)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
-
-        for _, stance in ipairs(shikudo_forms) do
-          defences.lost(stance)
-        end
-
-        defences.got("willow")
-      end,
+      isadvisable = function() return shikudo_form_isadvisable("willow") end,
+      oncompleted = function() return shikudo_form_oncompleted("willow") end,
 
       onstart = function ()
         send("adopt willow form", conf.commandecho)
@@ -14207,20 +14290,8 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt rain form",
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].rain and not defc.rain) or (conf.keepup and defkeepup[defs.mode].rain and not defc.rain)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
-
-        for _, stance in ipairs(shikudo_forms) do
-          defences.lost(stance)
-        end
-
-        defences.got("rain")
-      end,
+      isadvisable = function() return shikudo_form_isadvisable("rain") end,
+      oncompleted = function() return shikudo_form_oncompleted("rain") end,
 
       onstart = function ()
         send("adopt rain form", conf.commandecho)
@@ -14235,20 +14306,8 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt oak form",
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].oak and not defc.oak) or (conf.keepup and defkeepup[defs.mode].oak and not defc.oak)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
-
-        for _, stance in ipairs(shikudo_forms) do
-          defences.lost(stance)
-        end
-
-        defences.got("oak")
-      end,
+      isadvisable = function() return shikudo_form_isadvisable("oak") end,
+      oncompleted = function() return shikudo_form_oncompleted("oak") end,
 
       onstart = function ()
         send("adopt oak form", conf.commandecho)
@@ -14263,20 +14322,8 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt gaital form",
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].gaital and not defc.gaital) or (conf.keepup and defkeepup[defs.mode].gaital and not defc.gaital)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
-
-        for _, stance in ipairs(shikudo_forms) do
-          defences.lost(stance)
-        end
-
-        defences.got("gaital")
-      end,
+      isadvisable = function() return shikudo_form_isadvisable("gaital") end,
+      oncompleted = function() return shikudo_form_oncompleted("gaital") end,
 
       onstart = function ()
         send("adopt gaital form", conf.commandecho)
@@ -14291,20 +14338,8 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt maelstrom form",
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].maelstrom and not defc.maelstrom) or (conf.keepup and defkeepup[defs.mode].maelstrom and not defc.maelstrom)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        local shikudo_forms = {"tykonos", "willow", "rain", "oak", "gaital", "maelstrom"}
-
-        for _, stance in ipairs(shikudo_forms) do
-          defences.lost(stance)
-        end
-
-        defences.got("maelstrom")
-      end,
+      isadvisable = function() return shikudo_form_isadvisable("maelstrom") end,
+      oncompleted = function() return shikudo_form_oncompleted("maelstrom") end,
 
       onstart = function ()
         send("adopt maelstrom form", conf.commandecho)
@@ -14314,10 +14349,60 @@ affinity = {
 #end
 
 #if skills.tekura then
-#basicdef("bodyblock", "bdb")
-#basicdef("evadeblock", "evb")
-#basicdef("pinchblock", "pnb")
+  bodyblock = {
+    physical = {
+      aspriority = 0,
+      spriority = 0,
+      balanceful_act = true,
+      def = true,
+      isadvisable = function() return tekura_stance_isadvisable("bodyblock") end,
+      action = "bdb",
 
+      oncompleted = function ()
+        defences.got("bodyblock")
+      end,
+
+      onstart = function ()
+        send("bdb", conf.commandecho)
+      end
+    },
+  },
+  evadeblock = {
+    physical = {
+      aspriority = 0,
+      spriority = 0,
+      balanceful_act = true,
+      def = true,
+      action = "evb",
+      isadvisable = function() return tekura_stance_isadvisable("evadeblock") end,
+
+      oncompleted = function () 
+        defences.got("evadeblock") 
+      end,
+
+      onstart = function ()
+        send("evb", conf.commandecho)
+      end
+    },
+  },
+  pinchblock = {
+    physical = {
+      aspriority = 0,
+      spriority = 0,
+      balanceful_act = true,
+      def = true,
+      action = "pnb",
+      isadvisable = function() return tekura_stance_isadvisable("pinchblock") end,
+
+      oncompleted = function ()
+        defences.got("pinchblock")
+      end,
+
+      onstart = function ()
+        send("pnb", conf.commandecho)
+      end
+    },
+  },
   horse = {
     physical = {
       aspriority = 0,
@@ -14325,20 +14410,10 @@ affinity = {
       balanceful_act = true,
       def = true,
       undeffable = true,
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].horse and not defc.horse) or (conf.keepup and defkeepup[defs.mode].horse and not defc.horse)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        for _, stance in ipairs{"horse", "eagle", "cat", "bear", "rat", "scorpion", "dragon"} do
-          defences.lost(stance)
-        end
-
-        defences.got("horse")
-      end,
-
       action = "hrs",
+      isadvisable = function() return tekura_stance_isadvisable("horse") end,
+      oncompleted = function() return tekura_stance_oncompleted("horse") end,
+
       onstart = function ()
         send("hrs", conf.commandecho)
       end
@@ -14351,20 +14426,10 @@ affinity = {
       balanceful_act = true,
       def = true,
       undeffable = true,
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].eagle and not defc.eagle) or (conf.keepup and defkeepup[defs.mode].eagle and not defc.eagle)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        for _, stance in ipairs{"horse", "eagle", "cat", "bear", "rat", "scorpion", "dragon"} do
-          defences.lost(stance)
-        end
-
-        defences.got("eagle")
-      end,
-
       action = "egs",
+      isadvisable = function() return tekura_stance_isadvisable("eagle") end,
+      oncompleted = function() return tekura_stance_oncompleted("eagle") end,
+
       onstart = function ()
         send("egs", conf.commandecho)
       end
@@ -14377,20 +14442,10 @@ affinity = {
       balanceful_act = true,
       def = true,
       undeffable = true,
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].cat and not defc.cat) or (conf.keepup and defkeepup[defs.mode].cat and not defc.cat)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        for _, stance in ipairs{"horse", "eagle", "cat", "bear", "rat", "scorpion", "dragon"} do
-          defences.lost(stance)
-        end
-
-        defences.got("cat")
-      end,
-
       action = "cts",
+      isadvisable = function() return tekura_stance_isadvisable("cat") end,
+      oncompleted = function() return tekura_stance_oncompleted("cat") end,
+
       onstart = function ()
         send("cts", conf.commandecho)
       end
@@ -14403,20 +14458,10 @@ affinity = {
       balanceful_act = true,
       def = true,
       undeffable = true,
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].bear and not defc.bear) or (conf.keepup and defkeepup[defs.mode].bear and not defc.bear)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        for _, stance in ipairs{"horse", "eagle", "cat", "bear", "rat", "scorpion", "dragon"} do
-          defences.lost(stance)
-        end
-
-        defences.got("bear")
-      end,
-
       action = "brs",
+      isadvisable = function() return tekura_stance_isadvisable("bear") end,
+      oncompleted = function() return tekura_stance_oncompleted("bear") end,
+
       onstart = function ()
         send("brs", conf.commandecho)
       end
@@ -14429,20 +14474,10 @@ affinity = {
       balanceful_act = true,
       def = true,
       undeffable = true,
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].rat and not defc.rat) or (conf.keepup and defkeepup[defs.mode].rat and not defc.rat)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        for _, stance in ipairs{"horse", "eagle", "cat", "bear", "rat", "scorpion", "dragon"} do
-          defences.lost(stance)
-        end
-
-        defences.got("rat")
-      end,
-
       action = "rts",
+      isadvisable = function() return tekura_stance_isadvisable("rat") end,
+      oncompleted = function() return tekura_stance_oncompleted("rat") end,
+
       onstart = function ()
         send("rts", conf.commandecho)
       end
@@ -14455,20 +14490,10 @@ affinity = {
       balanceful_act = true,
       def = true,
       undeffable = true,
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].scorpion and not defc.scorpion) or (conf.keepup and defkeepup[defs.mode].scorpion and not defc.scorpion)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        for _, stance in ipairs{"horse", "eagle", "cat", "bear", "rat", "scorpion", "dragon"} do
-          defences.lost(stance)
-        end
-
-        defences.got("scorpion")
-      end,
-
       action = "scs",
+      isadvisable = function() return tekura_stance_isadvisable("scorpion") end,
+      oncompleted = function() return tekura_stance_oncompleted("scorpion") end,
+
       onstart = function ()
         send("scs", conf.commandecho)
       end
@@ -14481,20 +14506,10 @@ affinity = {
       balanceful_act = true,
       def = true,
       undeffable = true,
-
-      isadvisable = function ()
-        return (((sys.deffing and defdefup[defs.mode].dragon and not defc.dragon) or (conf.keepup and defkeepup[defs.mode].dragon and not defc.dragon)) and not codepaste.balanceful_defs_codepaste() and not defc.riding) or false
-      end,
-
-      oncompleted = function ()
-        for _, stance in ipairs{"horse", "eagle", "cat", "bear", "rat", "scorpion", "dragon"} do
-          defences.lost(stance)
-        end
-
-        defences.got("dragon")
-      end,
-
       action = "drs",
+      isadvisable = function() return tekura_stance_isadvisable("dragon") end,
+      oncompleted = function() return tekura_stance_oncompleted("dragon") end,
+
       onstart = function ()
         send("drs", conf.commandecho)
       end
@@ -15754,6 +15769,7 @@ affinity = {
     setweapon = "impaling",
     shadowveil = "shadowveil",
     shield = "shield",
+    shikudoform = false,
     shinbinding = "bind",
     shinclarity = "clarity",
     shinrejoinder = false,

--- a/raw-svo.dict.lua
+++ b/raw-svo.dict.lua
@@ -89,25 +89,7 @@ local dict_smoke_def = {}
 
 local codepaste = {}
 
-local tekura_stance_oncompleted = function (new_stance)
-  local stances = {
-    "horse", 
-    "eagle", 
-    "cat", 
-    "bear", 
-    "rat", 
-    "scorpion", 
-    "dragon"
-  }
-
-  for _, stance in ipairs(stances) do
-    defences.lost(stance)
-  end
-
-  defences.got(new_stance)
-end
-
-local tekura_stance_isadvisable = function (new_stance)
+local tekura_ability_isadvisable = function (new_stance)
   return (
     (
       (
@@ -127,7 +109,7 @@ local tekura_stance_isadvisable = function (new_stance)
   ) or false
 end
 
-local shikudo_form_isadvisable = function (new_form)
+local shikudo_ability_isadvisable = function (new_form)
   return (
     (
       (
@@ -145,6 +127,24 @@ local shikudo_form_isadvisable = function (new_form)
     and not codepaste.balanceful_defs_codepaste() 
     and not defc.riding
   ) or false
+end
+
+local tekura_stance_oncompleted = function (new_stance)
+  local stances = {
+    "horse", 
+    "eagle", 
+    "cat", 
+    "bear", 
+    "rat", 
+    "scorpion", 
+    "dragon"
+  }
+
+  for _, stance in ipairs(stances) do
+    defences.lost(stance)
+  end
+
+  defences.got(new_stance)
 end
 
 local shikudo_form_oncompleted = function (new_form)
@@ -14258,7 +14258,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt tykonos form",
-      isadvisable = function() return shikudo_form_isadvisable("tykonos") end,
+      isadvisable = function() return shikudo_ability_isadvisable("tykonos") end,
       oncompleted = function() return shikudo_form_oncompleted("tykonos") end,
 
       onstart = function ()
@@ -14274,7 +14274,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt willow form",
-      isadvisable = function() return shikudo_form_isadvisable("willow") end,
+      isadvisable = function() return shikudo_ability_isadvisable("willow") end,
       oncompleted = function() return shikudo_form_oncompleted("willow") end,
 
       onstart = function ()
@@ -14290,7 +14290,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt rain form",
-      isadvisable = function() return shikudo_form_isadvisable("rain") end,
+      isadvisable = function() return shikudo_ability_isadvisable("rain") end,
       oncompleted = function() return shikudo_form_oncompleted("rain") end,
 
       onstart = function ()
@@ -14306,7 +14306,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt oak form",
-      isadvisable = function() return shikudo_form_isadvisable("oak") end,
+      isadvisable = function() return shikudo_ability_isadvisable("oak") end,
       oncompleted = function() return shikudo_form_oncompleted("oak") end,
 
       onstart = function ()
@@ -14322,7 +14322,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt gaital form",
-      isadvisable = function() return shikudo_form_isadvisable("gaital") end,
+      isadvisable = function() return shikudo_ability_isadvisable("gaital") end,
       oncompleted = function() return shikudo_form_oncompleted("gaital") end,
 
       onstart = function ()
@@ -14338,7 +14338,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "adopt maelstrom form",
-      isadvisable = function() return shikudo_form_isadvisable("maelstrom") end,
+      isadvisable = function() return shikudo_ability_isadvisable("maelstrom") end,
       oncompleted = function() return shikudo_form_oncompleted("maelstrom") end,
 
       onstart = function ()
@@ -14355,7 +14355,7 @@ affinity = {
       spriority = 0,
       balanceful_act = true,
       def = true,
-      isadvisable = function() return tekura_stance_isadvisable("bodyblock") end,
+      isadvisable = function() return tekura_ability_isadvisable("bodyblock") end,
       action = "bdb",
 
       oncompleted = function ()
@@ -14374,7 +14374,7 @@ affinity = {
       balanceful_act = true,
       def = true,
       action = "evb",
-      isadvisable = function() return tekura_stance_isadvisable("evadeblock") end,
+      isadvisable = function() return tekura_ability_isadvisable("evadeblock") end,
 
       oncompleted = function () 
         defences.got("evadeblock") 
@@ -14392,7 +14392,7 @@ affinity = {
       balanceful_act = true,
       def = true,
       action = "pnb",
-      isadvisable = function() return tekura_stance_isadvisable("pinchblock") end,
+      isadvisable = function() return tekura_ability_isadvisable("pinchblock") end,
 
       oncompleted = function ()
         defences.got("pinchblock")
@@ -14411,7 +14411,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "hrs",
-      isadvisable = function() return tekura_stance_isadvisable("horse") end,
+      isadvisable = function() return tekura_ability_isadvisable("horse") end,
       oncompleted = function() return tekura_stance_oncompleted("horse") end,
 
       onstart = function ()
@@ -14427,7 +14427,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "egs",
-      isadvisable = function() return tekura_stance_isadvisable("eagle") end,
+      isadvisable = function() return tekura_ability_isadvisable("eagle") end,
       oncompleted = function() return tekura_stance_oncompleted("eagle") end,
 
       onstart = function ()
@@ -14443,7 +14443,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "cts",
-      isadvisable = function() return tekura_stance_isadvisable("cat") end,
+      isadvisable = function() return tekura_ability_isadvisable("cat") end,
       oncompleted = function() return tekura_stance_oncompleted("cat") end,
 
       onstart = function ()
@@ -14459,7 +14459,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "brs",
-      isadvisable = function() return tekura_stance_isadvisable("bear") end,
+      isadvisable = function() return tekura_ability_isadvisable("bear") end,
       oncompleted = function() return tekura_stance_oncompleted("bear") end,
 
       onstart = function ()
@@ -14475,7 +14475,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "rts",
-      isadvisable = function() return tekura_stance_isadvisable("rat") end,
+      isadvisable = function() return tekura_ability_isadvisable("rat") end,
       oncompleted = function() return tekura_stance_oncompleted("rat") end,
 
       onstart = function ()
@@ -14491,7 +14491,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "scs",
-      isadvisable = function() return tekura_stance_isadvisable("scorpion") end,
+      isadvisable = function() return tekura_ability_isadvisable("scorpion") end,
       oncompleted = function() return tekura_stance_oncompleted("scorpion") end,
 
       onstart = function ()
@@ -14507,7 +14507,7 @@ affinity = {
       def = true,
       undeffable = true,
       action = "drs",
-      isadvisable = function() return tekura_stance_isadvisable("dragon") end,
+      isadvisable = function() return tekura_ability_isadvisable("dragon") end,
       oncompleted = function() return tekura_stance_oncompleted("dragon") end,
 
       onstart = function ()

--- a/raw-svo.setup.lua
+++ b/raw-svo.setup.lua
@@ -309,6 +309,38 @@ signals.gmcpcharvitals:connect(function()
   end
 end)
 #end
+
+#if class == "monk" then
+signals.gmcpcharvitals:connect(function()
+  if gmcp.Char.Vitals.charstats then
+    for index, val in ipairs(gmcp.Char.Vitals.charstats) do
+      local stance = val:match("^Stance: (%w+)$")
+      local form = val:match("^Form: (%w+)$")
+
+      if stance then
+        me.path = "tekura"
+        me.form = nil
+        me.stance = stance:lower()
+        sk.ignored_defences['shikudo'].status = true
+
+        break
+      elseif form then
+        me.path = "shikudo"
+        me.form = form:lower()
+        me.stance = nil
+        sk.ignored_defences['tekura'].status = true
+
+        break
+      end
+    end
+  end
+
+  if not me.path then
+    me.path = "tekura"
+  end
+end)
+#end
+
 signals.gmcpiretimelist = luanotify.signal.new()
 signals.gmcpiretimelist:connect(function()
   me.gametime = deepcopy(gmcp.IRE.Time.List)

--- a/raw-svo.setup.lua
+++ b/raw-svo.setup.lua
@@ -321,6 +321,7 @@ signals.gmcpcharvitals:connect(function()
         me.path = "tekura"
         me.form = nil
         me.stance = stance:lower()
+        sk.ignored_defences['tekura'].status = false
         sk.ignored_defences['shikudo'].status = true
 
         break
@@ -329,6 +330,7 @@ signals.gmcpcharvitals:connect(function()
         me.form = form:lower()
         me.stance = nil
         sk.ignored_defences['tekura'].status = true
+        sk.ignored_defences['shikudo'].status = false
 
         break
       end


### PR DESCRIPTION
This PR is inspired by @jgh713 and credit should absolutely be given for getting me started. This PR changes a couple of specific items, detailed in commit 1f6aeaa.

Notably: `df` has been updated to remove the alternate monk path, and `vdefs` can now take shikudo forms in defup.

I'd appreciate a detailed code review here, even if this doesn't get merged in, so I can get an idea of any mistakes I've made.