### PR TITLE
Fixed command separator CONFIG regex

### DIFF
--- a/svo (install the zip, not me).xml
+++ b/svo (install the zip, not me).xml
@@ -52527,7 +52527,7 @@ svo.config.set(&quot;commandseparator&quot;, separator)</script>
                     <regexCodeList>
                         <string>|</string>
                         <string>CommandSeparator</string>
-                        <string>^\| +CommandSeparator +(.+)? +\|</string>
+                        <string>^\| +CommandSeparator +(.+)? +ShowSelfClasswho</string>
                     </regexCodeList>
                     <regexCodePropertyList>
                         <integer>2</integer>


### PR DESCRIPTION
Changed regex for finding the command separator. New CONFIG layout was messing it up and adding extra stuff to it, screwing up svof's use of the command separator. Should fix #367.