### PR TITLE
Ndb patches

### DIFF
--- a/doc/namedb.rst
+++ b/doc/namedb.rst
@@ -484,6 +484,9 @@ API
 
   ndb.iscityenemy(name)
     Similar to ndb.isenemy - but ignores whenever someone is a house enemy or not. So it checks everything else that ndb.isenemy checks (citizenship, iff, and city) while ignoring the status of someone being your House's enemy.
+    
+  ndb.isonlycityenemy(name)
+    Similar to ndb.iscityenemy - but ignores everything except if someone is an enemy to your current city if you have one.
 
   svo.config.set("ndbpaused", option, true)
     Disables or enables NameDB highlighting (same as what the ``npp`` alias does). ``option`` is a toggle in the same manner as ``svo.config.set()`` operates - it can be ``true``, ``false``, ``"on"``, ``"off"`` and so on. The last argument, ``true``, has to be there for the function to take effect.

--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -2950,13 +2950,13 @@ ndb.valid.cities = {
   "Ashtan", "Cyrene", "Hashan", "Eleusis", "Mhaldor", "Targossas"
 }
 ndb.valid.classes = {
-  "alchemist", "apostate", "bard", "blademaster", "druid", "infernal", "jester", "magi", "monk", "occultist", "paladin", "priest", "runewarden", "sentinel", "serpent", "shaman", "sylvan"
+  "alchemist", "apostate", "bard", "blademaster", "depthswalker", "druid", "infernal", "jester", "magi", "monk", "occultist", "paladin", "priest", "psion", "runewarden", "sentinel", "serpent", "shaman", "sylvan"
 }
 ndb.valid.houses = {
-  "Blacklotus", "Occultists", "Shadowsnakes", "Merchants", "Warlocks", "Ashura", "Spiritwalkers", "Cij", "Shield", "Virtuosi", "Outriders", "Dawnblade", "Harbingers", "Luminai", "Legates", "Insidium", "Scions", "Heartwood"
+  "Scions", "Merchants", "Heartwood", "Cij", "Somatikos", "Shield", "Krymenian", "Virtuosi", "Outriders", "Dawnblade", "Harbingers", "Luminai", "Legates", "Insidium", "Consortium", "Savants", "Vanguard"
 }
 ndb.valid.races = {
-  "tsol'aa", "dwarf", "human", "troll", "atavian", "rajamala", "horkval", "grook", "xoran", "siren", "satyr", "mhun",
+  "tsol'aa", "dwarf", "human", "troll", "atavian", "rajamala", "horkval", "grook", "xoran", "siren", "satyr", "mhun", "tash'la", "elemental lord", "elemental lady"
 }
 ndb.valid.infamous = {
   ["is rapidly approaching the ranks of the Infamous"] = 1,
@@ -3188,7 +3188,7 @@ end</script>
 
 function ndb.downloaded_file(_, filename)
   -- is the file that downloaded ours?
-  if not string.find(filename, "namedb.html") then return end
+  if not string.find(filename, "namedb.json") then return end
   local f = io.open(filename)
   local s = f:read("*all")
   if f then f:close() end
@@ -3246,7 +3246,7 @@ function ndb.downloaded_file(_, filename)
 end
 
 function ndb.getinfo(person)
-	downloadFile(getMudletHomeDir().."/"..person.."-namedb.html", "https://www.achaea.com/game/honors/"..person)
+  downloadFile(getMudletHomeDir().."/"..person.."-namedb.json", "http://api.achaea.com/characters/"..person..".json")
 end</script>
 					<eventHandlerList>
 						<string>sysDownloadDone</string>

--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -4234,8 +4234,8 @@ end</script>
   if data.immortal == 0 then
     cecho("&lt;a_darkcyan&gt;  Orgs:\n")
     cecho(string.format("&lt;a_darkgrey&gt;    House:  %-24s City:        %s (cr%s)%s\n",
-      (data.guild == '' and 'unknown' or data.guild),
-      (data.city == '' and 'unknown' or data.city),
+      string.title(data.guild == '' and 'unknown' or data.guild),
+      string.title(data.city == '' and 'unknown' or data.city),
       (data.city_rank == 0 and '?' or data.city_rank),
       (data.city_soldier == 0 and '' or ' (S)')
     ))

--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -2547,7 +2547,7 @@ if #alldata &gt;= 100 and not ndb.updateall then
 end
 
 ndb.updateall = nil
-ndb.fixed_set(ndb.db.people.might, -1)
+ndb.fixed_set(ndb.db.people.xp_rank, -1)
 
 svo.echof("Re-checking all %d known people in NameDB.", #alldata)
 raiseEvent("NameDB got new data")</script>

--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -3188,7 +3188,7 @@ end</script>
 
 function ndb.downloaded_file(_, filename)
   -- is the file that downloaded ours?
-  if not string.find(filename, "namedb.json") then return end
+  if not string.find(filename, "namedb.html") then return end
   local f = io.open(filename)
   local s = f:read("*all")
   if f then f:close() end
@@ -3246,8 +3246,7 @@ function ndb.downloaded_file(_, filename)
 end
 
 function ndb.getinfo(person)
-  downloadFile(getMudletHomeDir().."/"..person.."-namedb.json", "http://api.achaea.com/characters/"..person..".json")
---downloadFile(getMudletHomeDir().."/"..person.."-namedb.html", "https://www.achaea.com/game/honors/"..person)
+	downloadFile(getMudletHomeDir().."/"..person.."-namedb.html", "https://www.achaea.com/game/honors/"..person)
 end</script>
 					<eventHandlerList>
 						<string>sysDownloadDone</string>

--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -4090,6 +4090,7 @@ end</script>
 end</script>
 					<eventHandlerList>
 						<string>svo system loaded</string>
+						<string>sysInstallModule</string>
 					</eventHandlerList>
 				</Script>
 				<Script isActive="yes" isFolder="no">

--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -2539,7 +2539,7 @@ svo.showprompt()</script>
 				<name>(ndb update all) Re-check every person in the database</name>
 				<script>local alldata = db:fetch(ndb.db.people)
 
-if not svo.conf.autocheck and not svo.conf.usehonors then
+if not svo.conf.autocheck or not svo.conf.usehonors then
 	svo.echof("Both vconfig usehonors and vconfig autocheck must be set to yes to update all entries.")
 	return 
 end

--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -813,10 +813,7 @@ if multimatches[1][1] == "None." then
   return
 end
 
--- update the total amount of people in the game with a clever addition
-if selectString(multimatches[3][2], 1) &gt; -1 then
-  replace(string.format("%d (%d total)", multimatches[3][2], tonumber(multimatches[3][2])+#temp_name_list))
-end
+
 
 --[[
 for _,name in ipairs(data) do
@@ -962,7 +959,7 @@ disableTrigger("NameDB qw")</script>
 					<regexCodeList>
 						<string>.*</string>
 						<string>1</string>
-						<string>^Plus another (\d+) whose presence you cannot fully sense(?: \(\d+ total\))?\.$</string>
+						<string>^(?:Plus another (\d+) whose presence you cannot fully sense(?: \(\d+ total\))?\.|\((\d+) total\)\.)$</string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>1</integer>
@@ -1716,8 +1713,12 @@ temp_name_list[1].xp_rank = -2</script>
 						<regexCodeList>
 							<string>He is unranked in Achaea.</string>
 							<string>She is unranked in Achaea.</string>
+							<string>He has given up the adventuring life.</string>
+							<string>She has given up the adventuring life.</string>
 						</regexCodeList>
 						<regexCodePropertyList>
+							<integer>3</integer>
+							<integer>3</integer>
 							<integer>3</integer>
 							<integer>3</integer>
 						</regexCodePropertyList>
@@ -3246,6 +3247,7 @@ end
 
 function ndb.getinfo(person)
   downloadFile(getMudletHomeDir().."/"..person.."-namedb.json", "http://api.achaea.com/characters/"..person..".json")
+--downloadFile(getMudletHomeDir().."/"..person.."-namedb.html", "https://www.achaea.com/game/honors/"..person)
 end</script>
 					<eventHandlerList>
 						<string>sysDownloadDone</string>
@@ -4932,6 +4934,19 @@ function ndb.isenemy(name)
        (p.iff ~= 2 and
          ((city and city ~= "" and ndb.conf.citypolitics[city] == 'enemy') or
          (p.cityenemy == 1 or p.orderenemy == 1 or p.houseenemy == 1))) then
+    return true else return false
+  end
+end
+
+-- returns true only if someone is a city enemy. They could be a house enemy, order enemy, or politics enemy and not be considered an enemy by this
+function ndb.isonlycityenemy(name)
+  local p = ndb.getname(name)
+  if not p then return false end
+
+  local city = p.city
+
+ -- only return true for city enemy
+  if p.cityenemy == 1 then
     return true else return false
   end
 end

--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -2539,6 +2539,10 @@ svo.showprompt()</script>
 				<name>(ndb update all) Re-check every person in the database</name>
 				<script>local alldata = db:fetch(ndb.db.people)
 
+if not svo.conf.autocheck and not svo.conf.usehonors then
+	svo.echof("Both vconfig usehonors and vconfig autocheck must be set to yes to update all entries.")
+	return 
+end
 if #alldata &gt;= 100 and not ndb.updateall then
   svo.echof("Are you really sure you want to re-check everybody in the database? You've got %d names - this'll take a while. If yes, do this again.", #alldata)
   svo.showprompt()


### PR DESCRIPTION
-Added lines for retired players and puts them as unranked.
-Got rid of the fancy piece of work that @vadi2 did to give you an accurate count of online players because of a ninja change from the orb of concealment change.
-Updated the capture line for qwho so it doesn't break and error out when there are no players who are hidden from the list.
-Updated the link for honours so information datamining returns all the information we requested like house and current class when you do honours.