### PR TITLE
Diagnose fix

### DIFF
--- a/svo (alias and defence functions).xml
+++ b/svo (alias and defence functions).xml
@@ -849,7 +849,7 @@ function svo.dop(what, echoback)
 end
 
 function svo.dv()
-  sys.manualdiag = true
+  svo.sys.manualdiag = true
   svo.make_gnomes_work()
 end
 


### PR DESCRIPTION
This fixes the looping issue with the dv alias causing diagnose to loop randomly. It was setting the wrong variable to true and the system was not recognizing that we told it to do this and would continue to loop because it thought that we still needed to diag but kept thinking the true diag was an illusion.