### PR TITLE
Shrugging enhancement

### DIFF
--- a/svo (actions dictionary).xml
+++ b/svo (actions dictionary).xml
@@ -12275,7 +12275,13 @@ if svo.haveskillset('venom') then
       end,
 
       action = 'shrugging',
-      onstart = function() send('shrugging', conf.commandecho) end,
+			onstart = function()
+				if svo.conf.serverside then
+				  send('curing queue add shrugging', conf.commandecho) 
+				else
+      		send('shrugging', conf.commandecho) 
+				end
+			end,
 
       offbal = function() svo.lostbal_shrugging() end
     }


### PR DESCRIPTION
Added a check into the system for executing shrugging to put it on the severside curing queue due to many people using the serverside queueing it would never be used if they were chasing balance as the queueing would be able to fire before svo is able to do so. This allows it to be used as the curing queue will fire before the serverside command queue does.