### PR TITLE
Pipe Changes

### DIFF
--- a/svo (actions dictionary).xml
+++ b/svo (actions dictionary).xml
@@ -5882,7 +5882,7 @@ end
           or (not pipes.skullcap.arty2 and not pipes.skullcap.lit2 and pipes.skullcap.puffs2 &gt; 0 and not (pipes.skullcap.id2 == 0))
           )
         and (conf.relight or sk.forcelight_valerian or sk.forcelight_skullcap or sk.forcelight_elm)
-        and not (svo.doingaction('lightskullcap') or svo.doingaction('lightelm') or svo.doingaction('lightvalerian') or svo.doingaction('lightpipes'))) or false
+        and not (conf.serverside or svo.doingaction('lightskullcap') or svo.doingaction('lightelm') or svo.doingaction('lightvalerian') or svo.doingaction('lightpipes'))) or false
       end,
 
       oncompleted = function()
@@ -5924,7 +5924,7 @@ end
       end,
 
       isadvisable = function()
-        return ((svo.dict.fillskullcap.physical.mainpipeout() or svo.dict.fillskullcap.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance() and not (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed)) or false
+        return ((svo.dict.fillskullcap.physical.mainpipeout() or svo.dict.fillskullcap.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance() and not (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed) and not conf.serverside) or false
       end,
 
       oncompleted = function()
@@ -5968,7 +5968,7 @@ end
       end,
 
       isadvisable = function()
-        return ((svo.dict.fillelm.physical.mainpipeout() or svo.dict.fillelm.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance()  and not (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed)) or false
+        return ((svo.dict.fillelm.physical.mainpipeout() or svo.dict.fillelm.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance()  and not (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed) and not conf.serverside) or false
       end,
 
       oncompleted = function()
@@ -6012,7 +6012,7 @@ end
       end,
 
       isadvisable = function()
-        if (svo.dict.fillvalerian.physical.mainpipeout() or svo.dict.fillvalerian.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance() then
+        if ((svo.dict.fillvalerian.physical.mainpipeout() or svo.dict.fillvalerian.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance() and not conf.serverside) then
 
           if (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed) then
             sk.warn 'emptyvalerianpipenorefill'

--- a/svo (install, config, pipes, rift, parry, prios).xml
+++ b/svo (install, config, pipes, rift, parry, prios).xml
@@ -2866,14 +2866,14 @@ function svo.pipe_assignid(newid)
       pipes[i].id = newid
       svo.conf[i..'id'] = newid
       pipes[i].lit = false
-      send("empty "..newid, false)
+      svo.dofreeadd("empty "..newid, false)
       raiseEvent("svo config changed", i..'id')
       return i
     elseif pipes[i].id2 == 0 then
       pipes[i].id2 = newid
       svo.conf[i..'id2'] = newid
       pipes[i].lit2 = false
-      send("empty "..newid, false)
+      svo.dofreeadd("empty "..newid, false)
       raiseEvent("svo config changed", i..'id2')
       return i
     end
@@ -3618,9 +3618,8 @@ function sk.asyncfill(what, where)
         end
       end
     end
-
+		rift.outr(what)
     send("put " .. what .. " in " .. where, conf.commandecho)
-    rift.outr(what)
   else
     rift.outr(what)
     if pipes[orig].puffs &gt; 0 then

--- a/svo (install, config, pipes, rift, parry, prios).xml
+++ b/svo (install, config, pipes, rift, parry, prios).xml
@@ -2866,14 +2866,14 @@ function svo.pipe_assignid(newid)
       pipes[i].id = newid
       svo.conf[i..'id'] = newid
       pipes[i].lit = false
-      svo.dofreeadd("empty "..newid, false)
+      send("empty "..newid, false)
       raiseEvent("svo config changed", i..'id')
       return i
     elseif pipes[i].id2 == 0 then
       pipes[i].id2 = newid
       svo.conf[i..'id2'] = newid
       pipes[i].lit2 = false
-      svo.dofreeadd("empty "..newid, false)
+      send("empty "..newid, false)
       raiseEvent("svo config changed", i..'id2')
       return i
     end


### PR DESCRIPTION
Currently serverside curing is set up to automatically handle pipes. This commit has the following added:

Fixed the dict to tell svo not to worry about pipes (relighting and refilling) if serverside is turned on

Fixed the balance changes on refilling and relighting pipes

Fixed taking out an herb after trying to put it in the pipe first (was refill/outr and its now outr/refill)