### PR TITLE
Dragonbreath tracking fix

### DIFF
--- a/svo (actions dictionary).xml
+++ b/svo (actions dictionary).xml
@@ -9397,6 +9397,8 @@ end
       end,
 
       alreadygot = function() defences.got('dragonbreath') end,
+			
+      actions = {'summon acid', 'summon psi', 'summon ice', 'summon venom', 'summon dragonfire', 'summon lightning'},
 
       onstart = function()
         send("summon "..(conf.dragonbreath and conf.dragonbreath or 'unknown'), conf.commandecho)


### PR DESCRIPTION
The functions on the triggers were trying to access a definition in the dictionary for the defences that was never defined so the check for the completion would never finish and update.