### PR TITLE
Retain defs on classchange

### DIFF
--- a/svo (install me in module manager).xml
+++ b/svo (install me in module manager).xml
@@ -7173,29 +7173,41 @@ end</script>
 				<packageName></packageName>
 				<script>function svo.classchange(override)
   local newclass = (override ~= "gmcp.Char.Status") and override or gmcp.Char.Status.class
+  local temp_defs = {}
 	
 	-- if you're in Dragon or an unrecognised class, use the None system
 	-- works fine in Dragon as they don't have class-specific skills anyway
 	if not svo.knownskills[newclass:lower()] then newclass = "None" end
 		
+	-- save general defences in temp table, so svo doesn't waste resources
+	-- deffing what is already up	
+  for k,v in pairs(svo.defc) do
+  if v then
+     if svo.defs_data[k].type == "general" then
+        temp_defs[k] = true
+      end
+    end
+  end	
+		
   if svo.me.class ~= newclass then
-	  local oldclass = svo.me.class
+    local oldclass = svo.me.class
 
-		svo.me.class = newclass
-		svo.signals.saveconfig:emit()
+    svo.me.class = newclass
+    svo.signals.saveconfig:emit()
 		
 		-- reset all serverside prios so serverside doesn't spam class-specific defences
 		-- it's a bug in the game that serverside still tries to put up defences you can't
-		svo.sk.resetserversideprios()
+    svo.sk.resetserversideprios()
 		
-	  svo.systemloaded = false; svo_init_system()		
-	  svo.echof("Changed your Svof from %s over to %s.", oldclass, svo.me.class)
+    svo.systemloaded = false; svo_init_system()		
+    svo.defc = temp_defs
+    svo.echof("Changed your Svof from %s over to %s.", oldclass, svo.me.class)
 		
 		-- if system is not paused after dragonforming, unpause serverside
-		if not svo.conf.paused then
-		  svo.force_send("curing on")
-		end
-	end
+    if not svo.conf.paused then
+      svo.force_send("curing on")
+    end
+  end
 end</script>
 				<eventHandlerList>
 					<string>gmcp.Char.Status</string>

--- a/svo (install me in module manager).xml
+++ b/svo (install me in module manager).xml
@@ -7182,9 +7182,11 @@ end</script>
 	-- save general defences in temp table, so svo doesn't waste resources
 	-- deffing what is already up	
   for k,v in pairs(svo.defc) do
-  if v then
-     if svo.defs_data[k].type == "general" then
-        temp_defs[k] = true
+    if v then
+      if svo.defs_data[k].type then
+        if svo.defs_data[k].type == "general" then
+          temp_defs[k] = true
+        end
       end
     end
   end	
@@ -7205,7 +7207,7 @@ end</script>
 		
 		-- if system is not paused after dragonforming, unpause serverside
     if not svo.conf.paused then
-      svo.force_send("curing on")
+      svo.app("off")
     end
   end
 end</script>


### PR DESCRIPTION
Also fixed the indentations as per coding style guidelines (2 spaces, not tabs).

This should save some defup time/Wasted resources, if that is important. Though there is an initial spike of balance free defences I cannot figure out how to stop from being sent.