### PR TITLE
quick stun fix

### DIFF
--- a/svo (curing skeleton, controllers, action system).xml
+++ b/svo (curing skeleton, controllers, action system).xml
@@ -1056,7 +1056,7 @@ function svo.sk.stun_symptom()
   sk.stun_count = sk.stun_count + 1
 
   if sk.stun_count &gt;= 3 then
-    svo.valid.simplestun()
+    svo.valid.proper_stun()
     echo"\n" svo.echof("auto-detected stun.")
     sk.stun_count = 0
     return


### PR DESCRIPTION
Looks like it was trying to set an old version of the function which isn't really used anymore and with this I am no longer getting the LUA error to my console