### PR TITLE
Death Issue

### DIFF
--- a/svo (alias and defence functions).xml
+++ b/svo (alias and defence functions).xml
@@ -905,8 +905,18 @@ function svo.reset.affs(echoback)
 end
 
 function svo.reset.general()
-  svo.actions = svo.pl.OrderedMap()
-  svo.lifevision.l = svo.pl.OrderedMap()
+  --svo.actions = svo.pl.OrderedMap()
+  --svo.lifevision.l = svo.pl.OrderedMap()
+	
+	local to_kill = {}
+  for _,v in svo.actions:iter() do
+  	to_kill[#to_kill+1] = svo.dict[v.p.action_name][v.p.balance]
+  end
+
+  local killaction = svo.killaction
+  for _, action in ipairs(to_kill) do
+    killaction(action)
+  end
 
   for bal in pairs(svo.bals_in_use) do
     svo.bals_in_use[bal] = {}


### PR DESCRIPTION
Fixes the svo.actions table to reset properly on death which fix a number of issues that the system currently has. Should close the following

Closes #499 
Closes #504 
Closes #479 
Closes #475 
Closes #467 

All of these issues are related to dying and then trying to get the svo.actions table to work correctly.