### PR TITLE
Class Change Fixes

### DIFF
--- a/svo (alias and defence functions).xml
+++ b/svo (alias and defence functions).xml
@@ -3300,7 +3300,7 @@ if svo.haveskillset('shadowmancy') then
 
 -- signals for shadowcloak tracking
   signals.gmcpcharitemslist:connect(function()
-  if gmcp.Char.Status.class == "Depthswakler" then
+  if gmcp.Char.Status.class == "Depthswalker" then
     if gmcp.Char.Items.List.location ~= 'inv' then
       return
     end
@@ -3317,7 +3317,7 @@ if svo.haveskillset('shadowmancy') then
   end
   end, 'add/remove shadowcloak on gmcp items list')
   signals.gmcpcharitemsadd:connect(function()
-  if gmcp.Char.Status.class == "Depthswakler" then
+  if gmcp.Char.Status.class == "Depthswalker" then
     if gmcp.Char.Items.Add.location ~= 'inv' then
       return
     end
@@ -3331,7 +3331,7 @@ if svo.haveskillset('shadowmancy') then
   end
   end, 'add shadowcloak on gmcp items add')
   signals.gmcpcharitemsremove:connect(function()
-  if gmcp.Char.Status.class == "Depthswakler" then
+  if gmcp.Char.Status.class == "Depthswalker" then
     if gmcp.Char.Items.Remove.location ~= 'inv' then
       return
     end
@@ -3343,7 +3343,7 @@ if svo.haveskillset('shadowmancy') then
   end
   end, 'remove shadowcloak on gmcp items remove')
   signals.gmcpcharitemsupdate:connect(function()
-  if gmcp.Char.Status.class == "Depthswakler" then
+  if gmcp.Char.Status.class == "Depthswalker" then
     if gmcp.Char.Items.Update.location ~= 'inv' then
       return
     end

--- a/svo (alias and defence functions).xml
+++ b/svo (alias and defence functions).xml
@@ -3300,6 +3300,7 @@ if svo.haveskillset('shadowmancy') then
 
 -- signals for shadowcloak tracking
   signals.gmcpcharitemslist:connect(function()
+  if gmcp.Char.Status.class == "Depthswakler" then
     if gmcp.Char.Items.List.location ~= 'inv' then
       return
     end
@@ -3313,8 +3314,10 @@ if svo.haveskillset('shadowmancy') then
          return
       end
     end
+  end
   end, 'add/remove shadowcloak on gmcp items list')
   signals.gmcpcharitemsadd:connect(function()
+  if gmcp.Char.Status.class == "Depthswakler" then
     if gmcp.Char.Items.Add.location ~= 'inv' then
       return
     end
@@ -3325,8 +3328,10 @@ if svo.haveskillset('shadowmancy') then
         end
       end
     end
+  end
   end, 'add shadowcloak on gmcp items add')
   signals.gmcpcharitemsremove:connect(function()
+  if gmcp.Char.Status.class == "Depthswakler" then
     if gmcp.Char.Items.Remove.location ~= 'inv' then
       return
     end
@@ -3335,8 +3340,10 @@ if svo.haveskillset('shadowmancy') then
         defences.lost('shadowcloak')
       end
     end
+  end
   end, 'remove shadowcloak on gmcp items remove')
   signals.gmcpcharitemsupdate:connect(function()
+  if gmcp.Char.Status.class == "Depthswakler" then
     if gmcp.Char.Items.Update.location ~= 'inv' then
       return
     end
@@ -3347,6 +3354,7 @@ if svo.haveskillset('shadowmancy') then
         end
       end
     end
+  end
   end, 'add shadowcloak on gmcp items update')
 end
 

--- a/svo (install me in module manager).xml
+++ b/svo (install me in module manager).xml
@@ -7176,8 +7176,8 @@ end</script>
 			<Script isActive="yes" isFolder="no">
 				<name>svo.classchange</name>
 				<packageName></packageName>
-				<script>function svo.classchange()
-  local newclass = gmcp.Char.Status.class
+				<script>function svo.classchange(override)
+  local newclass = (override ~= "gmcp.Char.Status") and override or gmcp.Char.Status.class
 	local temp_defs = {}
   
 	-- if you're in an unrecognised class, use the None system

--- a/svo (install me in module manager).xml
+++ b/svo (install me in module manager).xml
@@ -7176,10 +7176,10 @@ end</script>
 			<Script isActive="yes" isFolder="no">
 				<name>svo.classchange</name>
 				<packageName></packageName>
-				<script>function svo.classchange(override)
-  local newclass = (override ~= "gmcp.Char.Status") and override or gmcp.Char.Status.class
+				<script>function svo.classchange()
+  local newclass = gmcp.Char.Status.class
 	local temp_defs = {}
-	
+  
 	-- if you're in an unrecognised class, use the None system
 	if not svo.knownskills[newclass:lower()] then newclass = "None" end
 		
@@ -7187,7 +7187,9 @@ end</script>
 	-- deffing what is already up	
   for k,v in pairs(svo.defc) do
     if v then
-      if svo.defs_data[k].type then
+      if not svo.defs_data[k] then
+        svo.defc[k] = nil
+      else
         if svo.defs_data[k].type == "general" then
           temp_defs[k] = true
         end
@@ -7197,7 +7199,7 @@ end</script>
 	
   if svo.me.class ~= newclass then
     local oldclass = svo.me.class
-
+    
     -- kill temporary defense triggers for old class
     for k,v in pairs(svo.defencetemptriggers) do
       killTrigger(v)


### PR DESCRIPTION
-Depthswalker had a special case of how the shadowcloak defence was coded. It added the defence based on an Inv check through gmcp, so in other classes if would give this defence. This fix removes the Inv check when not in Depthswalker

-Class change function was changed to remove any defences that did not belong in the new class to be removed from defc before copying over the new defs into the table, which allows going from dragonform to elemental form back to lesserform more stable.