### PR TITLE
clickable url fix

### DIFF
--- a/svo (aliases, triggers).xml
+++ b/svo (aliases, triggers).xml
@@ -51939,9 +51939,15 @@ setUnderline(true) setLink([[send("messages unread", false)]], "(svo): Read new 
 					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="yes" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 						<name>Clickable URL's</name>
 						<script>-- credit to: http://forums.mudlet.org/viewtopic.php?f=6&amp;t=1818#p9641
+local prefix = ""
+--if http(s), ftp, or telnet is not in the beginning of the string then http:// will be used instead to prefix the string.
+if not rex.find(matches[1], "^(http?s:\/\/|ftp|telnet)",1,"i") then
+  prefix = "http://"
+end
+
 for i,v in ipairs(matches) do
   if selectString(matches[i], 1) ~= -1 then
-    setLink([[openUrl("]]..matches[i]..[[")]], matches[i])
+    setLink([[openUrl("]] .. prefix .. matches[i] ..[[")]], matches[i])
     setUnderline(true)
   end
 end


### PR DESCRIPTION
Ensure that qt don't use file://; instead, it will use http:// by default if ftp://, http(s):// or telnet:// haven't been used.