### PR TITLE
Properly recognize ablaze as a defence for Fire Lords

### DIFF
--- a/svo (actions dictionary).xml
+++ b/svo (actions dictionary).xml
@@ -4532,7 +4532,8 @@ end
       end,
     }
   },
-  ablaze = {
+  
+  ablaze = {           
     gamename = 'burning',
     salve = {
       isadvisable = function()
@@ -4542,6 +4543,9 @@ end
       oncompleted = function()
         svo.lostbal_salve()
         svo.rmaff('ablaze')
+        if defc.torch and (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady") then
+          defences.lost('torch')
+        end
       end,
 
       all = function()
@@ -4559,22 +4563,30 @@ end
         empty.apply_mending()
       end,
 
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal"},
+      applycure = {'mending'},
+      actions = {"apply mending to body", "apply mending"},
       onstart = function()
         svo.apply(svo.dict.ablaze.salve, " to body")
       end
     },
     aff = {
       oncompleted = function()
-        codepaste.remove_burns('ablaze')
-        svo.addaffdict(svo.dict.ablaze)
+        if (defdefup[defs.mode].torch) or (conf.keepup and defkeepup[defs.mode].torch) and 
+        (svo.me.class == 'fire Elemental Lord' or svo.me.class == 'fire Elemental Lady') then
+          defences.got('torch')
+        else
+          codepaste.remove_burns('ablaze')
+          svo.addaffdict(svo.dict.ablaze)
+        end
       end,
     },
     gone = {
       oncompleted = function()
         local currentburn = sk.current_burn()
         svo.rmaff(currentburn)
+        if defc.torch and (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady") then
+          defences.lost('torch')
+        end
       end,
 
       -- used in blackout and passive curing where multiple levels could be cured at once
@@ -13835,6 +13847,30 @@ if svo.haveskillset('devotion') then
     }
   }
 end
+
+if svo.haveskillset('ignition') then
+  svo.dict.torch = {
+    physical = {
+      balanceful_act = true,
+      def = true,
+      undeffable = true,
+      
+        isadvisable = function ()
+        return (not defc.torch and ((sys.deffing and defdefup[defs.mode].torch) or (conf.keepup and defkeepup[defs.mode].torch)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
+      end,
+      
+        oncompleted = function ()
+          svo.rmaff('ablaze')
+          defences.got('torch')
+        end,
+        
+      actions = {"manifest torch"},
+      onstart = function ()
+        send('manifest torch', conf.commandecho)
+      end
+      }
+    }
+    end
 
 -- shortcut function to help create a dict action for a defence
 -- 'which' is the Svof defence name, use the same name in the 'Defences' script

--- a/svo (alias and defence functions).xml
+++ b/svo (alias and defence functions).xml
@@ -3500,6 +3500,13 @@ if svo.haveskillset('ignition') then
   def = "You have shrouded yourself with flame.",
   on = "A shroud of flame bursts into being, cloaking you in a burning aura of crimson.",
   off = "The burning shroud that cloaks you winks out of existence."})
+  
+  defs_data:set('torch', { type = 'ignition',
+  invisibledef = true,
+  on = "You flare your flames, burning ever brighter.",
+  off = {"The raging fire about your skin goes out.","Steam rises from your skin as the fires that plague you are extinguished.","Waves of elemental water surge over your body, quenching the tongues of flame."}
+  })
+  
 end
 
 if svo.haveskillset('duress') then

--- a/svo (curing skeleton, controllers, action system).xml
+++ b/svo (curing skeleton, controllers, action system).xml
@@ -2333,6 +2333,19 @@ function svo.sk.fix_affs_and_defs()
     svo.addaffdict(svo.dict.deafaff)
     svo.echof("deafness is now considered an affliction, will cure it.")
   end
+  
+    --ablaze check for fire elementals, they always must be ON FIRE!
+  if affs.ablaze and ((defdefup[defs.mode].torch) or (conf.keepup and defkeepup[defs.mode].torch)
+    and (svo.me.class == 'fire Elemental Lord' or svo.me.class == 'fire Elemental Lady')) then
+    svo.rmaff('ablaze')
+    defences.got('torch')
+    svo.echof("ablaze is now considered a defence.")
+  elseif defc.torch and not ((defdefup[defs.mode].torch) or (conf.keepup and defkeepup[defs.mode].torch)
+   and (svo.me.class ~= 'fire Elemental Lord' or svo.me.class ~= 'fire Elemental Lady')) then
+    defences.lost('torch')
+    svo.addaffdict(svo.dict.ablaze)
+    svo.echof("ablaze is now considered an affliction, will cure it.")
+  end
 	svo.sk.updateserversideprios()
 end
 


### PR DESCRIPTION
Ablaze actually regens firelord instead of hurting them, should be recognized as a defence.
This should work similarly to how blind/deaf switches works between affliction and defence according to special conditions,
Fixes #638 
