### PR TITLE
Fixes druid flame defence to work with ignite

### DIFF
--- a/svo (actions dictionary).xml
+++ b/svo (actions dictionary).xml
@@ -11027,7 +11027,7 @@ if svo.haveskillset('metamorphosis') then
 
       oncompleted = function() defences.got('flame') end,
 
-      actions = {"summon flame", "summon fire"},
+      actions = {"summon flame", "summon fire", "ignite"},
       onstart = function()
         if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'flame' then
           if defc.flame then send("relax flame", conf.commandecho) end

--- a/svo (alias and defence functions).xml
+++ b/svo (alias and defence functions).xml
@@ -2092,7 +2092,6 @@ if svo.haveskillset('metamorphosis') then
       return true
     end,
     invisibledef = true,
-
     on = {"You take a deep breath and realise your error - you sputter and engulf yourself in fire!", "You take a deep breath and feel the heat begin to build within you.", "You may now breathe yellow fire.", "You may now breathe blue fire.","You may now breathe white fire.", "With a roar you channel your reserves into your inner flame, instantly summoning forth a raging inferno.","You are already summoning your flame.",},
     offr = [[^You inhale deeply, allowing the raging flames to build up inside you. With an earth-shaking roar, you release a white-hot jet of fire directly at \w+\.$]],
     off = {"You can not relax a flame that you have not yet summoned.","A small gout of fire erupts harmlessly from your mouth.", "You take a deep breath and realise your error - you sputter and engulf yourself in fire!", "Unleashing white-hot flames in a reckless burst of fire, you create a roaring inferno about your person.", "Your inner fire does not burn with sufficient intensity, Metamorph.", "You take a deep breath and realise your error - you splutter and engulf yourself in fire!"},

--- a/svo (alias and defence functions).xml
+++ b/svo (alias and defence functions).xml
@@ -2089,13 +2089,13 @@ if svo.haveskillset('metamorphosis') then
           if echoback then svo.echof("Removed %s from %s, it's incompatible with %s to have simultaneously up.", morph, whereto, newdef) end
         end
       end
-
       return true
     end,
     invisibledef = true,
-    on = {"You take a deep breath and realise your error - you sputter and engulf yourself in fire!", "You take a deep breath and feel the heat begin to build within you.", "You are ready to breathe yellow fire.", "You are ready to breathe blue fire.","You are ready to breathe white fire.", "With a roar you channel your reserves into your inner flame, instantly summoning forth a raging inferno."},
+
+    on = {"You take a deep breath and realise your error - you sputter and engulf yourself in fire!", "You take a deep breath and feel the heat begin to build within you.", "You may now breathe yellow fire.", "You may now breathe blue fire.","You may now breathe white fire.", "With a roar you channel your reserves into your inner flame, instantly summoning forth a raging inferno.","You are already summoning your flame.",},
     offr = [[^You inhale deeply, allowing the raging flames to build up inside you. With an earth-shaking roar, you release a white-hot jet of fire directly at \w+\.$]],
-    off = {"A small gout of fire erupts harmlessly from your mouth.", "You take a deep breath and realise your error - you sputter and engulf yourself in fire!", "Unleashing white-hot flames in a reckless burst of fire, you create a roaring inferno about your person.", "Your inner fire does not burn with sufficient intensity, Metamorph.", "You take a deep breath and realise your error - you splutter and engulf yourself in fire!"},
+    off = {"You can not relax a flame that you have not yet summoned.","A small gout of fire erupts harmlessly from your mouth.", "You take a deep breath and realise your error - you sputter and engulf yourself in fire!", "Unleashing white-hot flames in a reckless burst of fire, you create a roaring inferno about your person.", "Your inner fire does not burn with sufficient intensity, Metamorph.", "You take a deep breath and realise your error - you splutter and engulf yourself in fire!"},
     })
     --Wyvern, Basilisk
 


### PR DESCRIPTION
Changed both the action and the defence dictionary entries. Also added an additional 'lost defence' line.

Closes #636 