### PR TITLE
Allow module to actually load

### DIFF
--- a/svo (mindnet).xml
+++ b/svo (mindnet).xml
@@ -107,7 +107,7 @@ end</script>
 			<packageName></packageName>
 			<script>function mindnetPrio(_, module)
   if module ~= "svo (mindnet)" then return true end
-  tempTimer(0, [[setModulePriority("]]..module..[[", 1)]])
+  tempTimer(0, [[setModulePriority("]]..module..[[", 0)]])
 end
 
 registerAnonymousEventHandler("sysInstall", "mindnetPrio", true)


### PR DESCRIPTION
Swap the module priority to 0 so that it is loaded when the svo system loaded event fires
Fixes #696 