### PR TITLE
Clarify formatting for install instructions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,7 +24,7 @@ To install the system, make sure that you're connected to server **achaea.com** 
 
 2) Unzip it somewhere permanent. Don't delete the unzipped files.
 
-3) Install svo (install me in module manager).xml in the Module Manager:
+3) Install ``svo (install me in module manager).xml`` in the Module Manager:
 
 .. image:: images/install-in-module-manager.png
 


### PR DESCRIPTION
Clarify formatting for install instructions, because it still brings confusion:

> sorry, which exactly file do I choose when I click install in the module manager?
just zip?
because it said unzip me