### PR TITLE
Riding defense Logic

### DIFF
--- a/svo (actions dictionary).xml
+++ b/svo (actions dictionary).xml
@@ -9843,7 +9843,8 @@ end
         return (
           ((sys.deffing and defdefup[defs.mode].riding and not defc.riding)
             or (not sys.deffing and conf.keepup and ((defkeepup[defs.mode].riding and not defc.riding) or (not defkeepup[defs.mode].riding and defc.riding))))
-          and not codepaste.balanceful_defs_codepaste() and not defc.dragonform and not affs.hamstring and (not affs.prone or svo.doingaction'prone') and not affs.crippledleftarm and not affs.crippledrightarm and not affs.mangledleftarm and not affs.mangledrightarm and not affs.mutilatedleftarm and not affs.mutilatedrightarm and not affs.unknowncrippledleg and not affs.parestolegs and not svo.doingaction'riding' and not affs.pinshot and not affs.paralysis) or false
+          and not codepaste.balanceful_defs_codepaste() and not defc.dragonform and not affs.hamstring and (not affs.prone or svo.doingaction'prone') and not affs.crippledleftarm and not affs.crippledrightarm and not affs.mangledleftarm and not affs.mangledrightarm and not affs.mutilatedleftarm and not affs.mutilatedrightarm and not affs.unknowncrippledleg and not affs.parestolegs and not svo.doingaction'riding' and not affs.pinshot and not affs.paralysis
+          and not string.find(svo.me.class, "Elemental")) or false
       end,
 
       oncompleted = function()

--- a/svo (alias and defence functions).xml
+++ b/svo (alias and defence functions).xml
@@ -1562,7 +1562,7 @@ end
     },
     def = "You are surrounded by a nearly invisible magical shield."})
   defs_data:set('riding', { type = 'general',
-    specialskip = function() return defc.dragonform end,
+    specialskip = function() return defc.dragonform or string.find(svo.me.class, "Elemental") end,
     ondef = function ()
       if tostring(conf.ridingsteed) and tostring(conf.ridingsteed):match("([A-Za-z]+)") and string.find(matches[2], tostring(conf.ridingsteed):match("([A-Za-z]+)"), nil, true) then
         return "("..tostring(conf.ridingsteed):match("([A-Za-z]+)")..")"


### PR DESCRIPTION
Updated the riding defense logic to not spam Elemental Lords/Ladies, since they cannot use a mount. This should solve issue #686 