### PR TITLE
update gmcp balance tracking

### DIFF
--- a/svo (aliases, triggers).xml
+++ b/svo (aliases, triggers).xml
@@ -8580,11 +8580,7 @@ svo.valid.hidden_evileye()</script>
 					</regexCodePropertyList>
 					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="yes" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 						<name>Capture flags</name>
-						<script>for _, balance in pairs{"balance", "equilibrium"} do
-  if svo.bals[balance] then svo["had_"..balance] = true end
-end
-
-svo.valid.setup_prompt()</script>
+						<script>svo.valid.setup_prompt()</script>
 						<triggerType>0</triggerType>
 						<conditonLineDelta>0</conditonLineDelta>
 						<mStayOpen>0</mStayOpen>
@@ -8603,7 +8599,7 @@ svo.valid.setup_prompt()</script>
 						</regexCodePropertyList>
 						<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 							<name>Eq</name>
-							<script>svo.bals.equilibrium = true</script>
+							<script></script>
 							<triggerType>0</triggerType>
 							<conditonLineDelta>99</conditonLineDelta>
 							<mStayOpen>0</mStayOpen>
@@ -8623,7 +8619,7 @@ svo.valid.setup_prompt()</script>
 						</Trigger>
 						<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 							<name>Balance</name>
-							<script>svo.bals.balance = true</script>
+							<script></script>
 							<triggerType>0</triggerType>
 							<conditonLineDelta>0</conditonLineDelta>
 							<mStayOpen>0</mStayOpen>
@@ -8786,30 +8782,7 @@ svo.valid.setup_prompt()</script>
 					</Trigger>
 					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 						<name>Do stuffs.</name>
-						<script>svo.watch = svo.watch or {}
-
-if not svo.innews then
-  for _, balance in pairs{"balance", "equilibrium"} do
-    if svo["had_"..balance] and not svo.bals[balance] then
-      raiseEvent("svo lost balance", balance)
-
-      svo.watch["bal_"..balance] = svo.watch["bal_"..balance] or createStopWatch()
-      startStopWatch(svo.watch["bal_"..balance])
-    elseif not svo["had_"..balance] and svo.bals[balance] then
-      raiseEvent("svo got balance", balance)
-
-      if svo.watch["bal_"..balance] then
-        local s = stopStopWatch(svo.watch["bal_"..balance])
-        svo.stats["last"..balance] = s
-        if svo.conf.showbaltimes then svo.echotime(s) end
-      end
-    end
-
-    svo["had_"..balance] = nil
-  end
-end
-
-svo.onprompt()</script>
+						<script>svo.onprompt()</script>
 						<triggerType>0</triggerType>
 						<conditonLineDelta>0</conditonLineDelta>
 						<mStayOpen>0</mStayOpen>
@@ -8972,7 +8945,7 @@ svo.onprompt()</script>
 						</regexCodePropertyList>
 					</Trigger>
 				</TriggerGroup>
-				<TriggerGroup isActive="no" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>General cures</name>
 					<script>-- this folder is supposed to be off, so it's okay!</script>
 					<triggerType>0</triggerType>
@@ -18350,7 +18323,7 @@ raiseEvent("svo got balance", "entities")</script>
 						</regexCodePropertyList>
 					</Trigger>
 				</TriggerGroup>
-				<TriggerGroup isActive="no" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>Shrugging balance</name>
 					<script></script>
 					<triggerType>0</triggerType>
@@ -18528,7 +18501,7 @@ raiseEvent("svo got balance", "homunculus")</script>
 						</regexCodePropertyList>
 					</Trigger>
 				</TriggerGroup>
-				<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<TriggerGroup isActive="no" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>Fitness balance</name>
 					<script></script>
 					<triggerType>0</triggerType>
@@ -18604,7 +18577,7 @@ raiseEvent("svo got balance", "homunculus")</script>
 						</regexCodePropertyList>
 					</Trigger>
 				</TriggerGroup>
-				<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<TriggerGroup isActive="no" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>Rage balance</name>
 					<script></script>
 					<triggerType>0</triggerType>
@@ -19543,7 +19516,7 @@ echo'\n' svo.config.set("shipmode", "on", true)</script>
 						</regexCodePropertyList>
 					</Trigger>
 				</TriggerGroup>
-				<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<TriggerGroup isActive="no" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>Two-hander recover footing</name>
 					<script></script>
 					<triggerType>0</triggerType>
@@ -48006,9 +47979,9 @@ svo.startedfighting("blademaster", multimatches[2][3])</script>
 				</Trigger>
 				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="yes" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>Limb damage</name>
-					<script>svo.valid.limb_hit(multimatches[2][3], "centreslash")
+					<script>svo.valid.limb_hit(multimatches[2][2], "centreslash")
 
-svo.startedfighting("blademaster", multimatches[2][2])</script>
+svo.startedfighting("blademaster", multimatches[2][3])</script>
 					<triggerType>0</triggerType>
 					<conditonLineDelta>0</conditonLineDelta>
 					<mStayOpen>0</mStayOpen>

--- a/svo (aliases, triggers).xml
+++ b/svo (aliases, triggers).xml
@@ -8945,7 +8945,7 @@ svo.valid.hidden_evileye()</script>
 						</regexCodePropertyList>
 					</Trigger>
 				</TriggerGroup>
-				<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<TriggerGroup isActive="no" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>General cures</name>
 					<script>-- this folder is supposed to be off, so it's okay!</script>
 					<triggerType>0</triggerType>
@@ -47979,9 +47979,9 @@ svo.startedfighting("blademaster", multimatches[2][3])</script>
 				</Trigger>
 				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="yes" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>Limb damage</name>
-					<script>svo.valid.limb_hit(multimatches[2][2], "centreslash")
+					<script>svo.valid.limb_hit(multimatches[2][3], "centreslash")
 
-svo.startedfighting("blademaster", multimatches[2][3])</script>
+svo.startedfighting("blademaster", multimatches[2][2])</script>
 					<triggerType>0</triggerType>
 					<conditonLineDelta>0</conditonLineDelta>
 					<mStayOpen>0</mStayOpen>

--- a/svo (curing skeleton, controllers, action system).xml
+++ b/svo (curing skeleton, controllers, action system).xml
@@ -2534,8 +2534,8 @@ function svo.valid.setup_prompt()
     bals.rightarm = 'unset'
     bals.leftarm = 'unset'
   else
-    bals.balance = false
-    bals.equilibrium = false
+    --bals.balance = false
+    --bals.equilibrium = false
     svo.pflags = {}
   end
 end
@@ -2649,6 +2649,18 @@ function svo.onprompt()
   sk.systemscommands = {}
 
   svo.promptcount = svo.promptcount + 1
+       
+  if svo.conf.showbaltimes then 
+    
+    if svo.sk.balchange and svo.stats['lastbalance'] then
+      svo.echotime(svo.stats['lastbalance'])
+      svo.sk.balchange = nil
+    end
+    if svo.sk.eqchange then
+      svo.echotime(svo.stats['lastequilibrium']) 
+      svo.sk.eqchange = nil
+    end
+  end
 
   checkblackout()
   check_promptflags()
@@ -2667,6 +2679,8 @@ function svo.onprompt()
   if conf.showchanges and not conf.commandecho or (conf.commandecho and conf.commandechotype == 'fancynewline') then
     sk.showstatchanges()
   end
+  
+  
 
   local processing_status, processing_message = pcall(signals.after_prompt_processing.emit, signals.after_prompt_processing)
   if not processing_status then
@@ -3026,6 +3040,7 @@ end
 svo.savesettings = svo.QQ
 
 -- add in blackout only, otherwise go off the prompt - this allows for time tracking
+--maybe can remove this now if it was only for tracking eq in blackout?
 function svo.goteq()
   sys.balancetick = sys.balancetick + 1
   if sys.actiontimeoutid then
@@ -3035,20 +3050,15 @@ function svo.goteq()
 
   if sys.misseddisrupt then killTimer(sys.misseddisrupt); sys.misseddisrupt = nil end
   sys.extended_eq = nil
-
-  if affs.blackout and not bals.equilibrium then bals.equilibrium = true; raiseEvent("svo got balance", 'equilibrium') end
 end
 
+--maybe can remove this now if it was only for tracking bal in blackout?
 function svo.gotbalance()
-  if affs.blackout then bals.balance = true end
   sys.balancetick = sys.balancetick + 1
   if sys.actiontimeoutid then
     killTimer(sys.actiontimeoutid)
     sys.actiontimeoutid = false
   end
-
-  -- FIXME
-  if affs.blackout and not bals.balance then bals.balance = true; raiseEvent("svo got balance", 'balance') end
 end
 
 function svo.gotarmbalance()
@@ -3597,8 +3607,44 @@ end
 
 -- capture the incoming values for gmcp balance and eq
 signals.gmcpcharvitals:connect(function()
-  svo.newbals.balance     = gmcp.Char.Vitals.bal == '1' and true or false
-  svo.newbals.equilibrium = gmcp.Char.Vitals.eq == '1' and true or false
+
+  svo.watch = svo.watch or {}
+  
+  local newbal = gmcp.Char.Vitals.bal == '1' and true or false
+  local neweq = gmcp.Char.Vitals.eq == '1' and true or false
+  
+  if svo.bals['balance'] and not newbal then
+    raiseEvent('svo lost balance', 'balance')
+    svo.watch['bal_balance'] = svo.watch['bal_balance'] or createStopWatch()
+    startStopWatch(svo.watch['bal_balance'])
+  elseif not svo.bals['balance'] and newbal then
+    raiseEvent('svo got balance', 'balance')
+    if svo.watch['bal_balance'] then
+      local s = stopStopWatch(svo.watch['bal_balance'])
+      svo.stats['lastbalance'] = s
+      
+      -- note to show changes on the actual line
+      svo.sk.balchange = true
+    end
+  end
+  
+  if svo.bals['equilibrium'] and not neweq then
+    raiseEvent('svo lost balance', 'equilibrium')
+    svo.watch['equilibrium'] = svo.watch['equilibrium'] or createStopWatch()
+    startStopWatch(svo.watch['equilibrium'])
+  elseif not svo.bals['equilibrium'] and neweq then
+    raiseEvent('svo got balance', 'equilibrium')
+    if svo.watch['equilibrium'] then
+      local s = stopStopWatch(svo.watch['equilibrium'])
+      svo.stats['lastequilibrium'] = s
+      -- note to show changes on the actual line
+      svo.sk.eqchange = true
+    end
+  end  
+
+  svo.bals.balance     = newbal
+  svo.bals.equilibrium = neweq
+
 end, "new balance detection")
 
 -- feed the curing systems curing command through the system, so it can track actions

--- a/svo (curing skeleton, controllers, action system).xml
+++ b/svo (curing skeleton, controllers, action system).xml
@@ -3040,7 +3040,6 @@ end
 svo.savesettings = svo.QQ
 
 -- add in blackout only, otherwise go off the prompt - this allows for time tracking
---maybe can remove this now if it was only for tracking eq in blackout?
 function svo.goteq()
   sys.balancetick = sys.balancetick + 1
   if sys.actiontimeoutid then

--- a/svo (curing skeleton, controllers, action system).xml
+++ b/svo (curing skeleton, controllers, action system).xml
@@ -3039,7 +3039,7 @@ end
 
 svo.savesettings = svo.QQ
 
--- add in blackout only, otherwise go off the prompt - this allows for time tracking
+-- add in blackout only, otherwise go off the prompt - this allows for time tracking for hidden eq loss
 function svo.goteq()
   sys.balancetick = sys.balancetick + 1
   if sys.actiontimeoutid then
@@ -3051,7 +3051,6 @@ function svo.goteq()
   sys.extended_eq = nil
 end
 
---maybe can remove this now if it was only for tracking bal in blackout?
 function svo.gotbalance()
   sys.balancetick = sys.balancetick + 1
   if sys.actiontimeoutid then


### PR DESCRIPTION
This will remove tracking balance and equilibrium from the prompt and solely use gmcp. This should help with things like tracking balance in blackout which had some issues and also remove some odd fixes throughout svof. 

There seem to be a few oddities tracking eq/bal in blackout pre-gmcp. I tried to catch them all and remove them without breaking something else but we will see. No issues that I could tell so far.