### PR TITLE
Fixes being unable to ink on a specific leg

### DIFF
--- a/svo (inker).xml
+++ b/svo (inker).xml
@@ -183,7 +183,7 @@
 			<script>svo.ti_ink(matches[2], matches[3], matches[4])</script>
 			<command></command>
 			<packageName></packageName>
-			<regex>^ink (.+) on (\w+(?: arm| leg)?)(?: of (\w+))?</regex>
+			<regex>^ink (\w+) on (\w+(?: arm| leg)?)(?: of (\w+))?</regex>
 		</Alias>
 	</AliasPackage>
 	<ActionPackage />

--- a/svo (inker).xml
+++ b/svo (inker).xml
@@ -183,7 +183,7 @@
 			<script>svo.ti_ink(matches[2], matches[3], matches[4])</script>
 			<command></command>
 			<packageName></packageName>
-			<regex>^ink (.+) on (\w+(?: arm|leg)?)(?: of (\w+))?</regex>
+			<regex>^ink (.+) on (\w+(?: arm| leg)?)(?: of (\w+))?</regex>
 		</Alias>
 	</AliasPackage>
 	<ActionPackage />

--- a/svo (inker).xml
+++ b/svo (inker).xml
@@ -183,7 +183,7 @@
 			<script>svo.ti_ink(matches[2], matches[3], matches[4])</script>
 			<command></command>
 			<packageName></packageName>
-			<regex>^ink (\w+) on (\w+(?: arm| leg)?)(?: of (\w+))?</regex>
+			<regex>^ink (.+) on (\w+(?: arm| leg)?)(?: of (\w+))?</regex>
 		</Alias>
 	</AliasPackage>
 	<ActionPackage />


### PR DESCRIPTION
The regex as it is looks for either a space followed by "arm" or just "leg". This means that with SVO right now we can't target left/right legs. Confirmed this is an SVO issue by adding spaces to the command "ink tree on right leg of Person" and it worked, but without them svo said "(svof): Going to ink tree on open place of right."