### PR TITLE
Add support for releases again - master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,26 +21,13 @@ jobs:
           # specify here the path to your version file (e.g. package.json, pom.xml...)
           version-file: inclient/current_version.txt
           schema: major
-          
-      - name: Verify tag
-        id: verifytag
-        env:
-          VersionToVerify: ${{ steps.getversion.outputs.version }}
-        run: |
-          echo "$VersionToVerify"
-          if [ $(git tag -l $VersionToVerify) ]; then
-            echo "{pushtag}={false}" >> $GITHUB_OUTPUT
-          else
-            echo "{pushtag}={true}" >> $GITHUB_OUTPUT
-          fi
         
     outputs:
       version: ${{ steps.getversion.outputs.version }}
-      canpushtag: ${{ steps.verifytag.outputs.pushtag }}
-  
+
   createtag:
     needs: [checkversion]
-    if: ${{ needs.checkversion.outputs.canpushtag == true }}
+    if: contains(github.ref, format('refs/tags/{0}', needs.checkversion.outputs.version)) == false
     runs-on: ubuntu-latest
     env:
       Version: ${{ needs.checkversion.outputs.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Verify tag
         id: verifytag
         env:
-          VersionToVerify: ${{ steps.getversion.outputs.version) }}
+          VersionToVerify: ${{ steps.getversion.outputs.version }}
         run: |
           echo "$VersionToVerify"
           if [ $(git tag -l "VersionToVerify") ]; then
@@ -43,7 +43,7 @@ jobs:
     if: ${{ needs.checkversion.outputs.canpushtag == true }}
     runs-on: ubuntu-latest
     env:
-      Version: ${{ needs.checkversion.outputs.version) }}
+      Version: ${{ needs.checkversion.outputs.version }}
     steps:
     - name: checkout
       uses: actions/checkout@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,52 @@
+name: 'CI TEST'
+on:
+  push:
+    branches: [ gh-pages ]
+    paths:
+    - 'inclient/current_version.txt'
+
+jobs:
+  checkversion:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          token: ${{ secrets.SVOF_PAT }}
+          ref: gh-pages
+      - name: Get version
+        id: getversion
+        uses: michmich112/extract-version@main
+        with:
+          # specify here the path to your version file (e.g. package.json, pom.xml...)
+          version-file: inclient/current_version.txt
+          schema: major
+          
+      - name: File contents
+        run: echo "${{ steps.getversion.outputs.version }}"
+    outputs:
+      version: ${{ steps.getversion.outputs.version }}
+  
+  createtag:
+    needs: [checkversion]
+    runs-on: ubuntu-latest
+    env:
+      Version: ${{ format('v{0}', needs.checkversion.outputs.version) }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@master
+      with:
+        token: ${{ secrets.SVOF_PAT }}
+        ref: in-client-svof
+        fetch-depth: 0
+    
+    - name: Push tag
+      id: maketag
+      env:
+        GITHUB_TOKEN: ${{ secrets.SVOF_PAT }}
+      run: |
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git tag -a $Version -m "$Version"
+        git push origin $Version
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Verify tag
         id: verifytag
         env:
-          VersionToVerify: ${{ format('v{0}', steps.getversion.outputs.version) }}
+          VersionToVerify: ${{ steps.getversion.outputs.version) }}
         run: |
           echo "$VersionToVerify"
           if [ $(git tag -l "VersionToVerify") ]; then
@@ -43,7 +43,7 @@ jobs:
     if: ${{ needs.checkversion.outputs.canpushtag == true }}
     runs-on: ubuntu-latest
     env:
-      Version: ${{ format('v{0}', needs.checkversion.outputs.version) }}
+      Version: ${{ needs.checkversion.outputs.version) }}
     steps:
     - name: checkout
       uses: actions/checkout@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: 'CI TEST'
+name: 'Versioning and Tagging'
 on:
   push:
     branches: [ gh-pages ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,13 +22,25 @@ jobs:
           version-file: inclient/current_version.txt
           schema: major
           
-      - name: File contents
-        run: echo "${{ steps.getversion.outputs.version }}"
+      - name: Verify tag
+        id: verifytag
+        env:
+          VersionToVerify: ${{ format('v{0}', steps.getversion.outputs.version) }}
+        run: |
+          echo "$VersionToVerify"
+          if [ $(git tag -l "VersionToVerify") ]; then
+            echo "{pushtag}={false}" >> $GITHUB_OUTPUT
+          else
+            echo "{pushtag}={true}" >> $GITHUB_OUTPUT
+          fi
+        
     outputs:
       version: ${{ steps.getversion.outputs.version }}
+      canpushtag: ${{ steps.verifytag.outputs.pushtag }}
   
   createtag:
     needs: [checkversion]
+    if: ${{ needs.checkversion.outputs.canpushtag == true }}
     runs-on: ubuntu-latest
     env:
       Version: ${{ format('v{0}', needs.checkversion.outputs.version) }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           VersionToVerify: ${{ steps.getversion.outputs.version }}
         run: |
           echo "$VersionToVerify"
-          if [ $(git tag -l "VersionToVerify") ]; then
+          if [ $(git tag -l $VersionToVerify) ]; then
             echo "{pushtag}={false}" >> $GITHUB_OUTPUT
           else
             echo "{pushtag}={true}" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
   createtag:
     needs: [checkversion]
-    if: contains(github.ref, format('refs/tags/{0}', needs.checkversion.outputs.version)) == false
+    if: contains(github.ref, format('refs/tags/{0}', needs.checkversion.outputs.version)) == 'false'
     runs-on: ubuntu-latest
     env:
       Version: ${{ needs.checkversion.outputs.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
 
   createtag:
     needs: [checkversion]
-    if: contains(github.ref, format('refs/tags/{0}', needs.checkversion.outputs.version)) == 'false'
     runs-on: ubuntu-latest
     env:
       Version: ${{ needs.checkversion.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: 'CI'
 on:
   push:
     tags:
-    - 'v*'
+    - '*'
 jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -62,7 +62,7 @@ jobs:
       with:
         #tag_name: ${{ format('v{0}', needs.checkversion.outputs.version) }}
         tag_name: ${{ github.ref_name }}
-        name: ${{ github.ref_name }}
+        name: ${{ format('v{0}', github.ref_name )}}
         body: ${{ steps.generatechangelog.outputs.changelog }}
         files: ${{ github.workspace }}/in-client-svof.zip
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Create zipped package
       id: makezip
       run: >
-        zip in-client-svof -mm
+        zip in-client-svof -MM
         "svo (actions dictionary).xml"
         "svo (alias and defence functions).xml"
         "svo (aliases, triggers).xml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: 'RELEASE TEST'
+on:
+  push:
+    tags:
+    - 'v*'
+jobs:
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@master
+      with:
+        ref: in-client-svof
+        fetch-depth: 0
+      
+    #- name: Build Changelog
+    #  id: generatechangelog
+    #  uses: mikepenz/release-changelog-builder-action@v3.4.0
+    #  with:
+    #    configuration: "release-changelog-configuration.json"
+    #    ignorePreReleases: "true"
+    #    toTag: "52"
+    #    token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create zipped package
+      id: makezip
+      run: >
+        zip in-client-svof
+        "svo (actions dictionary).xml"
+        "svo (alias and defence functions).xml"
+        "svo (aliases, triggers).xml"
+        "svo (burncounter).xml"
+        "svo (curing skeleton, controllers, action system).xml"
+        "svo (custom prompt, serverside).xml"
+        "svo (elistsorter).xml"
+        "svo (enchanter).xml"
+        "svo (fishdist).xml"
+        "svo (inker).xml"
+        "svo (install me in module manager).xml"
+        "svo (install, config, pipes, rift, parry, prios).xml"
+        "svo (limbcounter).xml"
+        "svo (logger).xml"
+        "svo (mindnet).xml"
+        "svo (namedb).xml"
+        "svo (offering).xml"
+        "svo (peopletracker).xml"
+        "svo (priestreport).xml"
+        "svo (reboundingsileristracker).xml"
+        "svo (refiller).xml"
+        "svo (runeidentifier).xml"
+        "svo (setup, misc, empty, funnies, dor).xml"
+        "svo (stormhammertarget).xml"
+        "svo (trigger functions).xml"
+        "config.lua"
+        "default_prios"
+        "ndb-help.lua"
+        "LICENSES.txt"
+        "LICENSE.txt"
+
+    - name: Make release
+      id: release
+      uses: softprops/action-gh-release@master
+      with:
+        #tag_name: ${{ format('v{0}', needs.checkversion.outputs.version) }}
+        tag_name: ${{ github.ref_name }}
+        name: ${{ github.ref_name }}
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+    - name: Upload zip
+      uses: shogo82148/actions-upload-release-asset@v1.6.3
+      with:
+        upload_url: ${{ steps.release.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/in-client-svof.zip
+
+    

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Create zipped package
       id: makezip
       run: >
-        zip in-client-svof
+        zip in-client-svof -mm
         "svo (actions dictionary).xml"
         "svo (alias and defence functions).xml"
         "svo (aliases, triggers).xml"
@@ -64,14 +64,15 @@ jobs:
         tag_name: ${{ github.ref_name }}
         name: ${{ github.ref_name }}
         body: ${{ steps.generatechangelog.outputs.changelog }}
+        files: ${{ github.workspace }}/in-client-svof.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-    - name: Upload zip
-      uses: shogo82148/actions-upload-release-asset@v1.6.3
-      with:
-        upload_url: ${{ steps.release.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/in-client-svof.zip
+    #- name: Upload zip
+    #  uses: shogo82148/actions-upload-release-asset@v1.6.3
+    #  with:
+    #    upload_url: ${{ steps.release.outputs.upload_url }}
+    #    asset_path: ${{ github.workspace }}/in-client-svof.zip
     
     - name: Make Mudlet-ready changelog
       id: mudletlog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Create zipped package
       id: makezip
       run: >
-        zip in-client-svof -MM
+        zip in-client-svof -MM -j
         "svo (actions dictionary).xml"
         "svo (alias and defence functions).xml"
         "svo (aliases, triggers).xml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,5 +72,8 @@ jobs:
       with:
         upload_url: ${{ steps.release.outputs.upload_url }}
         asset_path: ${{ github.workspace }}/in-client-svof.zip
-
     
+    - name: Make Mudlet-ready changelog
+      id: mudletlog
+      run: >
+        git log --graph --pretty=format:'%C(magenta)(%h)%C(reset) - %C(yellow)[%s]%C(reset) %b %C(bold blue)<%an>%Creset' --abbrev-commit --color=always --since="1 month" > ANSICHANGELOG.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,13 @@ jobs:
         ref: in-client-svof
         fetch-depth: 0
       
-    #- name: Build Changelog
-    #  id: generatechangelog
-    #  uses: mikepenz/release-changelog-builder-action@v3.4.0
-    #  with:
-    #    configuration: "release-changelog-configuration.json"
-    #    ignorePreReleases: "true"
-    #    toTag: "52"
-    #    token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build Changelog
+      id: generatechangelog
+      uses: mikepenz/release-changelog-builder-action@v3.4.0
+      with:
+        configuration: "release-changelog-configuration.json"
+        ignorePreReleases: "true"
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Create zipped package
       id: makezip
       run: >
@@ -64,7 +63,7 @@ jobs:
         #tag_name: ${{ format('v{0}', needs.checkversion.outputs.version) }}
         tag_name: ${{ github.ref_name }}
         name: ${{ github.ref_name }}
-        generate_release_notes: true
+        body: ${{ steps.generatechangelog.outputs.changelog }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         ref: in-client-svof
         fetch-depth: 0
-      
+    
     - name: Build Changelog
       id: generatechangelog
       uses: mikepenz/release-changelog-builder-action@v3.4.0
@@ -21,6 +21,12 @@ jobs:
         configuration: "release-changelog-configuration.json"
         ignorePreReleases: "true"
         token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Make Mudlet-ready changelog
+      id: mudletlog
+      run: >
+        git log --graph --pretty=format:'%C(magenta)(%h)%C(reset) - %C(yellow)[%s]%C(reset) %b %C(bold blue)<%an>%Creset' --abbrev-commit --color=always --since="1 month" > ANSICHANGELOG.txt
+    
     - name: Create zipped package
       id: makezip
       run: >
@@ -55,6 +61,7 @@ jobs:
         "ndb-help.lua"
         "LICENSES.txt"
         "LICENSE.txt"
+        "${{ github.workspace }}/ANSICHANGELOG.txt"
 
     - name: Make release
       id: release
@@ -67,14 +74,3 @@ jobs:
         files: ${{ github.workspace }}/in-client-svof.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-    #- name: Upload zip
-    #  uses: shogo82148/actions-upload-release-asset@v1.6.3
-    #  with:
-    #    upload_url: ${{ steps.release.outputs.upload_url }}
-    #    asset_path: ${{ github.workspace }}/in-client-svof.zip
-    
-    - name: Make Mudlet-ready changelog
-      id: mudletlog
-      run: >
-        git log --graph --pretty=format:'%C(magenta)(%h)%C(reset) - %C(yellow)[%s]%C(reset) %b %C(bold blue)<%an>%Creset' --abbrev-commit --color=always --since="1 month" > ANSICHANGELOG.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: 'RELEASE TEST'
+name: 'CI'
 on:
   push:
     tags:


### PR DESCRIPTION
Hello!
This is the first of a series of PRs I'm gonna make (since it also has changed on a few other branches for it to work) to add support for proper releases for Svof, as well as a (admittedly very basic) versioning logic.

The goal for this is to only create a release when we are 100% ready for it and not when pull requests are merged. So I made it so it will trigger the chain of workflows once the file 'current_version.txt' in gh-pages is edited with a new version which signifies we are ready for a new release.

For this to work though, we will need to create a new PAT to be used in one of the workflows. This is so because github can properly chain those workflows (if use `secrets.GITHUB_TOKEN` alone it won't chain them).

I took the liberty to create and edit a few labels too, since we will need the labels so the changelog builder can run.

With this we can probably finally close up the Client-Side Release project.