### PR TITLE
Emergency fix for Mudlet's sync bug wiping out files

### DIFF
--- a/svo (custom prompt, serverside).xml
+++ b/svo (custom prompt, serverside).xml
@@ -22,7 +22,7 @@
 
 svo = svo or {}; svo.loader = svo.loader or {}
 svo.modules_version = svo.modules_version or {}
-svo.modules_version["svo (custom prompt, serverside, peopletracker)"] = 1
+svo.modules_version["svo (custom prompt, serverside)"] = 1
 
 svo.loader.customprompt = function()
 

--- a/svo (install me in module manager).xml
+++ b/svo (install me in module manager).xml
@@ -7322,7 +7322,10 @@ function svo.uninstall_all_modules(event,modulename)
 
   for ourmodule,_ in pairs(svo.modules_version) do
     if not event or (ourmodule ~= "svo (install me in module manager)") then
+      disableModuleSync(ourmodule) -- need to disable module before uninstalling first due to a bug in Mudlet module sync
+      tempTimer(0, function()
   	  uninstallModule(ourmodule)
+      end)
     end
   end
 	svo.systemloaded = nil

--- a/svo (setup, misc, empty, funnies, dor).xml
+++ b/svo (setup, misc, empty, funnies, dor).xml
@@ -22,7 +22,7 @@ svo.modules_version = svo.modules_version or {}
 svo.modules_version["svo (setup, misc, empty, funnies, dor)"] = 1
 svo.loader.setup = function()
 
-svo.version = "52"
+svo.version = "53"
 
 if Logger and not svo.systemloaded then
   Logger:LogSection('svof', {'timestamp', split = 5000, 'keepOpen'})


### PR DESCRIPTION
Due to a bug in Mudlet's module sync, need to disable sync first or it will wipe out the xmls. Putting this bandaid fix so people don't run into it anymore until it is fixed. Also fixed an unrelated problem with the naming of one of the modules in the list.