### PR TITLE
Reset all signals on init

### DIFF
--- a/svo (install me in module manager).xml
+++ b/svo (install me in module manager).xml
@@ -7153,7 +7153,7 @@ function svo_init_system()
 	end
 	
   --clears all signals in case of a reload (e.g. classchange)
-  --svo.signals = nil
+  svo.signals = nil
   
 	for _, subsystem in ipairs(required_subsystems) do
 	  svo.loader[subsystem]()

--- a/svo (install me in module manager).xml
+++ b/svo (install me in module manager).xml
@@ -7152,6 +7152,9 @@ function svo_init_system()
 		return
 	end
 	
+  --clears all signals in case of a reload (e.g. classchange)
+  --svo.signals = nil
+  
 	for _, subsystem in ipairs(required_subsystems) do
 	  svo.loader[subsystem]()
 	end
@@ -7187,8 +7190,7 @@ end</script>
 				<name>svo.classchange</name>
 				<packageName></packageName>
 				<script>function svo.classchange(override)
-
-  local newclass = (override ~= "gmcp.Char.Status") and override or gmcp.Char.Status.class
+  local newclass = (override ~= gmcp.Char.Status.class) and override or gmcp.Char.Status.class
 	local temp_defs = {}
   
 	-- if you're in an unrecognised class, use the None system
@@ -7210,7 +7212,6 @@ end</script>
 	
   if svo.me.class ~= newclass then
     svo.sk.gettingfullstats = false
-    svo.signals.after_prompt_processing = nil
     local oldclass = svo.me.class
     
     -- kill temporary defense triggers for old class

--- a/svo (setup, misc, empty, funnies, dor).xml
+++ b/svo (setup, misc, empty, funnies, dor).xml
@@ -428,7 +428,7 @@ signals.gmcpcharvitals:connect(function()
 end, 'update morph')
 end
 
-if svo.me.class == 'Monk' then
+if svo.haveskillset('tekura') or svo.haveskillset('shikudo') then
 signals.gmcpcharvitals:connect(function()
   if gmcp.Char.Vitals.charstats then
     for _, val in ipairs(gmcp.Char.Vitals.charstats) do


### PR DESCRIPTION
This helps overlapping signals from causing problems after a class change ( or anytime the system reinitializes)

Should solve #779

also solves another error that svof seems to be throwing from the class change script. Not sure when this started but it is in the main build that is live.

![image](https://user-images.githubusercontent.com/38020432/201721074-07a50ee4-c7eb-4247-9ee3-b60c0f0116b7.png)
