### PR TITLE
Possible fix for prios resetting and random moveWindow errors

### DIFF
--- a/svo (actions dictionary).xml
+++ b/svo (actions dictionary).xml
@@ -410,7 +410,8 @@ end
       typically expect not to check for the common things because pre-
       filtering is done.
   ]]
-
+svo.old_dict = svo.dict
+if not next(svo.dict) then
 svo.dict = {
   -- (string) what serverside calls this by - names can be different as they were revealed years after Svof was made
   gamename = nil,
@@ -14389,8 +14390,11 @@ if svo.haveskillset('anathema') then
     }
   }
 
+end --end of defs
+else
+  --Keep dict state intact upon loading/reloading the script
+  svo.dict = svo.old_dict
 end
-
 -- shortcut function to help create a dict action for a defence
 -- 'which' is the Svof defence name, use the same name in the 'Defences' script
 -- 'command' is the game command to raise the defence

--- a/svo (actions dictionary).xml
+++ b/svo (actions dictionary).xml
@@ -410,13990 +410,13987 @@ end
       typically expect not to check for the common things because pre-
       filtering is done.
   ]]
-svo.old_dict = svo.dict
+--svo.old_dict = svo.dict
 if not next(svo.dict) then
-svo.dict = {
-  -- (string) what serverside calls this by - names can be different as they were revealed years after Svof was made
-  gamename = nil,
-  onservereignore = nil, -- (function) a function which'll return true if this needs to be ignored serverside
-  healhealth = {
-    description = "heals health with health/vitality or moss/potash",
-    sip = {
-      name = false, --'healhealth_sip',
-      balance = false, --'sip',
-      action_name = false, --'healhealth'
-
-      -- managed outside priority lists
-      irregular = true,
-
-      isadvisable = function()
-        -- should healhealth be prioritised above health affs, don't apply if above healthaffsabove% and have an aff
-        local function shouldntsip()
-          local crackedribs    = svo.prio.getnumber('crackedribs', 'sip')
-          local healhealth     = svo.prio.getnumber('healhealth', 'sip')
-          local skullfractures = svo.prio.getnumber('skullfractures', 'sip')
-          local torntendons    = svo.prio.getnumber('torntendons', 'sip')
-          local wristfractures = svo.prio.getnumber('wristfractures', 'sip')
-
-          if stats.hp &gt;= conf.healthaffsabove and ((healhealth &gt; crackedribs and affs.crackedribs) or
-            (healhealth &gt; skullfractures and affs.skullfractures) or (healhealth &gt; torntendons and affs.torntendons) or
-             (healhealth &gt; wristfractures and affs.wristfractures)) then
-            return true
-          end
-
-          return false
-        end
-
-if not svo.haveskillset('kaido') then
-        return ((stats.currenthealth &lt; sys.siphealth or (sk.gettingfullstats and stats.currenthealth &lt; stats.maxhealth))
-         and not svo.actions.healhealth_sip and not shouldntsip())
-else
-        return ((stats.currenthealth &lt; sys.siphealth or (sk.gettingfullstats and stats.currenthealth &lt; stats.maxhealth))
-         and not svo.actions.healhealth_sip  and not shouldntsip() and
-          (defc.dragonform or -- sip health if we're in dragonform, can't use Kaido
-            not svo.can_usemana() or -- or we don't have enough mana (should be an option). The downside of this is that we
-            -- won't get mana back via sipping, only moss, the time to being able to transmute will approach slower than
-            -- straight sipping mana
-            (affs.prone and not conf.transsipprone) or -- or we're prone and sipping while prone is off (better for
-            --bashing, not so for PK)
-            (conf.transmute ~= 'replaceall' and conf.transmute ~= 'replacehealth' and not svo.doingaction'transmute')
-            -- or we're not in a replacehealth/replaceall mode, so we can still sip
-          )
-        )
-end
-      end,
-
-      oncompleted = function() svo.lostbal_sip() end,
-
-      noeffect = function() svo.lostbal_sip() end,
-
-      onprioswitch = function()
-        codepaste.serversideahealthmanaprio()
-      end,
-
-      sipcure = {'health', 'vitality'},
-
-      onstart = function()
-        svo.sip(svo.dict.healhealth.sip)
-      end
-    },
-    moss = {
-      -- managed outside priority lists
-      irregular = true,
-
-      isadvisable = function()
-if not svo.haveskillset('kaido') then
-        return ((stats.currenthealth &lt; sys.mosshealth) and (not svo.doingaction('healhealth') or (stats.currenthealth &lt; (sys.mosshealth-600)))) or false
-else
-        return ((stats.currenthealth &lt; sys.mosshealth) and (not svo.doingaction('healhealth') or (stats.currenthealth &lt; (sys.mosshealth-600))) and (defc.dragonform or not svo.can_usemana() or affs.prone or (conf.transmute ~= 'replaceall' and not svo.doingaction'transmute'))) or false
-end
-      end,
-
-      oncompleted = function() svo.lostbal_moss() end,
-
-      noeffect = function() svo.lostbal_moss() end,
-
-      eatcure = {'irid', 'potash'},
-      actions = {"eat moss", "eat irid", "eat potash"},
-      onstart = function()
-        svo.eat(svo.dict.healhealth.moss)
-      end
-    },
-  },
-  healmana = {
-    description = "heals mana with mana/mentality or moss/potash",
-    sip = {
-      -- managed outside priority lists
-      irregular = true,
-
-      isadvisable = function()
-        return ((stats.currentmana &lt; sys.sipmana or (sk.gettingfullstats and stats.currentmana &lt; stats.maxmana)) and not svo.doingaction('healmana')) or false
-      end,
-
-      oncompleted = function() svo.lostbal_sip() end,
-
-      noeffect = function() svo.lostbal_sip() end,
-
-      onprioswitch = function()
-        codepaste.serversideahealthmanaprio()
-      end,
-
-      sipcure = {'mana', 'mentality'},
-
-      onstart = function()
-        svo.sip(svo.dict.healmana.sip)
-      end
-    },
-    moss = {
-      -- managed outside priority lists
-      irregular = true,
-
-      isadvisable = function()
-        return ((stats.currentmana &lt; sys.mossmana) and (not svo.doingaction('healmana') or (stats.currentmana &lt; (sys.mossmana-600)))) or false
-      end,
-
-      oncompleted = function() svo.lostbal_moss() end,
-
-      noeffect = function() svo.lostbal_moss() end,
-
-      eatcure = {'irid', 'potash'},
-      actions = {"eat moss", "eat irid", "eat potash"},
-      onstart = function()
-        svo.eat(svo.dict.healmana.moss)
-      end
-    },
-  },
-  skullfractures = {
-    count = 0,
-    sip = {
-      isadvisable = function()
-        return (affs.skullfractures and stats.hp &gt;= conf.healthaffsabove) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_sip()
-        svo.updateaffcount(svo.dict.skullfractures)
-      end,
-
-      cured = function()
-        svo.lostbal_sip()
-        svo.rmaff('skullfractures')
-        svo.dict.skullfractures.count = 0
-      end,
-
-      fizzled = function()
-        svo.lostbal_sip()
-        empty.apply_health_head()
-      end,
-
-      noeffect = function() svo.lostbal_sip() end,
-
-      -- in case an unrecognised message is shown, don't error
-      empty = function() end,
-
-      actions = {"apply health to head"},
-      onstart = function() send('apply health to head', conf.commandecho) end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.skullfractures)
-        svo.updateaffcount(svo.dict.skullfractures)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('skullfractures')
-        svo.dict.skullfractures.count = 0
-      end,
-
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.skullfractures)
-      end,
-
-      general_cured = function(_)
-        svo.rmaff('skullfractures')
-        svo.dict.skullfractures.count = 0
-      end,
-    }
-  },
-  crackedribs = {
-    count = 0,
-    sip = {
-      isadvisable = function()
-        return (affs.crackedribs and stats.hp &gt;= conf.healthaffsabove) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_sip()
-        svo.updateaffcount(svo.dict.crackedribs)
-      end,
-
-      cured = function()
-        svo.lostbal_sip()
-        svo.rmaff('crackedribs')
-        svo.dict.crackedribs.count = 0
-      end,
-
-      fizzled = function()
-        svo.lostbal_sip()
-        empty.apply_health_torso()
-      end,
-
-      noeffect = function() svo.lostbal_sip() end,
-
-      -- in case an unrecognised message is shown, don't error
-      empty = function() end,
-
-      actions = {"apply health to torso"},
-      onstart = function() send('apply health to torso', conf.commandecho) end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.crackedribs)
-        svo.updateaffcount(svo.dict.crackedribs)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('crackedribs')
-        svo.dict.crackedribs.count = 0
-      end,
-
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.crackedribs)
-      end,
-
-      general_cured = function()
-        svo.rmaff('crackedribs')
-        svo.dict.crackedribs.count = 0
-      end,
-    }
-  },
-  wristfractures = {
-    count = 0,
-    sip = {
-      isadvisable = function()
-        return (affs.wristfractures and stats.hp &gt;= conf.healthaffsabove) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_sip()
-        svo.updateaffcount(svo.dict.wristfractures)
-      end,
-
-      cured = function()
-        svo.lostbal_sip()
-        svo.rmaff('wristfractures')
-        svo.dict.wristfractures.count = 0
-      end,
-
-      fizzled = function()
-        svo.lostbal_sip()
-        empty.apply_health_arms()
-      end,
-
-      noeffect = function() svo.lostbal_sip() end,
-
-      -- in case an unrecognised message is shown, don't error
-      empty = function() end,
-
-      actions = {"apply health to arms"},
-      onstart = function() send('apply health to arms', conf.commandecho) end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.wristfractures)
-        svo.updateaffcount(svo.dict.wristfractures)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('wristfractures')
-        svo.dict.wristfractures.count = 0
-      end,
-
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.wristfractures)
-      end,
-
-      general_cured = function()
-        svo.rmaff('wristfractures')
-        svo.dict.wristfractures.count = 0
-      end,
-    }
-  },
-  torntendons = {
-    count = 0,
-    sip = {
-      isadvisable = function()
-        return (affs.torntendons and stats.hp &gt;= conf.healthaffsabove) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_sip()
-        svo.updateaffcount(svo.dict.torntendons)
-      end,
-
-      cured = function()
-        svo.lostbal_sip()
-        svo.rmaff('torntendons')
-        svo.dict.torntendons.count = 0
-      end,
-
-      fizzled = function()
-        svo.lostbal_sip()
-        empty.apply_health_legs()
-      end,
-
-      noeffect = function() svo.lostbal_sip() end,
-
-      -- in case an unrecognised message is shown, don't error
-      empty = function() end,
-
-      actions = {"apply health to legs"},
-      onstart = function() send('apply health to legs', conf.commandecho) end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.torntendons)
-        svo.updateaffcount(svo.dict.torntendons)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('torntendons')
-        svo.dict.torntendons.count = 0
-      end,
-
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.torntendons)
-      end,
-
-      general_cured = function()
-        svo.rmaff('torntendons')
-        svo.dict.torntendons.count = 0
-      end,
-    }
-  },
-  pressure = {
-    count = 0,
-    gamename = 'pressure',
-    name = 'pressure',
-    smoke = {
-      isadvisable = function()
-        return (affs.pressure and bals.smoke) or false
-      end,
-
-      -- this is called when you still have some left 
-      oncompleted = function()
-        svo.lostbal_smoke()
-        svo.updateaffcount(svo.dict.pressure)
-      end,
-
-      empty = function()
-        empty.eat_pear()
-        svo.lostbal_smoke()
-      end,
-
-      cured = function()
-        svo.lostbal_smoke()
-        svo.rmaff('pressure')
-        svo.dict.pressure.count = 0
-      end,
-
-      noeffect = function()
-			  svo.rmaff('pressure')
-			  svo.lostbal_smoke()
-		  end,
-
-      eatcure = {'pear', 'calcite'},
-
-      onstart = function() svo.eat(svo.dict.pressure.smoke) end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.pressure)
-        svo.updateaffcount(svo.dict.pressure)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('pressure')
-        svo.dict.pressure.count = 0
-      end,
-      
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.pressure)
-      end,
-
-      general_cured = function()
-        svo.rmaff('pressure')
-        svo.dict.pressure.count = 0
-      end,
-    }
-  },
-  cholerichumour = {
-    count = 0,
-    gamename = 'temperedcholeric',
-    name = 'cholerichumour',
-    herb = {
-      isadvisable = function()
-        return (affs.cholerichumour) or false
-      end,
-
-      -- this is called when you still have some left
-      oncompleted = function()
-        svo.lostbal_herb()
-        svo.updateaffcount(svo.dict.cholerichumour)
-      end,
-
-      empty = function()
-        empty.eat_ginger()
-        svo.lostbal_herb()
-      end,
-
-      cured = function()
-        svo.lostbal_herb()
-        svo.rmaff('cholerichumour')
-        svo.dict.cholerichumour.count = 0
-      end,
-
-      noeffect = function() svo.lostbal_herb() end,
-
-      -- does damage based on humour count
-      inundated = function()
-        svo.rmaff('cholerichumour')
-        svo.dict.cholerichumour.count = 0
-      end,
-
-      eatcure = {'ginger', 'antimony'},
-
-      onstart = function() svo.eat(svo.dict.cholerichumour.herb) end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.cholerichumour)
-        svo.updateaffcount(svo.dict.cholerichumour)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('cholerichumour')
-        svo.dict.cholerichumour.count = 0
-      end,
-      
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.cholerichumour)
-      end,
-
-      general_cured = function()
-        svo.rmaff('cholerichumour')
-        svo.dict.cholerichumour.count = 0
-      end,
-    }
-  },
-  melancholichumour = {
-    count = 0,
-    gamename = 'temperedmelancholic',
-    name = 'melancholichumour',
-    herb = {
-      isadvisable = function()
-        return (affs.melancholichumour) or false
-      end,
-
-      -- this is called when you still have some left
-      oncompleted = function()
-        svo.lostbal_herb()
-        svo.updateaffcount(svo.dict.melancholichumour)
-      end,
-
-      empty = function()
-        empty.eat_ginger()
-        svo.lostbal_herb()
-      end,
-
-      cured = function()
-        svo.lostbal_herb()
-        svo.rmaff('melancholichumour')
-        svo.dict.melancholichumour.count = 0
-      end,
-
-      noeffect = function() svo.lostbal_herb() end,
-
-      -- does mana damage based on humour count
-      inundated = function()
-        svo.rmaff('melancholichumour')
-        svo.dict.melancholichumour.count = 0
-      end,
-
-      eatcure = {'ginger', 'antimony'},
-
-      onstart = function() svo.eat(svo.dict.melancholichumour.herb) end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.melancholichumour)
-        svo.updateaffcount(svo.dict.melancholichumour)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('melancholichumour')
-        svo.dict.melancholichumour.count = 0
-      end,
-      
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.melancholichumour)
-      end,
-
-      general_cured = function()
-        svo.rmaff('melancholichumour')
-        svo.dict.melancholichumour.count = 0
-      end,
-    }
-  },
-  phlegmatichumour = {
-    gamename = 'temperedphlegmatic',
-    name = 'phlegmatichumour',
-    count = 0,
-    herb = {
-      isadvisable = function()
-        return (affs.phlegmatichumour) or false
-      end,
-
-      -- this is called when you still have some left
-      oncompleted = function()
-        svo.lostbal_herb()
-        svo.updateaffcount(svo.dict.phlegmatichumour)
-      end,
-
-      empty = function()
-        empty.eat_ginger()
-        svo.lostbal_herb()
-      end,
-
-      cured = function()
-        svo.lostbal_herb()
-        svo.rmaff('phlegmatichumour')
-        svo.dict.phlegmatichumour.count = 0
-      end,
-
-      noeffect = function() svo.lostbal_herb() end,
-      
-      inundated = function()
-        svo.rmaff('phlegmatichumour')
-        svo.dict.phlegmatichumour.count = 0
-      end,
-
-      eatcure = {'ginger', 'antimony'},
-
-      onstart = function() svo.eat(svo.dict.phlegmatichumour.herb) end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.phlegmatichumour)
-        svo.updateaffcount(svo.dict.phlegmatichumour)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('phlegmatichumour')
-        svo.dict.phlegmatichumour.count = 0
-      end,
-      
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.phlegmatichumour)
-      end,
-
-      general_cured = function()
-        svo.rmaff('phlegmatichumour')
-        svo.dict.phlegmatichumour.count = 0
-      end,
-    }
-  },
-  sanguinehumour = {
-    count = 0,
-    gamename = 'temperedsanguine',
-    name = 'sanguinehumour',
-    herb = {
-      isadvisable = function()
-        return (affs.sanguinehumour) or false
-      end,
-
-      -- this is called when you still have some left
-      oncompleted = function()
-        svo.lostbal_herb()
-        svo.updateaffcount(svo.dict.sanguinehumour)
-      end,
-
-      empty = function()
-        empty.eat_ginger()
-        svo.lostbal_herb()
-      end,
-
-      cured = function()
-        svo.lostbal_herb()
-        svo.rmaff('sanguinehumour')
-        svo.dict.sanguinehumour.count = 0
-      end,
-
-      noeffect = function() svo.lostbal_herb() end,
-
-      -- gives bleeding depending on your sanguine humour level, from 250 for first to 2500 for last
-      inundated = function()
-        local min = 250
-        -- local max = 2500
-        if not affs.sanguinehumour then return end
-
-        local bledfor = svo.dict.sanguinehumour.count * min
-
-        svo.addaffdict(svo.dict.bleeding)
-        svo.dict.bleeding.count = bledfor
-        svo.updateaffcount(svo.dict.bleeding)
-
-        svo.rmaff('sanguinehumour')
-        svo.dict.sanguinehumour.count = 0
-      end,
-
-      eatcure = {'ginger', 'antimony'},
-
-      onstart = function() svo.eat(svo.dict.sanguinehumour.herb) end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.sanguinehumour)
-        svo.updateaffcount(svo.dict.sanguinehumour)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('sanguinehumour')
-        svo.dict.sanguinehumour.count = 0
-      end,
-      
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.sanguinehumour)
-      end,
-
-      general_cured = function()
-        svo.rmaff('sanguinehumour')
-        svo.dict.sanguinehumour.count = 0
-      end,
-    }
-  },
+  svo.dict = {
+    -- (string) what serverside calls this by - names can be different as they were revealed years after Svof was made
+    gamename = nil,
+    onservereignore = nil, -- (function) a function which'll return true if this needs to be ignored serverside
+    healhealth = {
+      description = "heals health with health/vitality or moss/potash",
+      sip = {
+        name = false, --'healhealth_sip',
+        balance = false, --'sip',
+        action_name = false, --'healhealth'
   
-horror = {
-    count = 0,
-    gamename = 'horror',
-    name = 'horror',
-    herb = {
-      isadvisable = function()
-        return (affs.horror and bals.herb) or false
-      end,
-
-      -- this is called when you still have some left 
-      oncompleted = function()
-        svo.lostbal_herb()
-        svo.updateaffcount(svo.dict.horror)
-      end,
-
-      empty = function()
-        empty.eat_goldenseal()
-        svo.lostbal_herb()
-      end,
-
-      cured = function()
-        svo.lostbal_herb()
-        svo.rmaff('horror')
-        svo.dict.horror.count = 0
-      end,
-
-      noeffect = function()
-			  svo.rmaff('horror')
-			  svo.lostbal_herb()
-		  end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-
-      onstart = function() svo.eat(svo.dict.horror.herb) end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.horror)
-        svo.updateaffcount(svo.dict.horror)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('horror')
-        svo.dict.horror.count = 0
-      end,
-      
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.horror)
-      end,
-
-      general_cured = function()
-        svo.rmaff('horror')
-        svo.dict.horror.count = 0
-      end,
-    }
-  },
+        -- managed outside priority lists
+        irregular = true,
   
-  waterbubble = {
-    gamename = 'airpocket',
-    onservereignore = function()
-      return svo.me.class == "water Elemental Lady" or svo.me.class == "water Elemental Lord"
-      end,
-    herb = {
-      def = true,
-
-      isadvisable = function()
-        return not defc.waterbubble and ((sys.deffing and defdefup[defs.mode].waterbubble) or (conf.keepup and defkeepup[defs.mode].waterbubble)) and not affs.anorexia and me.is_underwater and not (svo.me.class == "water Elemental Lady" or svo.me.class == "water Elemental Lord")
-      end,
-
-      eatcure = {'pear', 'calcite'},
-
-      onstart = function() svo.eat(svo.dict.waterbubble.herb) end,
-
-      oncompleted = function() defences.got('waterbubble') end,
-
-      empty = function() end
-    }
-  },
-  pacifism = {
-    gamename = 'pacified',
-    herb = {
-      isadvisable = function()
-        return (affs.pacifism and
-          not svo.doingaction('pacifism') and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity')or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('pacifism')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'bellwort', 'cuprum'},
-      onstart = function() svo.eat(svo.dict.pacifism.herb) end,
-
-      empty = function() empty.eat_bellwort() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.pacifism and
-          not svo.doingaction('pacifism') and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity')or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('pacifism')
-        svo.lostbal_focus()
-      end,
-
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.pacifism)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('pacifism')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  peace = {
-    herb = {
-      isadvisable = function()
-        return (affs.peace and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity') or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('peace')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'bellwort', 'cuprum'},
-      onstart = function() svo.eat(svo.dict.peace.herb) end,
-
-      empty = function() empty.eat_bellwort() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.peace)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('peace') end,
-    }
-  },
-  inlove = {
-    gamename = 'lovers',
-    herb = {
-      isadvisable = function()
-        return (affs.inlove and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity') or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('inlove')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'bellwort', 'cuprum'},
-      onstart = function() svo.eat(svo.dict.inlove.herb) end,
-
-      empty = function() empty.eat_bellwort() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.inlove)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('inlove') end,
-    }
-  },
-  dissonance = {
-    herb = {
-      isadvisable = function()
-        return (affs.dissonance and not svo.usingbal('focus')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('dissonance')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-      onstart = function() svo.eat(svo.dict.dissonance.herb) end,
-
-      empty = function() empty.eat_goldenseal() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.dissonance)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('dissonance') end,
-    }
-  },
-  dizziness = {
-    herb = {
-      isadvisable = function()
-        return (affs.dizziness and
-          not svo.doingaction('dizziness') and not svo.usingbal('focus')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('dizziness')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-      onstart = function() svo.eat(svo.dict.dizziness.herb) end,
-
-      empty = function() empty.eat_goldenseal() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.dizziness and
-          not svo.doingaction('dizziness')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('dizziness')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.dizziness)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('dizziness')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  shyness = {
-    herb = {
-      isadvisable = function()
-        return (affs.shyness and
-          not svo.doingaction('shyness') and not svo.usingbal('focus')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('shyness')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-      onstart = function() svo.eat(svo.dict.shyness.herb) end,
-
-      empty = function() empty.eat_goldenseal() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.shyness and
-          not svo.doingaction('shyness')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('shyness')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.shyness)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('shyness')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  epilepsy = {
-    herb = {
-      isadvisable = function()
-        return (affs.epilepsy and
-          not svo.doingaction('epilepsy') and not svo.usingbal('focus')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('epilepsy')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-      onstart = function() svo.eat(svo.dict.epilepsy.herb) end,
-
-      empty = function() empty.eat_goldenseal() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.epilepsy and
-          not svo.doingaction('epilepsy')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('epilepsy')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.epilepsy)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('epilepsy')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  impatience = {
-    herb = {
-      isadvisable = function()
-        -- curing impatience before hypochondria will make it get re-applied
-        return (affs.impatience and not affs.madness and not svo.usingbal('focus')  and not affs.hypochondria) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('impatience')
-        svo.lostbal_herb()
-
-        -- if serverside cures impatience before we can even validate it, cancel it
-        svo.affsp.impatience = nil
-        svo.killaction(svo.dict.checkimpatience.misc)
-      end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-      onstart = function() svo.eat(svo.dict.impatience.herb) end,
-
-      empty = function() empty.eat_goldenseal() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.impatience)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('impatience') end,
-    }
-  },
-  stupidity = {
-    herb = {
-      isadvisable = function()
-        return (affs.stupidity and
-          not svo.doingaction('stupidity') and not svo.usingbal('focus')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('stupidity')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-      onstart = function() svo.eat(svo.dict.stupidity.herb) end,
-
-      empty = function() empty.eat_goldenseal() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.stupidity and
-          not svo.doingaction('stupidity') and not affs.madness) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('stupidity')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.stupidity)
-        sk.stupidity_count = 0
-        codepaste.badaeon()
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('stupidity')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  crushedthroat = {
-    salve = {
-      isadvisable = function()
-        return affs.crushedthroat or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('crushedthroat')
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.apply_mending_head()
-      end,
-
-      empty = function()
-        empty.apply_mending_head()
-      end,
-
-      applycure = {'mending'},
-      actions = {"apply mending to head"},
-      onstart = function()
-        svo.apply(svo.dict.crushedthroat.salve, " to head")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.crushedthroat)
-        sk.crushedthroat_count = 0
-        codepaste.badaeon()
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('crushedthroat')
-      end,
-    }
-  },
-  guilt = {
-    herb = {
-      isadvisable = function()
-        return (affs.guilt and
-          not svo.doingaction('guilt')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('guilt')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'lobelia', 'argentum'},
-      onstart = function() svo.eat(svo.dict.guilt.herb) end,
-
-      empty = function() empty.eat_lobelia() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.guilt)
-        sk.guilt_count = 0
-        codepaste.badaeon()
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('guilt')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  tenderskin = {
-    herb = {
-      isadvisable = function()
-        return (affs.tenderskin and
-          not svo.doingaction('tenderskin')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('tenderskin')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'lobelia', 'argentum'},
-      onstart = function() svo.eat(svo.dict.tenderskin.herb) end,
-
-      empty = function() empty.eat_lobelia() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.tenderskin)
-        sk.tenderskin_count = 0
-        codepaste.badaeon()
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('tenderskin')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  spiritburn = {
-    herb = {
-      isadvisable = function()
-        return (affs.spiritburn and
-          not svo.doingaction('spiritburn')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('spiritburn')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'lobelia', 'argentum'},
-      onstart = function() svo.eat(svo.dict.spiritburn.herb) end,
-
-      empty = function() empty.eat_lobelia() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.spiritburn)
-        sk.spiritburn_count = 0
-        codepaste.badaeon()
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('spiritburn')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  masochism = {
-    herb = {
-      isadvisable = function()
-        return (affs.masochism and not affs.madness and
-          not svo.doingaction('masochism')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('masochism')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'lobelia', 'argentum'},
-      onstart = function() svo.eat(svo.dict.masochism.herb) end,
-
-      empty = function() empty.eat_lobelia() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.masochism and not affs.madness and
-          not svo.doingaction('masochism')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('masochism')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.masochism)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('masochism')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  recklessness = {
-    herb = {
-      isadvisable = function()
-        return (affs.recklessness and not affs.madness and
-          not svo.doingaction('recklessness')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('recklessness')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'lobelia', 'argentum'},
-      onstart = function() svo.eat(svo.dict.recklessness.herb) end,
-
-      empty = function() empty.eat_lobelia() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.recklessness and not affs.madness and
-          not svo.doingaction('recklessness')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('recklessness')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function (data)
-        if data and data.attacktype and data.attacktype == 'domination' and (data.atline+1 == getLastLineNumber('main')
-          or (data.atline+1 == getLastLineNumber('main') and
-            svo.find_until_last_paragraph("The gremlin races between your legs, throwing you off-balance.", 'exact'))) then
-          svo.addaffdict(svo.dict.recklessness)
-        elseif not conf.aillusion or
-          (stats.maxhealth == stats.currenthealth and stats.maxmana == stats.currentmana) then
-          svo.addaffdict(svo.dict.recklessness)
-        end
-      end,
-
-      -- used for addaff to skip all checks
-      forced = function()
-        svo.addaffdict(svo.dict.recklessness)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('recklessness')
-        codepaste.remove_focusable()
-      end,
-    },
-    onremoved = function()
-      svo.check_generics()
-      if not affs.blackout then
-        svo.killaction(svo.dict.nomana.waitingfor)
-      end
-      signals.before_prompt_processing:block(svo.valid.check_recklessness)
-    end,
-    onadded = function()
-      signals.before_prompt_processing:unblock(svo.valid.check_recklessness)
-    end,
-  },
-  justice = {
-    herb = {
-      isadvisable = function()
-        return (affs.justice and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity') or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('justice')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'bellwort', 'cuprum'},
-      onstart = function() svo.eat(svo.dict.justice.herb) end,
-
-      empty = function() empty.eat_bellwort() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.justice)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('justice') end,
-    }
-  },
-  generosity = {
-    herb = {
-      isadvisable = function()
-        return (affs.generosity and
-          not svo.doingaction('generosity') and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity')or svo.haveskillset('valour')) or not svo.dict.rage.misc.isadvisable())) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('generosity')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'bellwort', 'cuprum'},
-      onstart = function() svo.eat(svo.dict.generosity.herb) end,
-
-      empty = function() empty.eat_bellwort() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.generosity and
-          not svo.doingaction('generosity') and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity')or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('generosity')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.generosity)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('generosity')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  weakness = {
-    gamename = 'weariness',
-    herb = {
-      isadvisable = function()
-        return (affs.weakness and
-          not svo.doingaction('weakness')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('weakness')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'kelp', 'aurum'},
-      onstart = function() svo.eat(svo.dict.weakness.herb) end,
-
-      empty = function() empty.eat_kelp() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.weakness)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('weakness')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  vertigo = {
-    herb = {
-      isadvisable = function()
-        return (affs.vertigo and not affs.madness and
-          not svo.doingaction('vertigo')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('vertigo')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'lobelia', 'argentum'},
-      onstart = function() svo.eat(svo.dict.vertigo.herb) end,
-
-      empty = function() empty.eat_lobelia() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.vertigo and not affs.madness and
-          not svo.doingaction('vertigo')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('vertigo')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.vertigo)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('vertigo')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  loneliness = {
-    herb = {
-      isadvisable = function()
-        return (affs.loneliness and not affs.madness and not svo.doingaction('loneliness')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('loneliness')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'lobelia', 'argentum'},
-      onstart = function() svo.eat(svo.dict.loneliness.herb) end,
-
-      empty = function() empty.eat_lobelia() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.loneliness and not affs.madness and not svo.doingaction('loneliness')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('loneliness')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.loneliness)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('loneliness')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  dementia = {
-    herb = {
-      isadvisable = function()
-        return (affs.dementia and not affs.madness and not svo.doingaction('dementia')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('dementia')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ash', 'stannum'},
-      onstart = function() svo.eat(svo.dict.dementia.herb) end,
-
-      empty = function() empty.eat_ash() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.dementia and not affs.madness and not svo.doingaction('dementia')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('dementia')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.dementia)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('dementia') end,
-    }
-  },
-  paranoia = {
-    herb = {
-      isadvisable = function()
-        return (affs.paranoia and not affs.madness and not svo.doingaction('paranoia')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('paranoia')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ash', 'stannum'},
-      onstart = function() svo.eat(svo.dict.paranoia.herb) end,
-
-      empty = function() empty.eat_ash() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.paranoia and not affs.madness and not svo.doingaction('paranoia')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('paranoia')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.paranoia)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('paranoia') end,
-    }
-  },
-  hypersomnia = {
-    herb = {
-      isadvisable = function()
-        return (affs.hypersomnia and not affs.madness) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('hypersomnia')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ash', 'stannum'},
-      onstart = function() svo.eat(svo.dict.hypersomnia.herb) end,
-
-      empty = function() empty.eat_ash() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.hypersomnia)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('hypersomnia') end,
-    }
-  },
-  hallucinations = {
-    herb = {
-      isadvisable = function()
-        return (affs.hallucinations and not affs.madness and not svo.doingaction('hallucinations')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('hallucinations')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ash', 'stannum'},
-      onstart = function() svo.eat(svo.dict.hallucinations.herb) end,
-
-      empty = function() empty.eat_ash() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.hallucinations and not affs.madness and not svo.doingaction('hallucinations')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('hallucinations')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.hallucinations)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('hallucinations') end,
-    }
-  },
-  confusion = {
-    herb = {
-      isadvisable = function()
-        return (affs.confusion and
-          not svo.doingaction('confusion') and not affs.madness) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('confusion')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ash', 'stannum'},
-      onstart = function() svo.eat(svo.dict.confusion.herb) end,
-
-      empty = function() empty.eat_ash() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.confusion and
-          not svo.doingaction('confusion') and not affs.madness) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('confusion')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.confusion)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('confusion')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  agoraphobia = {
-    herb = {
-      isadvisable = function()
-        return (affs.agoraphobia and
-          not svo.doingaction('agoraphobia')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('agoraphobia')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'lobelia', 'argentum'},
-      onstart = function() svo.eat(svo.dict.agoraphobia.herb) end,
-
-      empty = function() empty.eat_lobelia() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.agoraphobia and
-          not svo.doingaction('agoraphobia')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('agoraphobia')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.agoraphobia)
-        codepaste.remove_focusable()
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('agoraphobia') end,
-    }
-  },
-  claustrophobia = {
-    herb = {
-      isadvisable = function()
-        return (affs.claustrophobia and
-          not svo.doingaction('claustrophobia')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('claustrophobia')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'lobelia', 'argentum'},
-      onstart = function() svo.eat(svo.dict.claustrophobia.herb) end,
-
-      empty = function() empty.eat_lobelia() end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.claustrophobia and
-          not svo.doingaction('claustrophobia')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('claustrophobia')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.claustrophobia)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('claustrophobia')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
-  paralysis = {
-    herb = {
-      isadvisable = function()
-        return (affs.paralysis) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('paralysis')
-        svo.lostbal_herb()
-        svo.killaction(svo.dict.checkparalysis.misc)
-      end,
-
-      eatcure = {'bloodroot', 'magnesium'},
-      onstart = function() svo.eat(svo.dict.paralysis.herb) end,
-
-      empty = function() empty.eat_bloodroot() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.paralysis)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('paralysis') end,
-    },
-    onremoved = function() svo.affsp.paralysis = nil svo.donext() end
-  },
-  asthma = {
-    herb = {
-      isadvisable = function()
-        return (affs.asthma) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('asthma')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'kelp', 'aurum'},
-      onstart = function() svo.eat(svo.dict.asthma.herb) end,
-
-      empty = function() empty.eat_kelp() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.asthma)
-        local r = svo.findbybal('smoke')
-        if r then
-          svo.killaction(svo.dict[r.action_name].smoke)
-        end
-
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        codepaste.badaeon()
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('asthma') end,
-    }
-  },
-  clumsiness = {
-    herb = {
-      isadvisable = function()
-        return (affs.clumsiness) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('clumsiness')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'kelp', 'aurum'},
-      onstart = function() svo.eat(svo.dict.clumsiness.herb) end,
-
-      empty = function() empty.eat_kelp() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.clumsiness)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('clumsiness') end,
-    }
-  },
-  sensitivity = {
-    herb = {
-      isadvisable = function()
-        return (affs.sensitivity) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('sensitivity')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'kelp', 'aurum'},
-      onstart = function() svo.eat(svo.dict.sensitivity.herb) end,
-
-      empty = function() empty.eat_kelp() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.sensitivity)
-      end,
-
-      -- used by AI to check if we're deaf when we got sensi
-      checkdeaf = function()
-        -- if deafness was stripped, then prompt flags would have removed it at this point and defc.deaf wouldn't be set
-        -- also check back to see if deafness went instead, like from bloodleech:
-        -- A bloodleech leaps at you, clamping with teeth onto exposed flesh and secreting some foul toxin into your bloodstream. You stumble as you are afflicted with sensitivity.$Your hearing is suddenly restored.
-        -- or dragoncurse: A sudden sense of panic overtakes you as the draconic curse manifests, afflicting you with sensitivity.$Your hearing is suddenly restored.
-        -- however, don't go off on dstab: Bob pricks you twice in rapid succession with her dirk.$Your hearing is suddenly restored.$A prickly, stinging sensation spreads through your body.
-        if svo.find_until_last_paragraph("Your hearing is suddenly restored.", 'exact') and not svo.find_until_last_paragraph("A prickly, stinging sensation spreads through your body.", 'exact') then return end
-
-        if not conf.aillusion or (not defc.deaf and not affs.deafaff) then
-          svo.addaffdict(svo.dict.sensitivity)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('sensitivity') end,
-    }
-  },
-  healthleech = {
-    herb = {
-      isadvisable = function()
-        return (affs.healthleech) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('healthleech')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'kelp', 'aurum'},
-      onstart = function() svo.eat(svo.dict.healthleech.herb) end,
-
-      empty = function() empty.eat_kelp() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.healthleech)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('healthleech') end,
-    }
-  },
-  relapsing = {
-    -- if it's an aff that can be checked, remove it's action and add an appropriate checkaff. Then if the checkaff succeeds, add the relapsing too.
-    saw_with_checkable = false,
-    gamename = 'scytherus',
-    herb = {
-      isadvisable = function()
-        return (affs.relapsing) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('relapsing')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ginseng', 'ferrum'},
-      onstart = function() svo.eat(svo.dict.relapsing.herb) end,
-
-      empty = function() empty.eat_ginseng() end
-    },
-    --[[
-      relapsing:  ai off, accept everything
-                  ai on, accept everything only if we do have relapsing, or it's a checkable symptom -&gt; undeaf/unblind, blind/deaf, camus, else -&gt; ignore
-
-      implementation: generic affs get called to aff.oncompleted, otherwise specialities deal with aff.&lt;func&gt;
-    ]]
-    aff = {
-      -- this goes off when there is no AI or we got a generic affliction that doesn't mean much
-      oncompleted = function()
-        -- don't mess with anything special if we have it confirmed
-        if affs.relapsing then return end
-
-        if not conf.aillusion or svo.lifevision.l.diag_physical then
-          svo.addaffdict(svo.dict.relapsing)
-          svo.dict.relapsing.saw_with_checkable = nil
-        else
-          if svo.actions.checkparalysis_aff then
-            svo.dict.relapsing.saw_with_checkable = 'paralysis'
-          elseif not svo.pl.tablex.find_if(svo.actions:keys(), function (key) return string.find(key, 'check', 1, true) end) then
-            -- don't process the rest of the affs it gives if it's not checkable and we don't have relapsing already
-            sk.stopprocessing = true
-          end
-        end
-        svo.dict.relapsing.aff.hitvitality = nil
-      end,
-
-      forced = function()
-        svo.addaffdict(svo.dict.relapsing)
-      end,
-
-      camus = function (oldhp)
-        if not conf.aillusion or
-          ((not affs.recklessness and stats.currenthealth &lt; oldhp) -- health went down without recklessness
-           or (svo.dict.relapsing.aff.hitvitality and ((100/stats.maxhealth)* stats.currenthealth) &lt;= 60)) then -- or we're above due to vitality
-          svo.addaffdict(svo.dict.relapsing)
-          svo.dict.relapsing.aff.hitvitality = nil
-          svo.dict.relapsing.saw_with_checkable = nil
-        end
-      end,
-
-      sumac = function (oldhp)
-        if not conf.aillusion or
-          ((not affs.recklessness and stats.currenthealth &lt; oldhp) -- health went down without recklessness
-           or (svo.dict.relapsing.aff.hitvitality and ((100/stats.maxhealth)* stats.currenthealth) &lt;= 60)) then -- or we're above due to vitality
-          svo.addaffdict(svo.dict.relapsing)
-          svo.dict.relapsing.aff.hitvitality = nil
-          svo.dict.relapsing.saw_with_checkable = nil
-        end
-      end,
-
-      oleander = function (hadblind)
-        if not conf.aillusion or (not hadblind and (defc.blind or affs.blindaff)) then
-          svo.addaffdict(svo.dict.relapsing)
-          svo.dict.relapsing.saw_with_checkable = nil
-        end
-      end,
-
-      colocasia = function (hadblindordeaf)
-        if not conf.aillusion or (not hadblindordeaf and (defc.blind or affs.blindaff or defc.deaf or affs.deafaff)) then
-          svo.addaffdict(svo.dict.relapsing)
-          svo.dict.relapsing.saw_with_checkable = nil
-        end
-      end,
-
-      oculus = function (hadblind)
-        if not conf.aillusion or (hadblind and not (defc.blind or affs.blindaff)) then
-          svo.addaffdict(svo.dict.relapsing)
-          svo.dict.relapsing.saw_with_checkable = nil
-        end
-      end,
-
-      prefarar = function (haddeaf)
-        if not conf.aillusion or (haddeaf and not (defc.deaf or affs.deafaff)) then
-          svo.addaffdict(svo.dict.relapsing)
-          svo.dict.relapsing.saw_with_checkable = nil
-        end
-      end,
-
-      asthma = function()
-        if not conf.aillusion or svo.lifevision.l.diag_physical then
-          svo.addaffdict(svo.dict.relapsing)
-          svo.dict.relapsing.saw_with_checkable = nil
-        else
-          if svo.actions.checkasthma_aff then
-            svo.dict.relapsing.saw_with_checkable = 'asthma'
-          elseif not svo.pl.tablex.find_if(svo.actions:keys(), function (key) return string.find(key, 'check', 1, true) end) then
-            -- don't process the rest of the affs it gives.
-            sk.stopprocessing = true
-          end
-        end
-        svo.dict.relapsing.aff.hitvitality = nil
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('relapsing')
-        svo.dict.relapsing.saw_with_checkable = nil
-      end,
-    }
-  },
-  darkshade = {
-    herb = {
-      isadvisable = function()
-        return (affs.darkshade) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('darkshade')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ginseng', 'ferrum'},
-      onstart = function() svo.eat(svo.dict.darkshade.herb) end,
-
-      empty = function() empty.eat_ginseng() end
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        if not conf.aillusion or (not oldhp or stats.currenthealth &lt; oldhp) then
-          svo.addaffdict(svo.dict.darkshade)
-        end
-      end,
-
-      forced = function()
-        svo.addaffdict(svo.dict.darkshade)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('darkshade') end,
-    }
-  },
-  lethargy = {
-    herb = {
-      isadvisable = function()
-        -- curing lethargy before hypochondria or torntendons will make it get re-applied
-        return (affs.lethargy and not affs.madness and not affs.hypochondria) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('lethargy')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ginseng', 'ferrum'},
-      onstart = function() svo.eat(svo.dict.lethargy.herb) end,
-
-      empty = function() empty.eat_ginseng() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.lethargy)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('lethargy') end,
-    }
-  },
-  illness = {
-    gamename = 'nausea',
-    herb = {
-      isadvisable = function()
-        -- curing illness before hypochondria will make it get re-applied
-        return (affs.illness and not affs.madness and not affs.hypochondria) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('illness')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ginseng', 'ferrum'},
-      onstart = function() svo.eat(svo.dict.illness.herb) end,
-
-      empty = function() empty.eat_ginseng() end
-    },
-    aff = {
-      oncompleted = function()
-        if not svo.find_until_last_paragraph("Your enhanced constitution allows you to shrug off the nausea.", 'exact') then
-          svo.addaffdict(svo.dict.illness)
-        end
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('illness') end,
-    }
-  },
-  addiction = {
-    herb = {
-      isadvisable = function()
-        -- curing addiction before hypochondria or skullfractures will make it get re-applied
-        return (affs.addiction and not affs.madness and not affs.hypochondria) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('addiction')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ginseng', 'ferrum'},
-      onstart = function() svo.eat(svo.dict.addiction.herb) end,
-
-      empty = function() empty.eat_ginseng() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.addiction)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('addiction') end,
-    },
-    onremoved = function()
-      rift.checkprecache()
-    end
-  },
-  haemophilia = {
-    herb = {
-      isadvisable = function()
-        return (affs.haemophilia) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('haemophilia')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ginseng', 'ferrum'},
-      onstart = function() svo.eat(svo.dict.haemophilia.herb) end,
-
-      empty = function() empty.eat_ginseng() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.haemophilia)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('haemophilia') end,
-    }
-  },
-  hypochondria = {
-    herb = {
-      isadvisable = function()
-        return (affs.hypochondria) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('hypochondria')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'kelp', 'aurum'},
-      onstart = function() svo.eat(svo.dict.hypochondria.herb) end,
-
-      empty = function() empty.eat_kelp() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.hypochondria)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('hypochondria') end,
-    }
-  },
-
--- smoke cures
-  aeon = {
-    smoke = {
-      isadvisable = function()
-        return (affs.aeon and codepaste.smoke_elm_pipe()) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('aeon')
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-      end,
-
-      smokecure = {'elm', 'cinnabar'},
-      onstart = function()
-        send("smoke " .. pipes.elm.id, conf.commandecho)
-      end,
-
-      empty = function()
-        empty.smoke_elm()
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.aeon)
-        svo.affsp.aeon = nil
-        defences.lost('speed')
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        sk.checkaeony()
-        signals.changecuring:emit()
-        codepaste.badaeon()
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('aeon') end,
-    },
-    onremoved = function()
-      svo.affsp.aeon = nil
-      sk.retardation_count = 0
-      sk.checkaeony()
-      signals.changecuring:emit()
-    end
-  },
-  hellsight = {
-    smoke = {
-      isadvisable = function()
-        return (affs.hellsight and not affs.inquisition and codepaste.smoke_valerian_pipe()) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('hellsight')
-        svo.lostbal_smoke()
-        sk.valerian_smokepuff()
-      end,
-
-      smokecure = {'valerian', 'realgar'},
-      onstart = function()
-        send("smoke " .. pipes.valerian.id, conf.commandecho)
-      end,
-
-      empty = function()
-        empty.smoke_valerian()
-        svo.lostbal_smoke()
-        sk.valerian_smokepuff()
-      end,
-
-      inquisition = function()
-        svo.addaffdict(svo.dict.inquisition)
-        sk.valerian_smokepuff()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.hellsight)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('hellsight') end,
-    }
-  },
-  deadening = {
-    smoke = {
-      isadvisable = function()
-        return (affs.deadening and codepaste.smoke_elm_pipe()) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('deadening')
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-      end,
-
-      smokecure = {'elm', 'cinnabar'},
-      onstart = function()
-        send("smoke " .. pipes.elm.id, conf.commandecho)
-      end,
-
-      empty = function()
-        empty.smoke_elm()
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.deadening)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('deadening') end,
-    }
-  },
-  madness = {
-    gamename = 'whisperingmadness',
-    smoke = {
-      isadvisable = function()
-        return (affs.madness and codepaste.smoke_elm_pipe() and not affs.hecate) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('madness')
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-      end,
-
-      smokecure = {'elm', 'cinnabar'},
-      onstart = function()
-        send("smoke " .. pipes.elm.id, conf.commandecho)
-      end,
-
-      empty = function()
-        empty.smoke_elm()
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-      end,
-
-      hecate = function()
-        sk.elm_smokepuff()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.madness)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('madness') end,
-    }
-  },
-  tension = {
-    smoke = {
-      isadvisable = function()
-        return (affs.tension and codepaste.smoke_elm_pipe()) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('tension')
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-      end,
-
-      smokecure = {'elm', 'cinnabar'},
-      onstart = function()
-        send("smoke " .. pipes.elm.id, conf.commandecho)
-      end,
-
-      empty = function()
-        empty.smoke_elm()
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.tension)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('tension') end,
-    }
-  },
-  -- valerian cures
-  slickness = {
-    smoke = {
-      isadvisable = function()
-        return (affs.slickness and codepaste.smoke_valerian_pipe() and not svo.doingaction'slickness') or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('slickness')
-        svo.lostbal_smoke()
-        sk.valerian_smokepuff()
-      end,
-
-      smokecure = {'valerian', 'realgar'},
-      onstart = function()
-        send("smoke " .. pipes.valerian.id, conf.commandecho)
-      end,
-
-      empty = function()
-        empty.smoke_valerian()
-        svo.lostbal_smoke()
-        sk.valerian_smokepuff()
-      end
-    },
-    herb = {
-      isadvisable = function()
-        return (affs.slickness and not affs.anorexia and not svo.doingaction'slickness' and not affs.stain) or false -- anorexia is redundant, but just in for now
-      end,
-
-      oncompleted = function()
-        svo.rmaff('slickness')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'bloodroot', 'magnesium'},
-      onstart = function() svo.eat(svo.dict.slickness.herb) end,
-
-      empty = function() empty.eat_bloodroot() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.slickness)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('slickness') end,
-    }
-  },
-  disloyalty = {
-    smoke = {
-      isadvisable = function()
-        return (affs.disloyalty and codepaste.smoke_valerian_pipe()) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('disloyalty')
-        svo.lostbal_smoke()
-        sk.valerian_smokepuff()
-      end,
-
-      smokecure = {'valerian', 'realgar'},
-      onstart = function()
-        send("smoke " .. pipes.valerian.id, conf.commandecho)
-      end,
-
-      empty = function()
-        empty.smoke_valerian()
-        svo.lostbal_smoke()
-        sk.valerian_smokepuff()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.disloyalty)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('disloyalty') end,
-    }
-  },
-  manaleech = {
-    smoke = {
-      isadvisable = function()
-        return (affs.manaleech and codepaste.smoke_valerian_pipe()) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('manaleech')
-        svo.lostbal_smoke()
-        sk.valerian_smokepuff()
-      end,
-
-      smokecure = {'valerian', 'realgar'},
-      onstart = function()
-        send("smoke " .. pipes.valerian.id, conf.commandecho)
-      end,
-
-      empty = function()
-        empty.smoke_valerian()
-        svo.lostbal_smoke()
-        sk.valerian_smokepuff()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.manaleech)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('manaleech') end,
-    }
-  },
-
-
-  -- restoration cures
-  heartseed = {
-    salve = {
-      isadvisable = function()
-        return (affs.heartseed and not affs.mildtrauma) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingheartseed.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to torso", "apply restoration", "apply reconstructive to torso", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.heartseed.salve, " to torso")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.heartseed.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.heartseed)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('heartseed') end,
-    }
-  },
-  curingheartseed = {
-    waitingfor = {
-      customwait = 6, -- 4 to cure
-
-      oncompleted = function() svo.rmaff('heartseed') end,
-
-      ontimeout = function() svo.rmaff('heartseed') end,
-
-      noeffect = function() svo.rmaff('heartseed') end,
-
-      onstart = function()
-        -- add blocking of the cure coming too early if it'll become necessary.
-      end,
-    }
-  },
-  calcifiedskull = {
-    salve = {
-      isadvisable = function()
-        return (affs.calcifiedskull and not affs.mildconcussion) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingcalcifiedskull.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to head", "apply restoration", "apply reconstructive to head", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.calcifiedskull.salve, " to head")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.calcifiedskull.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.calcifiedskull)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('calcifiedskull') end,
-    }
-  },
-  curingcalcifiedskull = {
-    waitingfor = {
-      customwait = 6, -- 4 to cure
-
-      oncompleted = function() svo.rmaff('calcifiedskull') end,
-
-      ontimeout = function() svo.rmaff('calcifiedskull') end,
-
-      noeffect = function() svo.rmaff('calcifiedskull') end,
-
-      onstart = function()
-        -- add blocking of the cure coming too early if it'll become necessary.
-      end,
-    }
-  },
-  calcifiedtorso = {
-    salve = {
-      isadvisable = function()
-        return (affs.calcifiedtorso and not affs.mildtrauma) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingcalcifiedtorso.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to torso", "apply restoration", "apply reconstructive to torso", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.calcifiedtorso.salve, " to torso")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.calcifiedtorso.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.calcifiedtorso)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('calcifiedtorso') end,
-    }
-  },
-  curingcalcifiedtorso = {
-    waitingfor = {
-      customwait = 6, -- 4 to cure
-
-      oncompleted = function() svo.rmaff('calcifiedtorso') end,
-
-      ontimeout = function() svo.rmaff('calcifiedtorso') end,
-
-      noeffect = function() svo.rmaff('calcifiedtorso') end,
-
-      onstart = function()
-        -- add blocking of the cure coming too early if it'll become necessary.
-      end,
-    }
-  },
-  hypothermia = {
-    salve = {
-      isadvisable = function()
-        return (affs.hypothermia and not affs.mildtrauma) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curinghypothermia.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to torso", "apply restoration", "apply reconstructive to torso", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.hypothermia.salve, " to torso")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.hypothermia.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.hypothermia)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('hypothermia') end,
-    }
-  },
-  curinghypothermia = {
-    waitingfor = {
-      customwait = 6, -- 4 to cure
-
-      oncompleted = function() svo.rmaff('hypothermia') end,
-
-      ontimeout = function() svo.rmaff('hypothermia') end,
-
-      noeffect = function() svo.rmaff('hypothermia') end,
-
-      onstart = function()
-        -- add blocking of the cure coming too early if it'll become necessary.
-      end,
-    }
-  },
-  tonguetied = {
-    salve = {
-      isadvisable = function()
-        return (affs.tonguetied) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingtonguetied.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to head", "apply restoration", "apply reconstructive to head", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.tonguetied.salve, " to head")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.tonguetied.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.tonguetied)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('tonguetied') end,
-    }
-  },
-  curingtonguetied = {
-    waitingfor = {
-      customwait = 6, -- 4 to cure
-
-      oncompleted = function() svo.rmaff('tonguetied') end,
-
-      ontimeout = function() svo.rmaff('tonguetied') end,
-
-      noeffect = function() svo.rmaff('tonguetied') end,
-
-      onstart = function()
-        -- add blocking of the cure coming too early if it'll become necessary.
-      end,
-    }
-  },
-
-  mutilatedrightleg = {
-    gamename = 'mangledrightleg',
-    salve = {
-      isadvisable = function()
-        return (affs.mutilatedrightleg) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingmutilatedrightleg.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to legs", "apply restoration", "apply reconstructive to legs", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.mutilatedrightleg.salve, " to legs")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.mutilatedrightleg.salve.oncompleted()
-      end,
-
-      -- in blackout, this goes through quietly
-      ontimeout = function()
-        if affs.blackout then
-          svo.dict.mutilatedrightleg.salve.oncompleted()
-        end
-      end,
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        codepaste.addrestobreakleg('mutilatedrightleg', oldhp)
-      end,
-
-      tekura = function (oldhp)
-        codepaste.addrestobreakleg('mutilatedrightleg', oldhp, true)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mutilatedrightleg') end,
-    }
-  },
-  curingmutilatedrightleg = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('mutilatedrightleg')
-        svo.addaffdict(svo.dict.mangledrightleg)
-
-        local result = svo.checkany(svo.dict.curingmutilatedleftleg.waitingfor, svo.dict.curingmangledrightleg.waitingfor, svo.dict.curingmangledleftleg.waitingfor, svo.dict.curingparestolegs.waitingfor)
-
-        if result then
-          svo.killaction(svo.dict[result.action_name].waitingfor)
-        end
-      end,
-
-      ontimeout = function()
-        if affs.mutilatedrightleg then
-          svo.rmaff('mutilatedrightleg')
-          svo.addaffdict(svo.dict.mangledrightleg)
-        end
-      end,
-
-      onstart = function() end,
-
-      oncuredleft = function()
-        svo.rmaff('mutilatedrightleg')
-        svo.addaffdict(svo.dict.mangledrightleg)
-      end,
-
-      noeffect = function() svo.rmaff('mutilatedrightleg') end
-    }
-  },
-  parestolegs = {
-    salve = {
-      uncurable = true,
-
-      customwaitf = function()
-        return not affs.blackout and 0 or 4 -- can't see applies in blackout
-      end,
-
-      isadvisable = function()
-        return (affs.parestolegs) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingparestolegs.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to legs", "apply restoration", "apply reconstructive to legs", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.parestolegs.salve, " to legs")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.parestolegs.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.parestolegs)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('parestolegs') end,
-    }
-  },
-  curingparestolegs = {
-    waitingfor = {
-      customwait = 4,
-
-      oncompleted = function()
-        svo.rmaff('parestolegs')
-
-        local result = svo.checkany(svo.dict.curingmutilatedrightleg.waitingfor, svo.dict.curingmutilatedleftleg.waitingfor, svo.dict.curingmangledrightleg.waitingfor, svo.dict.curingmangledleftleg.waitingfor)
-
-        if result then
-          svo.killaction(svo.dict[result.action_name].waitingfor)
-        end
-      end,
-
-      onstart = function() end,
-
-      ontimeout = function() svo.rmaff('parestolegs') end,
-
-      noeffect = function() svo.rmaff('parestolegs') end
-    }
-  },
-  mangledrightleg = {
-    gamename = 'damagedrightleg',
-    salve = {
-      isadvisable = function()
-        return (affs.mangledrightleg and not (affs.mutilatedrightleg or affs.mutilatedleftleg)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingmangledrightleg.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to legs", "apply restoration", "apply reconstructive to legs", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.mangledrightleg.salve, " to legs")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.mangledrightleg.salve.oncompleted()
-      end,
-
-      -- in blackout, this goes through quietly
-      ontimeout = function()
-        if affs.blackout then
-          svo.dict.mangledrightleg.salve.oncompleted()
-        end
-      end,
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        codepaste.addrestobreakleg('mangledrightleg', oldhp)
-      end,
-
-      tekura = function (oldhp)
-        codepaste.addrestobreakleg('mangledrightleg', oldhp, true)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mangledrightleg') end,
-    }
-  },
-  curingmangledrightleg = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('parestolegs')
-        svo.rmaff('mangledrightleg')
-        svo.addaffdict(svo.dict.crippledrightleg)
-
-        local result = svo.checkany(svo.dict.curingmutilatedrightleg.waitingfor, svo.dict.curingmutilatedleftleg.waitingfor, svo.dict.curingmangledleftleg.waitingfor, svo.dict.curingparestolegs.waitingfor)
-
-        if result then
-          svo.killaction(svo.dict[result.action_name].waitingfor)
-        end
-      end,
-
-      ontimeout = function()
-        if affs.mangledrightleg then
-          svo.rmaff('mangledrightleg')
-          svo.addaffdict(svo.dict.crippledrightleg)
-        end
-      end,
-
-      onstart = function() end,
-
-      oncuredleft = function()
-        svo.rmaff('mangledrightleg')
-        svo.addaffdict(svo.dict.crippledrightleg)
-      end,
-
-      noeffect = function() svo.rmaff('mangledrightleg') end
-    }
-  },
-  crippledrightleg = {
-    gamename = 'brokenrightleg',
-    salve = {
-      isadvisable = function()
-        return (affs.crippledrightleg and not (affs.mutilatedrightleg or affs.mangledrightleg or affs.parestolegs)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('crippledrightleg')
-
-        if affs.unknowncrippledlimb then
-          svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count - 1
-          if svo.dict.unknowncrippledlimb.count &lt;= 0 then svo.rmaff'unknowncrippledlimb' else svo.updateaffcount(svo.dict.unknowncrippledlimb) end
-        end
-
-        if not affs.unknowncrippledleg then return end
-        svo.dict.unknowncrippledleg.count = svo.dict.unknowncrippledleg.count - 1
-        if svo.dict.unknowncrippledleg.count &lt;= 0 then svo.rmaff'unknowncrippledleg' else svo.updateaffcount(svo.dict.unknowncrippledleg) end
-      end,
-
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending to legs", "apply mending", "apply renewal to legs", "apply renewal"},
-      onstart = function()
-        svo.apply(svo.dict.crippledrightleg.salve, " to legs")
-      end,
-
-      fizzled = function()
-        svo.lostbal_salve()
-        svo.addaffdict(svo.dict.mangledrightleg)
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.noeffect_mending_legs()
-      end,
-
-      -- sometimes restoration can lag out and hit when this goes - ignore
-      empty = function() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.crippledrightleg)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('crippledrightleg') end,
-    }
-  },
-  mutilatedleftleg = {
-    gamename = 'mangledleftleg',
-    salve = {
-      isadvisable = function()
-        return (affs.mutilatedleftleg) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingmutilatedleftleg.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to legs", "apply restoration", "apply reconstructive to legs", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.mutilatedleftleg.salve, " to legs")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.mutilatedleftleg.salve.oncompleted()
-      end,
-
-      -- in blackout, this goes through quietly
-      ontimeout = function()
-        if affs.blackout then
-          svo.dict.mutilatedleftleg.salve.oncompleted()
-        end
-      end,
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        codepaste.addrestobreakleg('mutilatedleftleg', oldhp)
-      end,
-
-      tekura = function (oldhp)
-        codepaste.addrestobreakleg('mutilatedleftleg', oldhp, true)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mutilatedleftleg') end,
-    }
-  },
-  curingmutilatedleftleg = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('mutilatedleftleg')
-        svo.addaffdict(svo.dict.mangledleftleg)
-
-        local result = svo.checkany(svo.dict.curingmutilatedrightleg.waitingfor, svo.dict.curingmangledrightleg.waitingfor, svo.dict.curingmangledleftleg.waitingfor, svo.dict.curingparestolegs.waitingfor)
-
-        if result then
-          svo.killaction(svo.dict[result.action_name].waitingfor)
-        end
-      end,
-
-      ontimeout = function()
-        if affs.mutilatedleftleg then
-          svo.rmaff('mutilatedleftleg')
-          svo.addaffdict(svo.dict.mangledleftleg)
-        end
-      end,
-
-      onstart = function() end,
-
-      oncuredleft = function()
-        svo.rmaff('mutilatedleftleg')
-        svo.addaffdict(svo.dict.mangledleftleg)
-      end,
-
-      noeffect = function() svo.rmaff('mutilatedleftleg') end
-    }
-  },
-  mangledleftleg = {
-    gamename = 'damagedleftleg',
-    salve = {
-      isadvisable = function()
-        return (affs.mangledleftleg and not (affs.mutilatedrightleg or affs.mutilatedleftleg)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingmangledleftleg.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to legs", "apply restoration", "apply reconstructive to legs", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.mangledleftleg.salve, " to legs")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.mangledleftleg.salve.oncompleted()
-      end,
-
-      -- in blackout, this goes through quietly
-      ontimeout = function()
-        if affs.blackout then
-          svo.dict.mangledleftleg.salve.oncompleted()
-        end
-      end,
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        codepaste.addrestobreakleg('mangledleftleg', oldhp)
-      end,
-
-      tekura = function (oldhp)
-        codepaste.addrestobreakleg('mangledleftleg', oldhp, true)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mangledleftleg') end,
-    }
-  },
-  curingmangledleftleg = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('parestolegs')
-        svo.rmaff('mangledleftleg')
-        svo.addaffdict(svo.dict.crippledleftleg)
-
-        local result = svo.checkany(svo.dict.curingmutilatedrightleg.waitingfor, svo.dict.curingmutilatedleftleg.waitingfor, svo.dict.curingmangledrightleg.waitingfor, svo.dict.curingparestolegs.waitingfor)
-
-        if result then
-          svo.killaction(svo.dict[result.action_name].waitingfor)
-        end
-      end,
-
-      ontimeout = function()
-        if affs.mangledleftleg then
-          svo.rmaff('mangledleftleg')
-          svo.addaffdict(svo.dict.crippledleftleg)
-        end
-      end,
-
-      onstart = function() end,
-
-      oncuredleft = function()
-        svo.rmaff('mangledleftleg')
-        svo.addaffdict(svo.dict.crippledleftleg)
-      end,
-
-      noeffect = function() svo.rmaff('mangledleftleg') end
-    }
-  },
-  crippledleftleg = {
-    gamename = 'brokenleftleg',
-    salve = {
-      isadvisable = function()
-        return (affs.crippledleftleg and not (affs.mutilatedleftleg or affs.mangledleftleg or affs.parestolegs)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('crippledleftleg')
-
-        if affs.unknowncrippledlimb then
-          svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count - 1
-          if svo.dict.unknowncrippledlimb.count &lt;= 0 then svo.rmaff'unknowncrippledlimb' else svo.updateaffcount(svo.dict.unknowncrippledlimb) end
-        end
-
-        if not affs.unknowncrippledleg then return end
-        svo.dict.unknowncrippledleg.count = svo.dict.unknowncrippledleg.count - 1
-        if svo.dict.unknowncrippledleg.count &lt;= 0 then svo.rmaff'unknowncrippledleg' else svo.updateaffcount(svo.dict.unknowncrippledleg) end
-      end,
-
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending to legs", "apply mending", "apply renewal to legs", "apply renewal"},
-      onstart = function()
-        svo.apply(svo.dict.crippledleftleg.salve, " to legs")
-      end,
-
-      fizzled = function()
-        svo.lostbal_salve()
-        svo.addaffdict(svo.dict.mangledleftleg)
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.noeffect_mending_legs()
-      end,
-
-      -- sometimes restoration can lag out and hit when this goes - ignore
-      empty = function() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.crippledleftleg)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('crippledleftleg') end,
-    }
-  },
-  parestoarms = {
-    salve = {
-      uncurable = true,
-
-      customwaitf = function()
-        return not affs.blackout and 0 or 4 -- can't see applies in blackout
-      end,
-
-      isadvisable = function()
-        return (affs.parestoarms) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingparestoarms.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to arms", "apply restoration", "apply reconstructive to arms", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.parestoarms.salve, " to arms")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.parestoarms.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.parestoarms)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('parestoarms') end,
-    }
-  },
-  curingparestoarms = {
-    waitingfor = {
-      customwait = 4,
-
-      oncompleted = function()
-        svo.rmaff('parestoarms')
-
-        local result = svo.checkany(svo.dict.curingmutilatedrightarm.waitingfor, svo.dict.curingmutilatedleftarm.waitingfor, svo.dict.curingmangledrightarm.waitingfor, svo.dict.curingmangledleftarm.waitingfor)
-
-        if result then
-          svo.killaction(svo.dict[result.action_name].waitingfor)
-        end
-      end,
-
-      onstart = function() end,
-
-      ontimeout = function() svo.rmaff('parestoarms') end,
-
-      noeffect = function() svo.rmaff('parestoarms') end
-    }
-  },
-  mutilatedleftarm = {
-    gamename = 'mangledleftarm',
-    salve = {
-      isadvisable = function()
-        return (affs.mutilatedleftarm) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingmutilatedleftarm.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to arms", "apply restoration", "apply reconstructive to arms", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.mutilatedleftarm.salve, " to arms")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.mutilatedleftarm.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        codepaste.addrestobreakarm('mutilatedleftarm', oldhp)
-      end,
-
-      tekura = function (oldhp)
-        codepaste.addrestobreakarm('mutilatedleftarm', oldhp, true)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mutilatedleftarm') end,
-    },
-    onremoved = function() signals.canoutr:emit() end
-  },
-  curingmutilatedleftarm = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('mutilatedleftarm')
-        svo.addaffdict(svo.dict.mangledleftarm)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-
-        local result = svo.checkany(svo.dict.curingmutilatedrightarm.waitingfor, svo.dict.curingmangledrightarm.waitingfor, svo.dict.curingmangledleftarm.waitingfor, svo.dict.curingparestoarms.waitingfor)
-
-        if result then
-          svo.killaction(svo.dict[result.action_name].waitingfor)
-        end
-      end,
-
-      ontimeout = function()
-        if affs.mutilatedleftarm then
-          svo.rmaff('mutilatedleftarm')
-          svo.addaffdict(svo.dict.mangledleftarm)
-        end
-      end,
-
-      onstart = function() end,
-
-      oncuredleft = function()
-        svo.rmaff('mutilatedleftarm')
-        svo.addaffdict(svo.dict.mangledleftarm)
-      end,
-
-      noeffect = function() svo.rmaff('mutilatedleftarm') end
-    }
-  },
-  mangledleftarm = {
-    gamename = 'damagedleftarm',
-    salve = {
-      isadvisable = function()
-        return (affs.mangledleftarm and not (affs.mutilatedrightarm or affs.mutilatedleftarm)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingmangledleftarm.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to arms", "apply restoration", "apply reconstructive to arms", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.mangledleftarm.salve, " to arms")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.mangledleftarm.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        codepaste.addrestobreakarm('mangledleftarm', oldhp)
-      end,
-
-      tekura = function (oldhp)
-        codepaste.addrestobreakarm('mangledleftarm', oldhp, true)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mangledleftarm') end,
-    },
-    onremoved = function() signals.canoutr:emit() end
-  },
-  curingmangledleftarm = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('parestoarms')
-        svo.rmaff('mangledleftarm')
-        svo.addaffdict(svo.dict.crippledleftarm)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-
-        local result = svo.checkany(svo.dict.curingmutilatedrightarm.waitingfor, svo.dict.curingmutilatedleftarm.waitingfor, svo.dict.curingmangledrightarm.waitingfor, svo.dict.curingparestoarms.waitingfor)
-
-        if result then
-          svo.killaction(svo.dict[result.action_name].waitingfor)
-        end
-      end,
-
-      ontimeout = function()
-        if affs.mangledleftarm then
-          svo.rmaff('mangledleftarm')
-          svo.addaffdict(svo.dict.crippledleftarm)
-          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        end
-      end,
-
-      onstart = function() end,
-
-      oncuredleft = function()
-        svo.rmaff('mangledleftarm')
-        svo.addaffdict(svo.dict.crippledleftarm)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end,
-
-      noeffect = function() svo.rmaff('mangledleftarm') end
-    }
-  },
-  crippledleftarm = {
-    gamename = 'brokenleftarm',
-    salve = {
-      isadvisable = function()
-        return (affs.crippledleftarm and not (affs.mutilatedleftarm or affs.mangledleftarm or affs.parestoarms)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('crippledleftarm')
-
-        if affs.unknowncrippledlimb then
-          svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count - 1
-          if svo.dict.unknowncrippledlimb.count &lt;= 0 then svo.rmaff'unknowncrippledlimb' else svo.updateaffcount(svo.dict.unknowncrippledlimb) end
-        end
-
-        if not affs.unknowncrippledarm then return end
-        svo.dict.unknowncrippledarm.count = svo.dict.unknowncrippledarm.count - 1
-        if svo.dict.unknowncrippledarm.count &lt;= 0 then svo.rmaff'unknowncrippledarm' else svo.updateaffcount(svo.dict.unknowncrippledarm) end
-      end,
-
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending to arms", "apply mending", "apply renewal to arms", "apply renewal"},
-      onstart = function()
-        svo.apply(svo.dict.crippledleftarm.salve, " to arms")
-      end,
-
-      fizzled = function()
-        svo.lostbal_salve()
-        svo.addaffdict(svo.dict.mangledleftarm)
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.noeffect_mending_arms()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.crippledleftarm)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        signals.canoutr:emit()
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('crippledleftarm') end,
-    },
-    onremoved = function() signals.canoutr:emit() end
-  },
-  mutilatedrightarm = {
-    gamename = 'mangledrightarm',
-    salve = {
-      isadvisable = function()
-        return (affs.mutilatedrightarm) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingmutilatedrightarm.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to arms", "apply restoration", "apply reconstructive to arms", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.mutilatedrightarm.salve, " to arms")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.mutilatedrightarm.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        codepaste.addrestobreakarm('mutilatedrightarm', oldhp)
-      end,
-
-      tekura = function (oldhp)
-        codepaste.addrestobreakarm('mutilatedrightarm', oldhp, true)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mutilatedrightarm') end,
-    },
-    onremoved = function() signals.canoutr:emit() end
-  },
-  curingmutilatedrightarm = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('mutilatedrightarm')
-        svo.addaffdict(svo.dict.mangledrightarm)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-
-        local result = svo.checkany(svo.dict.curingmutilatedleftarm.waitingfor, svo.dict.curingmangledrightarm.waitingfor, svo.dict.curingmangledleftarm.waitingfor, svo.dict.curingparestoarms.waitingfor)
-
-        if result then
-          svo.killaction(svo.dict[result.action_name].waitingfor)
-        end
-      end,
-
-      ontimeout = function()
-        if affs.mutilatedrightarm then
-          svo.rmaff('mutilatedrightarm')
-          svo.addaffdict(svo.dict.mangledrightarm)
-        end
-      end,
-
-      onstart = function() end,
-
-      oncuredleft = function()
-        svo.rmaff('mutilatedleftarm')
-        svo.addaffdict(svo.dict.mangledleftarm)
-      end,
-
-      noeffect = function() svo.rmaff('mutilatedrightarm') end
-    }
-  },
-  mangledrightarm = {
-    gamename = 'damagedrightarm',
-    salve = {
-      isadvisable = function()
-        return (affs.mangledrightarm and not (affs.mutilatedrightarm or affs.mutilatedleftarm)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingmangledrightarm.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to arms", "apply restoration", "apply reconstructive to arms", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.mangledrightarm.salve, " to arms")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.mangledrightarm.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        codepaste.addrestobreakarm('mangledrightarm', oldhp)
-      end,
-
-      tekura = function (oldhp)
-        codepaste.addrestobreakarm('mangledrightarm', oldhp, true)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mangledrightarm') end,
-    },
-    onremoved = function() signals.canoutr:emit() end
-  },
-  curingmangledrightarm = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('mangledrightarm')
-        svo.rmaff('parestoarms')
-        svo.addaffdict(svo.dict.crippledrightarm)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-
-        local result = svo.checkany(svo.dict.curingmutilatedrightarm.waitingfor, svo.dict.curingmutilatedleftarm.waitingfor, svo.dict.curingmangledleftarm.waitingfor, svo.dict.curingparestoarms.waitingfor)
-
-        if result then
-          svo.killaction(svo.dict[result.action_name].waitingfor)
-        end
-      end,
-
-      ontimeout = function()
-        if affs.mangledrightarm then
-          svo.rmaff('mangledrightarm')
-          svo.addaffdict(svo.dict.crippledrightarm)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        end
-      end,
-
-      onstart = function() end,
-
-      oncuredleft = function()
-        svo.rmaff('mangledleftarm')
-        svo.addaffdict(svo.dict.crippledleftarm)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end,
-
-      noeffect = function() svo.rmaff('mangledrightarm') end
-    }
-  },
-  crippledrightarm = {
-    gamename = 'brokenrightarm',
-    salve = {
-      isadvisable = function()
-        return (affs.crippledrightarm and not (affs.mutilatedrightarm or affs.mangledrightarm or affs.parestoarms)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('crippledrightarm')
-
-        if affs.unknowncrippledlimb then
-          svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count - 1
-          if svo.dict.unknowncrippledlimb.count &lt;= 0 then svo.rmaff'unknowncrippledlimb' else svo.updateaffcount(svo.dict.unknowncrippledlimb) end
-        end
-
-        if not affs.unknowncrippledarm then return end
-        svo.dict.unknowncrippledarm.count = svo.dict.unknowncrippledarm.count - 1
-        if svo.dict.unknowncrippledarm.count &lt;= 0 then svo.rmaff'unknowncrippledarm' else svo.updateaffcount(svo.dict.unknowncrippledarm) end
-      end,
-
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending to arms", "apply mending", "apply renewal to arms", "apply renewal"},
-      onstart = function()
-        svo.apply(svo.dict.crippledrightarm.salve, " to arms")
-      end,
-
-      fizzled = function()
-        svo.lostbal_salve()
-        svo.addaffdict(svo.dict.mangledrightarm)
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.noeffect_mending_arms()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.crippledrightarm)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        signals.canoutr:emit()
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('crippledrightarm') end,
-    },
-    onremoved = function() signals.canoutr:emit() end
-  },
-  laceratedthroat = {
-    salve = {
-      isadvisable = function()
-        return (affs.laceratedthroat) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curinglaceratedthroat.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to head", "apply restoration", "apply reconstructive to head", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.laceratedthroat.salve, " to head")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.laceratedthroat.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.laceratedthroat)
-      end,
-
-      -- separated, so we can use it normally if necessary - another class might get it
-      sylvanhit = function (oldhp)
-        if not conf.aillusion or (not affs.recklessness and stats.currenthealth &lt; oldhp) then
-          svo.addaffdict(svo.dict.laceratedthroat)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('laceratedthroat') end,
-    }
-  },
-  curinglaceratedthroat = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('laceratedthroat')
-        svo.addaffdict(svo.dict.slashedthroat)
-      end,
-
-      onstart = function() end,
-
-      noeffect = function()
-        svo.rmaff('laceratedthroat')
-        svo.addaffdict(svo.dict.slashedthroat)
-      end
-    }
-  },
-  slashedthroat = {
-    salve = {
-      isadvisable = function()
-        return (affs.slashedthroat) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('slashedthroat')
-      end,
-
-      noeffect = function()
-        empty.apply_epidermal_head()
-      end,
-
-      empty = function()
-        empty.apply_epidermal_head()
-      end,
-
-      applycure = {'epidermal', 'sensory'},
-      actions = {"apply epidermal to head", "apply epidermal", "apply sensory to head", "apply sensory"},
-      onstart = function()
-        svo.apply(svo.dict.slashedthroat.salve, " to head")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.slashedthroat)
-      end,
-
-      -- separated, so we can use it normally if necessary - another class might get it
-      sylvanhit = function (oldhp)
-        if not conf.aillusion or (not affs.recklessness and stats.currenthealth &lt; oldhp) then
-          svo.addaffdict(svo.dict.slashedthroat)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('slashedthroat') end,
-    }
-  },
-  serioustrauma = {
-    salve = {
-      isadvisable = function()
-        return (affs.serioustrauma) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingserioustrauma.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to torso", "apply restoration", "apply reconstructive to torso", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.serioustrauma.salve, " to torso")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.serioustrauma.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        if not conf.aillusion or not oldhp or oldhp &gt; stats.currenthealth or svo.paragraph_length &gt;= 3 then
-          if affs.mildtrauma then svo.rmaff('mildtrauma') end
-          svo.addaffdict(svo.dict.serioustrauma)
-        end
-      end,
-
-      forced = function()
-        if affs.mildtrauma then svo.rmaff('mildtrauma') end
-        svo.addaffdict(svo.dict.serioustrauma)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('serioustrauma') end,
-    }
-  },
-  curingserioustrauma = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('serioustrauma')
-        svo.addaffdict(svo.dict.mildtrauma)
-      end,
-
-      ontimeout = function()
-        if affs.serioustrauma then
-          svo.rmaff('serioustrauma')
-          svo.addaffdict(svo.dict.mildtrauma)
-        end
-      end,
-
-      onstart = function() end,
-
-      noeffect = function()
-        svo.rmaff('serioustrauma')
-        svo.rmaff('mildtrauma')
-      end
-    }
-  },
-  mildtrauma = {
-    salve = {
-      isadvisable = function()
-        return (affs.mildtrauma) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingmildtrauma.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to torso", "apply restoration", "apply reconstructive to torso", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.mildtrauma.salve, " to torso")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.mildtrauma.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        if not conf.aillusion or not oldhp or oldhp &gt; stats.currenthealth or svo.paragraph_length &gt;= 3 then
-          svo.addaffdict(svo.dict.mildtrauma)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mildtrauma') end,
-    }
-  },
-  curingmildtrauma = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function() svo.rmaff('mildtrauma') end,
-
-      ontimeout = function() svo.rmaff('mildtrauma') end,
-
-      onstart = function() end,
-
-      noeffect = function() svo.rmaff('mildtrauma') end
-    }
-  },
-  seriousconcussion = {
-    gamename = 'mangledhead',
-    salve = {
-      isadvisable = function()
-        return (affs.seriousconcussion) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingseriousconcussion.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to head", "apply restoration", "apply reconstructive to head", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.seriousconcussion.salve, " to head")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.seriousconcussion.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        if not conf.aillusion or not oldhp or oldhp &gt; stats.currenthealth or svo.paragraph_length &gt;= 3 then
-          if affs.mildconcussion then svo.rmaff('mildconcussion') end
-          svo.addaffdict(svo.dict.seriousconcussion)
-          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        end
-      end,
-
-      forced = function()
-        if affs.mildconcussion then svo.rmaff('mildconcussion') end
-        svo.addaffdict(svo.dict.seriousconcussion)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('seriousconcussion') end,
-    },
-    onadded = function()
-      if affs.prone and affs.seriousconcussion then
-        sk.warn 'pulpable'
-      end
-    end
-  },
-  curingseriousconcussion = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function()
-        svo.rmaff('seriousconcussion')
-        svo.addaffdict(svo.dict.mildconcussion)
-      end,
-
-      ontimeout = function()
-        if affs.seriousconcussion then
-          svo.rmaff('seriousconcussion')
-          svo.addaffdict(svo.dict.mildconcussion)
-        end
-      end,
-
-      onstart = function() end,
-
-      noeffect = function()
-        svo.rmaff('seriousconcussion')
-        svo.rmaff('mildconcussion')
-      end
-    }
-  },
-  mildconcussion = {
-    gamename = 'damagedhead',
-    salve = {
-      isadvisable = function()
-        return (affs.mildconcussion) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-
-        svo.doaction(svo.dict.curingmildconcussion.waitingfor)
-      end,
-
-      applycure = {'restoration', 'reconstructive'},
-      actions = {"apply restoration to head", "apply restoration", "apply reconstructive to head", "apply reconstructive"},
-      onstart = function()
-        svo.apply(svo.dict.mildconcussion.salve, " to head")
-      end,
-
-      -- we get no msg from an application of this
-      empty = function()
-        svo.dict.mildconcussion.salve.oncompleted()
-      end
-    },
-    aff = {
-      oncompleted = function (oldhp)
-        if not conf.aillusion or not oldhp or oldhp &gt; stats.currenthealth or svo.paragraph_length &gt;= 3 then
-          svo.addaffdict(svo.dict.mildconcussion)
-          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        end
-      end,
-
-      forced = function()
-        svo.addaffdict(svo.dict.mildconcussion)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mildconcussion') end,
-    }
-  },
-  curingmildconcussion = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function() svo.rmaff('mildconcussion') end,
-
-      ontimeout = function() svo.rmaff('mildconcussion') end,
-
-      onstart = function() end,
-
-      noeffect = function() svo.rmaff('mildconcussion') end
-    }
-  },
-
-
--- salve cures
-  anorexia = {
-    salve = {
-      isadvisable = function()
-        return (affs.anorexia and not svo.doingaction'anorexia') or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('anorexia')
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.apply_epidermal_body()
-      end,
-
-      empty = function()
-        empty.apply_epidermal_body()
-      end,
-
-      applycure = {'epidermal', 'sensory'},
-      actions = {"apply epidermal to body", "apply epidermal", "apply sensory to body", "apply sensory"},
-      onstart = function()
-        svo.apply(svo.dict.anorexia.salve, " to body")
-      end
-    },
-    focus = {
-      isadvisable = function()
-        return (affs.anorexia and
-          not svo.doingaction('anorexia')) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('anorexia')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.anorexia)
-        codepaste.badaeon()
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('anorexia')
-        codepaste.remove_focusable()
-      end,
-    }
-  },
+        isadvisable = function()
+          -- should healhealth be prioritised above health affs, don't apply if above healthaffsabove% and have an aff
+          local function shouldntsip()
+            local crackedribs    = svo.prio.getnumber('crackedribs', 'sip')
+            local healhealth     = svo.prio.getnumber('healhealth', 'sip')
+            local skullfractures = svo.prio.getnumber('skullfractures', 'sip')
+            local torntendons    = svo.prio.getnumber('torntendons', 'sip')
+            local wristfractures = svo.prio.getnumber('wristfractures', 'sip')
   
-  ablaze = {           
-    gamename = 'burning',
-    onservereignore = function()
-      return ((svo.defdefup[svo.defs.mode].torch or svo.defkeepup[svo.defs.mode].torch) and 
-      (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady"))
-    end,
-    salve = {
-      isadvisable = function()
-        return (affs.ablaze and not (defdefup[defs.mode].torch or (conf.keepup and defkeepup[defs.mode].torch) and 
-        (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady"))) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('ablaze')
-        if defc.torch and (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady") then
-          defences.lost('torch')
-        end
-      end,
-
-      all = function()
-        svo.lostbal_salve()
-        codepaste.remove_burns()
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      empty = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      applycure = {'mending'},
-      actions = {"apply mending to body", "apply mending"},
-      onstart = function()
-        svo.apply(svo.dict.ablaze.salve, " to body")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        if ((defdefup[defs.mode].torch) or (conf.keepup and defkeepup[defs.mode].torch)) and 
-        (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady") then
-          defences.got('torch')
-        else
-          codepaste.remove_burns('ablaze')
-          svo.addaffdict(svo.dict.ablaze)
-        end
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        local currentburn = sk.current_burn()
-        svo.rmaff(currentburn)
-        if defc.torch and (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady") then
-          defences.lost('torch')
-        end
-      end,
-
-      -- used in blackout and passive curing where multiple levels could be cured at once
-      generic_reducelevel = function(amount)
-        -- if no amount is specified, find the current level and take it down a notch
-        if not amount then
-          local reduceto, currentburn = sk.previous_burn(), sk.current_burn()
-
-          svo.rmaff(currentburn)
-          svo.addaffdict(svo.dict[reduceto])
-        else -- amount is specified
-          local reduceto, currentburn = sk.previous_burn(amount), sk.current_burn()
-          svo.rmaff(currentburn)
-
-          if not reduceto then reduceto = 'ablaze' end
-          svo.addaffdict(svo.dict[reduceto])
-        end
-      end
-    }
-  },
-  severeburn = {
-    salve = {
-      irregular = true,
-
-      isadvisable = function()
-        return (affs.severeburn) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('severeburn')
-        svo.addaffdict(svo.dict.ablaze)
-      end,
-
-      all = function()
-        svo.lostbal_salve()
-        codepaste.remove_burns()
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      empty = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal"},
-      onstart = function()
-        svo.apply(svo.dict.severeburn.salve, " to body")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        codepaste.remove_burns('severeburn')
-        svo.addaffdict(svo.dict.severeburn)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('severeburn') end,
-    }
-  },
-  extremeburn = {
-    salve = {
-      irregular = true,
-
-      isadvisable = function()
-        return (affs.extremeburn) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('extremeburn')
-        svo.addaffdict(svo.dict.severeburn)
-      end,
-
-      all = function()
-        svo.lostbal_salve()
-        codepaste.remove_burns()
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      empty = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal"},
-      onstart = function()
-        svo.apply(svo.dict.extremeburn.salve, " to body")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        codepaste.remove_burns('extremeburn')
-        svo.addaffdict(svo.dict.extremeburn)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('extremeburn') end,
-    }
-  },
-  charredburn = {
-    salve = {
-      irregular = true,
-
-      isadvisable = function()
-        return (affs.charredburn) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('charredburn')
-        svo.addaffdict(svo.dict.extremeburn)
-      end,
-
-      all = function()
-        svo.lostbal_salve()
-        codepaste.remove_burns()
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      empty = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal"},
-      onstart = function()
-        svo.apply(svo.dict.charredburn.salve, " to body")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        codepaste.remove_burns('charredburn')
-        svo.addaffdict(svo.dict.charredburn)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('charredburn') end,
-    }
-  },
-  meltingburn = {
-    salve = {
-      irregular = true,
-
-      isadvisable = function()
-        return (affs.meltingburn) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('meltingburn')
-        svo.addaffdict(svo.dict.charredburn)
-      end,
-
-      all = function()
-        svo.lostbal_salve()
-        codepaste.remove_burns()
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      empty = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal"},
-      onstart = function()
-        svo.apply(svo.dict.meltingburn.salve, " to body")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        codepaste.remove_burns('meltingburn')
-        svo.addaffdict(svo.dict.meltingburn)
-
-        sk.warn 'golemdestroyable'
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('meltingburn') end,
-    }
-  },
-  selarnia = {
-    salve = {
-      isadvisable = function()
-        return (affs.selarnia) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('selarnia')
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      empty = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal", "apply mending to torso", "apply renewal to torso"},
-      onstart = function()
-        svo.apply(svo.dict.selarnia.salve, " to body")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.selarnia)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('selarnia') end,
-    }
-  },
-  itching = {
-    salve = {
-      isadvisable = function()
-        return (affs.itching) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('itching')
-      end,
-
-      noeffect = function()
-        empty.apply_epidermal_body()
-      end,
-
-      empty = function()
-        empty.apply_epidermal_body()
-      end,
-
-      applycure = {'epidermal', 'sensory'},
-      actions = {"apply epidermal to body", "apply epidermal", "apply sensory to body", "apply sensory"},
-      onstart = function()
-        svo.apply(svo.dict.itching.salve, " to body")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.itching)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('itching') end,
-    }
-  },
-  stuttering = {
-    salve = {
-      isadvisable = function()
-        return (affs.stuttering and not affs.tonguetied) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('stuttering')
-      end,
-
-      noeffect = function()
-        empty.apply_epidermal_head()
-      end,
-
-      empty = function()
-        empty.apply_epidermal_head()
-      end,
-
-      applycure = {'epidermal', 'sensory'},
-      actions = {"apply epidermal to head", "apply epidermal", "apply sensory to head", "apply sensory"},
-      onstart = function()
-        svo.apply(svo.dict.stuttering.salve, " to head")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.stuttering)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('stuttering') end,
-    }
-  },
-  scalded = {
-    salve = {
-      isadvisable = function()
-        return (affs.scalded and not defc.blind and not affs.blindaff) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('scalded')
-      end,
-
-      noeffect = function()
-        empty.apply_epidermal_head()
-      end,
-
-      empty = function()
-        empty.apply_epidermal_head()
-      end,
-
-      applycure = {'epidermal', 'sensory'},
-      actions = {"apply epidermal to head", "apply epidermal", "apply sensory to head", "apply sensory"},
-      onstart = function()
-        svo.apply(svo.dict.scalded.salve, " to head")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.scalded)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('scalded') end,
-    }
-  },
-  numbedleftarm = {
-    waitingfor = {
-      customwait = 15, -- lasts 15s
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      ontimeout = function()
-        svo.rmaff('numbedleftarm')
-        svo.make_gnomes_work()
-      end,
-
-      oncompleted = function()
-        svo.rmaff('numbedleftarm')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.numbedleftarm)
-        if not svo.actions.numbedleftarm_waitingfor then svo.doaction(svo.dict.numbedleftarm.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('numbedleftarm')
-        svo.killaction(svo.dict.numbedleftarm.waitingfor)
-      end,
-    }
-  },
-  numbedrightarm = {
-    waitingfor = {
-      customwait = 8, -- lasts 8s
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      ontimeout = function()
-        svo.rmaff('numbedrightarm')
-        svo.make_gnomes_work()
-      end,
-
-      oncompleted = function()
-        svo.rmaff('numbedrightarm')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.numbedrightarm)
-        if not svo.actions.numbedrightarm_waitingfor then svo.doaction(svo.dict.numbedrightarm.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('numbedrightarm')
-        svo.killaction(svo.dict.numbedrightarm.waitingfor)
-      end,
-    }
-  },
-revealed = {
-    waitingfor = {
-      customwait = 80, -- lasts 80s
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      ontimeout = function()
-        svo.rmaff('revealed')
-        svo.make_gnomes_work()
-      end,
-
-      oncompleted = function()
-        svo.rmaff('revealed')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.revealed)
-        if not svo.actions.revealed_waitingfor then svo.doaction(svo.dict.revealed.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('revealed')
-        svo.killaction(svo.dict.revealed.waitingfor)
-      end,
-    }
-  },
-  blindaff = {
-    gamename = 'blind',
-    onservereignore = function()
-      return (svo.defdefup[svo.defs.mode].blind or svo.defkeepup[svo.defs.mode].blind)
-    end,
-    salve = {
-      isadvisable = function()
-        return (affs.blindaff and not ((sys.deffing and defdefup[defs.mode].blind) or
-          (conf.keepup and defkeepup[defs.mode].blind)) or affs.scalded) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('blindaff')
-        defences.lost('blind')
-
-        local restoreaff, restoredef
-        if affs.deafaff then restoreaff = true end
-        if defc.deaf then restoredef = true end
-
-        empty.apply_epidermal_head()
-
-        if restoreaff then svo.addaffdict(svo.dict.deafaff) end
-        if restoredef then defences.got('deaf') end
-      end,
-
-      noeffect = function()
-        empty.apply_epidermal_head()
-      end,
-
-      empty = function()
-        empty.apply_epidermal_head()
-      end,
-
-      applycure = {'epidermal'},
-      actions = {"apply epidermal to head", "apply epidermal"},
-      onstart = function()
-        svo.apply(svo.dict.blindaff.salve, " to head")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        if (defdefup[defs.mode].blind) or (conf.keepup and defkeepup[defs.mode].blind) or
-          (svo.me.class == 'Apostate' or defc.mindseye) then
-          defences.got('blind')
-        else
-          svo.addaffdict(svo.dict.blindaff)
-        end
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('blindaff')
-        defences.lost('blind')
-      end,
-    }
-  },
-  deafaff = {
-    gamename = 'deaf',
-    onservereignore = function()
-      return (svo.defdefup[svo.defs.mode].deaf or svo.defkeepup[svo.defs.mode].deaf)
-    end,
-    salve = {
-      isadvisable = function()
-        return (affs.deafaff and not ((sys.deffing and defdefup[defs.mode].deaf) or
-          (conf.keepup and defkeepup[defs.mode].deaf))) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('deafaff')
-        defences.lost('deaf')
-      end,
-
-      noeffect = function()
-        empty.apply_epidermal_head()
-      end,
-
-      empty = function()
-        empty.apply_epidermal_head()
-      end,
-
-      applycure = {'epidermal', 'sensory'},
-      actions = {"apply epidermal to head", "apply epidermal", "apply sensory to head", "apply sensory"},
-      onstart = function()
-        svo.apply(svo.dict.deafaff.salve, " to head")
-      end
-    },
-    aff = {
-      oncompleted = function()
-        if (defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf) or defc.mindseye then
-          defences.got('deaf')
-        else
-          svo.addaffdict(svo.dict.deafaff)
-        end
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('deafaff')
-        defences.lost('deaf')
-      end,
-    }
-  },
-
-  shivering = {
-    salve = {
-      isadvisable = function()
-        return (affs.shivering and not affs.frozen and not affs.hypothermia) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('shivering')
-      end,
-
-      noeffect = function() svo.lostbal_salve() end,
-
-      gotcaloricdef = function (hypothermia)
-        if not hypothermia then svo.rmaff({'frozen', 'shivering'}) end
-        svo.dict.caloric.salve.oncompleted ()
-      end,
-
-      applycure = {'caloric', 'exothermic'},
-      actions = {"apply caloric to body", "apply caloric", "apply exothermic to body", "apply exothermic"},
-      onstart = function()
-        svo.apply(svo.dict.shivering.salve, " to body")
-      end,
-
-      empty = function()
-        svo.lostbal_salve()
-        svo.rmaff('shivering')
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.shivering)
-        defences.lost('caloric')
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('shivering') end,
-    }
-  },
-  frozen = {
-    salve = {
-      isadvisable = function()
-        return (affs.frozen and not affs.hypothermia) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('frozen')
-        svo.addaffdict(svo.dict.shivering)
-      end,
-
-      noeffect = function() svo.lostbal_salve() end,
-
-      gotcaloricdef = function (hypothermia)
-        if not hypothermia then svo.rmaff({'frozen', 'shivering'}) end
-        svo.dict.caloric.salve.oncompleted ()
-      end,
-
-      applycure = {'caloric', 'exothermic'},
-      actions = {"apply caloric to body", "apply caloric", "apply exothermic to body", "apply exothermic"},
-      onstart = function()
-        svo.apply(svo.dict.frozen.salve, " to body")
-      end,
-
-      empty = function()
-        svo.lostbal_salve()
-        svo.rmaff('frozen')
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.frozen)
-        defences.lost('caloric')
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('frozen') end
-    }
-  },
-
--- purgatives
-  voyria = {
-    purgative = {
-      isadvisable = function()
-        return not affs.latency and ((affs.voyria) or false)
-      end,
-
-      oncompleted = function()
-        svo.lostbal_purgative()
-        svo.rmaff('voyria')
-      end,
-
-      sipcure = {'immunity', 'antigen'},
-      onstart = function()
-        svo.sip(svo.dict.voyria.purgative)
-      end,
-
-      noeffect = function()
-        svo.rmaff('voyria')
-        svo.lostbal_purgative()
-      end,
-
-      empty = function()
-        svo.lostbal_purgative()
-        empty.sip_immunity()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.voyria)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('voyria') end
-    }
-  },
-
-
--- misc
-  lovers = {
-    map = {},
-    tempmap = {},
-    physical = {
-      balanceful_act = true,
-      dontbatch = true,
-
-      isadvisable = function()
-        return (affs.lovers and not svo.doingaction('lovers')) or false
-      end,
-
-      oncompleted = function (whom)
-        svo.dict.lovers.map[whom] = nil
-        if not next(svo.dict.lovers.map) then
-          svo.rmaff('lovers')
-        end
-      end,
-
-      onclear = function()
-        svo.dict.lovers.tempmap = {}
-      end,
-
-      nobody = function()
-        if svo.dict.lovers.rejecting then
-          svo.dict.lovers.map[svo.dict.lovers.rejecting] = nil
-          svo.dict.lovers.rejecting = nil
-        end
-
-        if not next(svo.dict.lovers.map) then
-          svo.rmaff('lovers')
-        end
-      end,
-
-      onstart = function()
-        svo.dict.lovers.rejecting = next(svo.dict.lovers.map)
-        if not svo.dict.lovers.rejecting then -- if we added it via some manual way w/o a name, this failsafe will catch &amp; remove it
-          svo.rmaff('lovers')
-          return
-        end
-
-        send("reject " .. svo.dict.lovers.rejecting, conf.commandecho)
-      end
-    },
-    aff = {
-      oncompleted = function (whom)
-        if not svo.dict.lovers.tempmap and not whom then return end
-
-        svo.addaffdict(svo.dict.lovers)
-        for _, name in ipairs(svo.dict.lovers.tempmap) do
-          svo.dict.lovers.map[name] = true
-        end
-        svo.dict.lovers.tempmap = {}
-
-        if whom then
-          svo.dict.lovers[whom] = true
-        end
-
-        svo.affl.lovers = {names = svo.dict.lovers.map}
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('lovers')
-        svo.dict.lovers.map = {}
-      end,
-    }
-  },
-  fear = {
-    misc = {
-      isadvisable = function()
-        return (affs.fear and not affs.horror and not svo.doingaction('fear')) or false
-      end,
-
-      oncompleted = function() svo.rmaff('fear') end,
-
-      action = 'compose',
-      onstart = function() send('compose', conf.commandecho) end
-    },
-    focus = {
-      isadvisable = function()
-        return false
-        --[[return (affs.fear and
-          not svo.doingaction('fear')) or false]]
-      end,
-
-      oncompleted = function()
-        svo.rmaff('fear')
-        svo.lostbal_focus()
-      end,
-
-      action = 'focus',
-      onstart = function() send('focus', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        empty.focus()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.fear)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('fear')
-        codepaste.remove_focusable()
-      end
-    }
-  },
-  sleep = {
-    misc = {
-      isadvisable = function()
-        return (affs.sleep and
-          not svo.doingaction('curingsleep') and not svo.doingaction('sleep')) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.curingsleep.waitingfor)
-      end,
-
-      actions = {'wake', "wake up"},
-      onstart = function() send('wake up', conf.commandecho) end,
-
-      -- ???
-      empty = function() end
-    },
-    aff = {
-      oncompleted = function()
-        if not affs.sleep then svo.addaffdict(svo.dict.sleep) defences.lost('insomnia') end
-      end,
-
-      symptom = function()
-        if not affs.sleep then svo.addaffdict(svo.dict.sleep) defences.lost('insomnia') end
-        svo.addaffdict(svo.dict.prone)
-
-        -- reset non-wait things we were doing, because they got cancelled by the stun
-        if affs.sleep or svo.actions.sleep_aff then
-          for _,v in svo.actions:iter() do
-            if v.p.balance ~= 'waitingfor' and v.p.balance ~= 'aff' and v.p.name ~= 'sleep_misc' then
-              svo.killaction(svo.dict[v.p.action_name][v.p.balance])
-            end
-          end
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('sleep') end,
-    }
-  },
-  curingsleep = {
-    waitingfor = {
-      customwait = 999,
-
-      oncompleted = function()
-        svo.rmaff('sleep')
-
-        -- reset sleep so we try waking up again after being awoken and slept at once (like in a dsl or a delph snipe)
-        if svo.actions.sleep_misc then
-          svo.killaction(svo.dict.sleep.misc)
-        end
-      end,
-
-      onstart = function() end
-    }
-  },
-  bleeding = {
-    count = 0,
-    -- affs.bleeding.spammingbleed is used to throttle bleed spamming so it doesn't get out of control
-    misc = {
-      -- managed outside priorities
-      uncurable = true,
-
-      isadvisable = function()
-        if affs.bleeding and not svo.doingaction('bleeding') and not affs.bleeding.spammingbleed and not affs.haemophilia and not affs.sleep and svo.can_usemana() and conf.clot then
-          if (not affs.corrupted and svo.dict.bleeding.count &gt;= conf.bleedamount) then
-            return true
-          elseif (affs.corrupted and svo.dict.bleeding.count &gt;= conf.manableedamount) then
-            if stats.currenthealth &gt;= sys.corruptedhealthmin then
+            if stats.hp &gt;= conf.healthaffsabove and ((healhealth &gt; crackedribs and affs.crackedribs) or
+              (healhealth &gt; skullfractures and affs.skullfractures) or (healhealth &gt; torntendons and affs.torntendons) or
+               (healhealth &gt; wristfractures and affs.wristfractures)) then
               return true
-            else
-              sk.warn 'cantclotmana'
-              return false
             end
+  
+            return false
           end
-        else return false end
-      end,
-
-      -- by default, oncompleted means a clot went through okay
-      oncompleted = function()
-        svo.dict.bleeding.saw_haemophilia = nil
-      end,
-
-      -- oncured in this case means that we actually cured it; don't have any more bleeding
-      oncured = function()
-        if affs.bleeding and affs.bleeding.spammingbleed then killTimer(affs.bleeding.spammingbleed); affs.bleeding.spammingbleed = nil end
-        svo.rmaff('bleeding')
-        svo.dict.bleeding.count = 0
-        svo.dict.bleeding.saw_haemophilia = nil
-      end,
-
-      nomana = function()
-        if not svo.actions.nomana_waitingfor and stats.currentmana ~= 0 then
-          svo.echof("Seems we're out of mana.")
-          svo.doaction(svo.dict.nomana.waitingfor)
+  
+  if not svo.haveskillset('kaido') then
+          return ((stats.currenthealth &lt; sys.siphealth or (sk.gettingfullstats and stats.currenthealth &lt; stats.maxhealth))
+           and not svo.actions.healhealth_sip and not shouldntsip())
+  else
+          return ((stats.currenthealth &lt; sys.siphealth or (sk.gettingfullstats and stats.currenthealth &lt; stats.maxhealth))
+           and not svo.actions.healhealth_sip  and not shouldntsip() and
+            (defc.dragonform or -- sip health if we're in dragonform, can't use Kaido
+              not svo.can_usemana() or -- or we don't have enough mana (should be an option). The downside of this is that we
+              -- won't get mana back via sipping, only moss, the time to being able to transmute will approach slower than
+              -- straight sipping mana
+              (affs.prone and not conf.transsipprone) or -- or we're prone and sipping while prone is off (better for
+              --bashing, not so for PK)
+              (conf.transmute ~= 'replaceall' and conf.transmute ~= 'replacehealth' and not svo.doingaction'transmute')
+              -- or we're not in a replacehealth/replaceall mode, so we can still sip
+            )
+          )
+  end
+        end,
+  
+        oncompleted = function() svo.lostbal_sip() end,
+  
+        noeffect = function() svo.lostbal_sip() end,
+  
+        onprioswitch = function()
+          codepaste.serversideahealthmanaprio()
+        end,
+  
+        sipcure = {'health', 'vitality'},
+  
+        onstart = function()
+          svo.sip(svo.dict.healhealth.sip)
         end
-
-        svo.dict.bleeding.saw_haemophilia = nil
-        if affs.bleeding and affs.bleeding.spammingbleed then killTimer(affs.bleeding.spammingbleed); affs.bleeding.spammingbleed = nil end
-      end,
-
-      haemophilia = function()
-        if svo.dict.bleeding.saw_haemophilia then
-          svo.addaffdict(svo.dict.haemophilia)
-          svo.echof("Seems like we do have haemophilia for real.")
-        else
-          svo.dict.bleeding.saw_haemophilia = true
+      },
+      moss = {
+        -- managed outside priority lists
+        irregular = true,
+  
+        isadvisable = function()
+  if not svo.haveskillset('kaido') then
+          return ((stats.currenthealth &lt; sys.mosshealth) and (not svo.doingaction('healhealth') or (stats.currenthealth &lt; (sys.mosshealth-600)))) or false
+  else
+          return ((stats.currenthealth &lt; sys.mosshealth) and (not svo.doingaction('healhealth') or (stats.currenthealth &lt; (sys.mosshealth-600))) and (defc.dragonform or not svo.can_usemana() or affs.prone or (conf.transmute ~= 'replaceall' and not svo.doingaction'transmute'))) or false
+  end
+        end,
+  
+        oncompleted = function() svo.lostbal_moss() end,
+  
+        noeffect = function() svo.lostbal_moss() end,
+  
+        eatcure = {'irid', 'potash'},
+        actions = {"eat moss", "eat irid", "eat potash"},
+        onstart = function()
+          svo.eat(svo.dict.healhealth.moss)
         end
-        if affs.bleeding and affs.bleeding.spammingbleed then killTimer(affs.bleeding.spammingbleed); affs.bleeding.spammingbleed = nil end
-      end,
-
-      action = 'clot',
-      onstart = function()
-        local show = conf.commandecho and not conf.gagclot
-        send('clot', show)
-
-        -- don't optimize with corruption for now (but do if need need be)
-        if not sys.sync and ((not affs.corrupted and svo.stats.mp &gt;= 70 and (svo.dict.bleeding.count and svo.dict.bleeding.count &gt;= 200))
-            or (affs.corrupted and stats.currenthealth+500 &gt;= sys.corruptedhealthmin)) then
-          send('clot', show)
-          send('clot', show)
-
-          -- after sending a bunch of clots, wait a bit before doing it again
-          if affs.bleeding then
-            if affs.bleeding.spammingbleed then killTimer(affs.bleeding.spammingbleed); affs.bleeding.spammingbleed = nil end
-            affs.bleeding.spammingbleed = tempTimer(svo.getping(), function() affs.bleeding.spammingbleed = nil; svo.make_gnomes_work() end)
-          end
-        end
-      end
+      },
     },
-    aff = {
-      oncompleted = function (amount)
-        svo.addaffdict(svo.dict.bleeding)
-        -- TODO: affs.count vs svo.dict.count?
-        affs.bleeding.p.count = amount or (affs.bleeding.p.count + 200)
-        svo.updateaffcount(svo.dict.bleeding)
-
-        -- remove bleeding if we've had it for a while and didn't clot it up
-        if sk.smallbleedremove then killTimer(sk.smallbleedremove) end
-        sk.smallbleedremove = tempTimer(conf.smallbleedremove or 8, function()
-          sk.smallbleedremove = nil
-          if not affs.bleeding then return end
-
-          if svo.dict.bleeding.count &lt;= conf.bleedamount or svo.dict.bleeding.count &lt;= conf.manableedamount then
-            svo.rmaff('bleeding')
-          end
-        end)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('bleeding') end,
-    },
-    onremoved = function()
-      svo.dict.bleeding.count = 0
-      if sk.smallbleedremove then
-        killTimer(sk.smallbleedremove)
-        sk.smallbleedremove = nil
-      end
-    end
-  },
-  touchtree = {
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        if not next(affs) or not bals.tree or svo.doingaction('touchtree') or affs.sleep or not conf.tree or affs.stun
-         or affs.unconsciousness or affs.numbedrightarm or affs.numbedleftarm or affs.paralysis or affs.webbed
-          or affs.bound or affs.transfixed or affs.roped or affs.impale or ((affs.crippledleftarm or affs.mangledleftarm
-           or affs.mutilatedleftarm) and (affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm))
-            or codepaste.nonstdcure() then return false end
-
-        for name, func in pairs(svo.tree) do
-          if not me.disabledtreefunc[name] then
-            local s,m = pcall(func[1])
-            if s and m then return true end
-          end
+    healmana = {
+      description = "heals mana with mana/mentality or moss/potash",
+      sip = {
+        -- managed outside priority lists
+        irregular = true,
+  
+        isadvisable = function()
+          return ((stats.currentmana &lt; sys.sipmana or (sk.gettingfullstats and stats.currentmana &lt; stats.maxmana)) and not svo.doingaction('healmana')) or false
+        end,
+  
+        oncompleted = function() svo.lostbal_sip() end,
+  
+        noeffect = function() svo.lostbal_sip() end,
+  
+        onprioswitch = function()
+          codepaste.serversideahealthmanaprio()
+        end,
+  
+        sipcure = {'mana', 'mentality'},
+  
+        onstart = function()
+          svo.sip(svo.dict.healmana.sip)
         end
-      end,
-
-      oncompleted = function (aff)
-        -- small heuristic - shivering can be upgraded to frozen
-        if aff == 'shivering' and not affs.shivering and affs.frozen then
-          svo.rmaff('frozen')
-        -- handle levels of burns
-
-        elseif aff == "all burns" then
-          codepaste.remove_burns()
-
-        elseif aff == 'burn' then
-          local previousburn, currentburn = sk.previous_burn(), sk.current_burn()
-
-          if not currentburn then
-            codepaste.remove_burns()
-          else
-            svo.rmaff(currentburn)
-            svo.addaffdict(svo.dict[previousburn])
-          end
-
-        elseif aff == 'skullfractures' then
+      },
+      moss = {
+        -- managed outside priority lists
+        irregular = true,
+  
+        isadvisable = function()
+          return ((stats.currentmana &lt; sys.mossmana) and (not svo.doingaction('healmana') or (stats.currentmana &lt; (sys.mossmana-600)))) or false
+        end,
+  
+        oncompleted = function() svo.lostbal_moss() end,
+  
+        noeffect = function() svo.lostbal_moss() end,
+  
+        eatcure = {'irid', 'potash'},
+        actions = {"eat moss", "eat irid", "eat potash"},
+        onstart = function()
+          svo.eat(svo.dict.healmana.moss)
+        end
+      },
+    },
+    skullfractures = {
+      count = 0,
+      sip = {
+        isadvisable = function()
+          return (affs.skullfractures and stats.hp &gt;= conf.healthaffsabove) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_sip()
           svo.updateaffcount(svo.dict.skullfractures)
-
-        elseif aff == "skullfractures cured" then
+        end,
+  
+        cured = function()
+          svo.lostbal_sip()
           svo.rmaff('skullfractures')
           svo.dict.skullfractures.count = 0
-
-        elseif aff == 'crackedribs' then
+        end,
+  
+        fizzled = function()
+          svo.lostbal_sip()
+          empty.apply_health_head()
+        end,
+  
+        noeffect = function() svo.lostbal_sip() end,
+  
+        -- in case an unrecognised message is shown, don't error
+        empty = function() end,
+  
+        actions = {"apply health to head"},
+        onstart = function() send('apply health to head', conf.commandecho) end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.skullfractures)
+          svo.updateaffcount(svo.dict.skullfractures)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('skullfractures')
+          svo.dict.skullfractures.count = 0
+        end,
+  
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.skullfractures)
+        end,
+  
+        general_cured = function(_)
+          svo.rmaff('skullfractures')
+          svo.dict.skullfractures.count = 0
+        end,
+      }
+    },
+    crackedribs = {
+      count = 0,
+      sip = {
+        isadvisable = function()
+          return (affs.crackedribs and stats.hp &gt;= conf.healthaffsabove) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_sip()
           svo.updateaffcount(svo.dict.crackedribs)
-        
-        elseif aff == "crackedribs cured" then
+        end,
+  
+        cured = function()
+          svo.lostbal_sip()
           svo.rmaff('crackedribs')
           svo.dict.crackedribs.count = 0
-
-        elseif aff == 'wristfractures' then
+        end,
+  
+        fizzled = function()
+          svo.lostbal_sip()
+          empty.apply_health_torso()
+        end,
+  
+        noeffect = function() svo.lostbal_sip() end,
+  
+        -- in case an unrecognised message is shown, don't error
+        empty = function() end,
+  
+        actions = {"apply health to torso"},
+        onstart = function() send('apply health to torso', conf.commandecho) end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.crackedribs)
+          svo.updateaffcount(svo.dict.crackedribs)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('crackedribs')
+          svo.dict.crackedribs.count = 0
+        end,
+  
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.crackedribs)
+        end,
+  
+        general_cured = function()
+          svo.rmaff('crackedribs')
+          svo.dict.crackedribs.count = 0
+        end,
+      }
+    },
+    wristfractures = {
+      count = 0,
+      sip = {
+        isadvisable = function()
+          return (affs.wristfractures and stats.hp &gt;= conf.healthaffsabove) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_sip()
           svo.updateaffcount(svo.dict.wristfractures)
-
-        elseif aff == "wristfractures cured" then
+        end,
+  
+        cured = function()
+          svo.lostbal_sip()
           svo.rmaff('wristfractures')
           svo.dict.wristfractures.count = 0
-
-        elseif aff == 'torntendons' then
+        end,
+  
+        fizzled = function()
+          svo.lostbal_sip()
+          empty.apply_health_arms()
+        end,
+  
+        noeffect = function() svo.lostbal_sip() end,
+  
+        -- in case an unrecognised message is shown, don't error
+        empty = function() end,
+  
+        actions = {"apply health to arms"},
+        onstart = function() send('apply health to arms', conf.commandecho) end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.wristfractures)
+          svo.updateaffcount(svo.dict.wristfractures)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('wristfractures')
+          svo.dict.wristfractures.count = 0
+        end,
+  
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.wristfractures)
+        end,
+  
+        general_cured = function()
+          svo.rmaff('wristfractures')
+          svo.dict.wristfractures.count = 0
+        end,
+      }
+    },
+    torntendons = {
+      count = 0,
+      sip = {
+        isadvisable = function()
+          return (affs.torntendons and stats.hp &gt;= conf.healthaffsabove) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_sip()
           svo.updateaffcount(svo.dict.torntendons)
-
-        elseif aff == "torntendons cured" then
+        end,
+  
+        cured = function()
+          svo.lostbal_sip()
           svo.rmaff('torntendons')
           svo.dict.torntendons.count = 0
-
-        else
-          svo.rmaff(aff)
+        end,
+  
+        fizzled = function()
+          svo.lostbal_sip()
+          empty.apply_health_legs()
+        end,
+  
+        noeffect = function() svo.lostbal_sip() end,
+  
+        -- in case an unrecognised message is shown, don't error
+        empty = function() end,
+  
+        actions = {"apply health to legs"},
+        onstart = function() send('apply health to legs', conf.commandecho) end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.torntendons)
+          svo.updateaffcount(svo.dict.torntendons)
         end
-
-        svo.lostbal_tree()
-      end,
-
-      action = "touch tree",
-      onstart = function() send('touch tree', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_tree()
-        empty.tree()
-      end,
-
-      offbal = function() svo.lostbal_tree() end
-    }
-  },
-  restore = {
-    physical = {
-      balanceful_act = true,
-      uncurable = true,
-
-      isadvisable = function()
-        if not next(affs) or not conf.restore or svo.usingbal('salve') or codepaste.balanceful_codepaste() or
-          codepaste.nonstdcure() then return false end
-
-        for name, func in pairs(svo.restore) do
-          if not me.disabledrestorefunc[name] then
-            local s,m = pcall(func[1])
-            if s and m then svo.debugf("restore: %s strat went off", name) return true end
-          end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('torntendons')
+          svo.dict.torntendons.count = 0
+        end,
+  
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.torntendons)
+        end,
+  
+        general_cured = function()
+          svo.rmaff('torntendons')
+          svo.dict.torntendons.count = 0
+        end,
+      }
+    },
+    pressure = {
+      count = 0,
+      gamename = 'pressure',
+      name = 'pressure',
+      smoke = {
+        isadvisable = function()
+          return (affs.pressure and bals.smoke) or false
+        end,
+  
+        -- this is called when you still have some left 
+        oncompleted = function()
+          svo.lostbal_smoke()
+          svo.updateaffcount(svo.dict.pressure)
+        end,
+  
+        empty = function()
+          empty.eat_pear()
+          svo.lostbal_smoke()
+        end,
+  
+        cured = function()
+          svo.lostbal_smoke()
+          svo.rmaff('pressure')
+          svo.dict.pressure.count = 0
+        end,
+  
+        noeffect = function()
+  			  svo.rmaff('pressure')
+  			  svo.lostbal_smoke()
+  		  end,
+  
+        eatcure = {'pear', 'calcite'},
+  
+        onstart = function() svo.eat(svo.dict.pressure.smoke) end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.pressure)
+          svo.updateaffcount(svo.dict.pressure)
         end
-      end,
-
-      oncompleted = function (number)
-        if number then
-          -- empty
-          if number+1 == getLineNumber() then
-            svo.dict.unknowncrippledlimb.count = 0
-            svo.dict.unknowncrippledarm.count = 0
-            svo.dict.unknowncrippledleg.count = 0
-            svo.rmaff({'crippledleftarm', 'crippledleftleg', 'crippledrightarm', 'crippledrightleg', 'unknowncrippledarm', 'unknowncrippledleg', 'unknowncrippledlimb'})
-          end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('pressure')
+          svo.dict.pressure.count = 0
+        end,
+        
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.pressure)
+        end,
+  
+        general_cured = function()
+          svo.rmaff('pressure')
+          svo.dict.pressure.count = 0
+        end,
+      }
+    },
+    cholerichumour = {
+      count = 0,
+      gamename = 'temperedcholeric',
+      name = 'cholerichumour',
+      herb = {
+        isadvisable = function()
+          return (affs.cholerichumour) or false
+        end,
+  
+        -- this is called when you still have some left
+        oncompleted = function()
+          svo.lostbal_herb()
+          svo.updateaffcount(svo.dict.cholerichumour)
+        end,
+  
+        empty = function()
+          empty.eat_ginger()
+          svo.lostbal_herb()
+        end,
+  
+        cured = function()
+          svo.lostbal_herb()
+          svo.rmaff('cholerichumour')
+          svo.dict.cholerichumour.count = 0
+        end,
+  
+        noeffect = function() svo.lostbal_herb() end,
+  
+        -- does damage based on humour count
+        inundated = function()
+          svo.rmaff('cholerichumour')
+          svo.dict.cholerichumour.count = 0
+        end,
+  
+        eatcure = {'ginger', 'antimony'},
+  
+        onstart = function() svo.eat(svo.dict.cholerichumour.herb) end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.cholerichumour)
+          svo.updateaffcount(svo.dict.cholerichumour)
         end
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end,
-
-      action = 'restore',
-      onstart = function() send('restore', conf.commandecho) end
-    }
-  },
-  dragonheal = {
-    physical = {
-      balanceful_act = true,
-      uncurable = true,
-
-      isadvisable = function()
-        if not next(affs) or not defc.dragonform or not conf.dragonheal or not bals.dragonheal or codepaste.balanceful_codepaste() or codepaste.nonstdcure() or (affs.recklessness and affs.weakness) then return false end
-
-        for name, func in pairs(svo.dragonheal) do
-          if not me.disableddragonhealfunc[name] then
-            local s,m = pcall(func[1])
-            if s and m then return true end
-          end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('cholerichumour')
+          svo.dict.cholerichumour.count = 0
+        end,
+        
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.cholerichumour)
+        end,
+  
+        general_cured = function()
+          svo.rmaff('cholerichumour')
+          svo.dict.cholerichumour.count = 0
+        end,
+      }
+    },
+    melancholichumour = {
+      count = 0,
+      gamename = 'temperedmelancholic',
+      name = 'melancholichumour',
+      herb = {
+        isadvisable = function()
+          return (affs.melancholichumour) or false
+        end,
+  
+        -- this is called when you still have some left
+        oncompleted = function()
+          svo.lostbal_herb()
+          svo.updateaffcount(svo.dict.melancholichumour)
+        end,
+  
+        empty = function()
+          empty.eat_ginger()
+          svo.lostbal_herb()
+        end,
+  
+        cured = function()
+          svo.lostbal_herb()
+          svo.rmaff('melancholichumour')
+          svo.dict.melancholichumour.count = 0
+        end,
+  
+        noeffect = function() svo.lostbal_herb() end,
+  
+        -- does mana damage based on humour count
+        inundated = function()
+          svo.rmaff('melancholichumour')
+          svo.dict.melancholichumour.count = 0
+        end,
+  
+        eatcure = {'ginger', 'antimony'},
+  
+        onstart = function() svo.eat(svo.dict.melancholichumour.herb) end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.melancholichumour)
+          svo.updateaffcount(svo.dict.melancholichumour)
         end
-      end,
-
-      oncompleted = function (number)
-        if number then
-          -- empty
-          if number+1 == getLineNumber() then
-            empty.dragonheal()
-          end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('melancholichumour')
+          svo.dict.melancholichumour.count = 0
+        end,
+        
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.melancholichumour)
+        end,
+  
+        general_cured = function()
+          svo.rmaff('melancholichumour')
+          svo.dict.melancholichumour.count = 0
+        end,
+      }
+    },
+    phlegmatichumour = {
+      gamename = 'temperedphlegmatic',
+      name = 'phlegmatichumour',
+      count = 0,
+      herb = {
+        isadvisable = function()
+          return (affs.phlegmatichumour) or false
+        end,
+  
+        -- this is called when you still have some left
+        oncompleted = function()
+          svo.lostbal_herb()
+          svo.updateaffcount(svo.dict.phlegmatichumour)
+        end,
+  
+        empty = function()
+          empty.eat_ginger()
+          svo.lostbal_herb()
+        end,
+  
+        cured = function()
+          svo.lostbal_herb()
+          svo.rmaff('phlegmatichumour')
+          svo.dict.phlegmatichumour.count = 0
+        end,
+  
+        noeffect = function() svo.lostbal_herb() end,
+        
+        inundated = function()
+          svo.rmaff('phlegmatichumour')
+          svo.dict.phlegmatichumour.count = 0
+        end,
+  
+        eatcure = {'ginger', 'antimony'},
+  
+        onstart = function() svo.eat(svo.dict.phlegmatichumour.herb) end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.phlegmatichumour)
+          svo.updateaffcount(svo.dict.phlegmatichumour)
         end
-
-        svo.lostbal_dragonheal()
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end,
-
-      nobalance = function() svo.lostbal_dragonheal() end,
-
-      action = 'dragonheal',
-      onstart = function() send('dragonheal', conf.commandecho) end
-    }
-  },
-  defcheck = {
-    physical = {
-      balanceful_act = true,
-      uncurable = true,
-
-      isadvisable = function()
-        return (bals.balance and bals.equilibrium and me.manualdefcheck and not svo.doingaction('defcheck')) or false
-      end,
-
-      oncompleted = function()
-        me.manualdefcheck = false
-        svo.process_defs()
-      end,
-
-      ontimeout = function()
-        me.manualdefcheck = false
-      end,
-
-      action = 'def',
-      onstart = function() send('def', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('phlegmatichumour')
+          svo.dict.phlegmatichumour.count = 0
+        end,
+        
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.phlegmatichumour)
+        end,
+  
+        general_cured = function()
+          svo.rmaff('phlegmatichumour')
+          svo.dict.phlegmatichumour.count = 0
+        end,
+      }
     },
-  },
-  diag = {
-    physical = {
-      balanceful_act = true,
-      uncurable = true,
-
-      isadvisable = function()
-        return ((sys.manualdiag or (affs.unknownmental and affs.unknownmental.p.count &gt;= conf.unknownfocus) or (affs.unknownany and affs.unknownany.p.count &gt;= conf.unknownany)) and bals.balance and bals.equilibrium and not svo.doingaction('diag')) or false
-      end,
-
-      oncompleted = function()
-        sys.manualdiag = false
-        sk.diag_list = {}
-        svo.rmaff('unknownmental')
-        svo.rmaff('unknownany')
-        svo.dict.unknownmental.count = 0
-        svo.dict.unknownany.count = 0
-        svo.dict.bleeding.saw_haemophilia = nil
-        svo.dict.relapsing.saw_with_checkable = nil
-
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end,
-
-      actions = {'diag', 'diagnose', "diag me", "diagnose me"},
-      onstart = function() send('diag', conf.commandecho) end
-    },
-  },
-  block = {
-    gamename = 'blocking',
-    physical = {
-      blockingdir = "",
-      balanceless_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        if defc.block and ((conf.keepup and not defkeepup[defs.mode].block and not sys.deffing) or (sys.deffing and not defdefup[defs.mode].block)) and not svo.doingaction'block' then return true end
-
-        return (
-          ((sys.deffing and defdefup[defs.mode].block) or (conf.keepup and defkeepup[defs.mode].block and not sys.deffing))
-          and (not defc.block or svo.dict.block.physical.blockingdir ~= conf.blockingdir)
-          and not svo.doingaction'block'
-          and (not sys.enabledgmcp or (gmcp.Room and gmcp.Room.Info.exits[conf.blockingdir]))
-          and not codepaste.balanceful_codepaste()
-          and not affs.prone
-          and (not svo.haveskillset('metamorphosis') or (defc.riding or defc.elephant or defc.dragonform or defc.hydra))
-          and (not svo.haveskillset('subterfuge') or not defc.phase)
-        ) or false
-      end,
-
-      oncompleted = function (dir)
-        if dir then
-          svo.dict.block.physical.blockingdir = sk.anytoshort(dir)
-        else --workaround for looping
-          svo.dict.block.physical.blockingdir = conf.blockingdir
+    sanguinehumour = {
+      count = 0,
+      gamename = 'temperedsanguine',
+      name = 'sanguinehumour',
+      herb = {
+        isadvisable = function()
+          return (affs.sanguinehumour) or false
+        end,
+  
+        -- this is called when you still have some left
+        oncompleted = function()
+          svo.lostbal_herb()
+          svo.updateaffcount(svo.dict.sanguinehumour)
+        end,
+  
+        empty = function()
+          empty.eat_ginger()
+          svo.lostbal_herb()
+        end,
+  
+        cured = function()
+          svo.lostbal_herb()
+          svo.rmaff('sanguinehumour')
+          svo.dict.sanguinehumour.count = 0
+        end,
+  
+        noeffect = function() svo.lostbal_herb() end,
+  
+        -- gives bleeding depending on your sanguine humour level, from 250 for first to 2500 for last
+        inundated = function()
+          local min = 250
+          -- local max = 2500
+          if not affs.sanguinehumour then return end
+  
+          local bledfor = svo.dict.sanguinehumour.count * min
+  
+          svo.addaffdict(svo.dict.bleeding)
+          svo.dict.bleeding.count = bledfor
+          svo.updateaffcount(svo.dict.bleeding)
+  
+          svo.rmaff('sanguinehumour')
+          svo.dict.sanguinehumour.count = 0
+        end,
+  
+        eatcure = {'ginger', 'antimony'},
+  
+        onstart = function() svo.eat(svo.dict.sanguinehumour.herb) end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.sanguinehumour)
+          svo.updateaffcount(svo.dict.sanguinehumour)
         end
-        defences.got('block')
-      end,
-
-      -- in case of failing to block, register that the action has been completed
-      failed = function() end,
-
-      onstart = function()
-        if (not defc.block or svo.dict.block.physical.blockingdir ~= conf.blockingdir) then
-          send("block "..tostring(conf.blockingdir), conf.commandecho)
-        else
-          send('unblock', conf.commandecho)
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('sanguinehumour')
+          svo.dict.sanguinehumour.count = 0
+        end,
+        
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.sanguinehumour)
+        end,
+  
+        general_cured = function()
+          svo.rmaff('sanguinehumour')
+          svo.dict.sanguinehumour.count = 0
+        end,
+      }
+    },
+    
+  horror = {
+      count = 0,
+      gamename = 'horror',
+      name = 'horror',
+      herb = {
+        isadvisable = function()
+          return (affs.horror and bals.herb) or false
+        end,
+  
+        -- this is called when you still have some left 
+        oncompleted = function()
+          svo.lostbal_herb()
+          svo.updateaffcount(svo.dict.horror)
+        end,
+  
+        empty = function()
+          empty.eat_goldenseal()
+          svo.lostbal_herb()
+        end,
+  
+        cured = function()
+          svo.lostbal_herb()
+          svo.rmaff('horror')
+          svo.dict.horror.count = 0
+        end,
+  
+        noeffect = function()
+  			  svo.rmaff('horror')
+  			  svo.lostbal_herb()
+  		  end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+  
+        onstart = function() svo.eat(svo.dict.horror.herb) end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.horror)
+          svo.updateaffcount(svo.dict.horror)
         end
-      end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('horror')
+          svo.dict.horror.count = 0
+        end,
+        
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.horror)
+        end,
+  
+        general_cured = function()
+          svo.rmaff('horror')
+          svo.dict.horror.count = 0
+        end,
+      }
     },
-    gone = {
-      oncompleted = function()
-        defences.lost('block')
-        svo.dict.block.physical.blockingdir = ""
-
-        if svo.actions.block_physical then
-          svo.killaction(svo.dict.block.physical)
+    
+    waterbubble = {
+      gamename = 'airpocket',
+      onservereignore = function()
+        return svo.me.class == "water Elemental Lady" or svo.me.class == "water Elemental Lord"
+        end,
+      herb = {
+        def = true,
+  
+        isadvisable = function()
+          return not defc.waterbubble and ((sys.deffing and defdefup[defs.mode].waterbubble) or (conf.keepup and defkeepup[defs.mode].waterbubble)) and not affs.anorexia and me.is_underwater and not (svo.me.class == "water Elemental Lady" or svo.me.class == "water Elemental Lord")
+        end,
+  
+        eatcure = {'pear', 'calcite'},
+  
+        onstart = function() svo.eat(svo.dict.waterbubble.herb) end,
+  
+        oncompleted = function() defences.got('waterbubble') end,
+  
+        empty = function() end
+      }
+    },
+    pacifism = {
+      gamename = 'pacified',
+      herb = {
+        isadvisable = function()
+          return (affs.pacifism and
+            not svo.doingaction('pacifism') and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity')or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('pacifism')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'bellwort', 'cuprum'},
+        onstart = function() svo.eat(svo.dict.pacifism.herb) end,
+  
+        empty = function() empty.eat_bellwort() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.pacifism and
+            not svo.doingaction('pacifism') and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity')or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('pacifism')
+          svo.lostbal_focus()
+        end,
+  
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
         end
-      end
-    }
-  },
-  doparry = {
-    physical = {
-      balanceless_act = true,
-      uncurable = true,
-
-      isadvisable = function()
-        return (not sys.sp_satisfied and not sys.blockparry and not affs.paralysis
-          and not svo.doingaction('doparry') and ((svo.haveskillset('tekura') and conf.guarding) or conf.parry) and not codepaste.balanceful_codepaste()
-          -- blademasters can parry with their sword sheathed, and monks don't need to wield anything
-          and ((svo.haveskillset('tekura') or svo.me.class == 'Blademaster') or ((not sys.enabledgmcp or defc.dragonform) or (next(me.wielded) and sk.have_parryable())))
-          and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function (limb)
-        local t = svo.sps.parry_currently
-        for currentlimb, _ in pairs(t) do t[currentlimb] = false end
-        t[limb] = true
-        svo.check_sp_satisfied()
-      end,
-
-      onstart = function()
-        if svo.sps.something_to_parry() then
-          for name, limb in pairs(svo.sp_config.parry_shouldbe) do
-            if limb and limb ~= svo.sps.parry_currently[name] then
-if not (svo.haveskillset('tekura') and conf.guarding) then
-              send(string.format("%sparry %s", (not defc.dragonform and "" or 'claw'), name), conf.commandecho)
-else
-              send(string.format("%s %s", (not defc.dragonform and 'guard' or 'clawparry'), name), conf.commandecho)
-end
-              return
-            end
-          end
-        elseif type(svo.sp_config.parry) == 'string' and svo.sp_config.parry == 'manual' then
-          -- check if we need to unparry in manual
-          for limb, status in pairs(svo.sps.parry_currently) do
-            if status ~= svo.sp_config.parry_shouldbe[limb] then
-if not (svo.haveskillset('tekura') and conf.guarding) then
-             send(string.format("%sparry nothing", (not defc.dragonform and "" or 'claw')), conf.commandecho)
-else
-             send(string.format("%s nothing", (not defc.dragonform and 'guard' or 'clawparry')), conf.commandecho)
-end
-             return
-            end
-          end
-
-          -- got here? nothing to do...
-          svo.sys.sp_satisfied = true
-        elseif svo.sp_config.priority[1] and not svo.sps.parry_currently[svo.sp_config.priority[1]] then
-if not (svo.haveskillset('tekura') and conf.guarding) then
-          send(string.format("%sparry %s", (not defc.dragonform and "" or 'claw'), svo.sp_config.priority[1]), conf.commandecho)
-else
-          send(string.format("%s %s", (not defc.dragonform and 'guard' or 'clawparry'), svo.sp_config.priority[1]), conf.commandecho)
-end
-        else -- got here? nothing to do...
-          svo.sys.sp_satisfied = true end
-      end,
-
-      none = function()
-        for limb, _ in pairs(svo.sps.parry_currently) do
-          svo.sps.parry_currently[limb] = false
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.pacifism)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('pacifism')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    peace = {
+      herb = {
+        isadvisable = function()
+          return (affs.peace and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity') or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('peace')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'bellwort', 'cuprum'},
+        onstart = function() svo.eat(svo.dict.peace.herb) end,
+  
+        empty = function() empty.eat_bellwort() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.peace)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('peace') end,
+      }
+    },
+    inlove = {
+      gamename = 'lovers',
+      herb = {
+        isadvisable = function()
+          return (affs.inlove and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity') or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('inlove')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'bellwort', 'cuprum'},
+        onstart = function() svo.eat(svo.dict.inlove.herb) end,
+  
+        empty = function() empty.eat_bellwort() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.inlove)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('inlove') end,
+      }
+    },
+    dissonance = {
+      herb = {
+        isadvisable = function()
+          return (affs.dissonance and not svo.usingbal('focus')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('dissonance')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+        onstart = function() svo.eat(svo.dict.dissonance.herb) end,
+  
+        empty = function() empty.eat_goldenseal() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.dissonance)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('dissonance') end,
+      }
+    },
+    dizziness = {
+      herb = {
+        isadvisable = function()
+          return (affs.dizziness and
+            not svo.doingaction('dizziness') and not svo.usingbal('focus')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('dizziness')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+        onstart = function() svo.eat(svo.dict.dizziness.herb) end,
+  
+        empty = function() empty.eat_goldenseal() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.dizziness and
+            not svo.doingaction('dizziness')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('dizziness')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
         end
-
-        svo.check_sp_satisfied()
-      end
-    }
-  },
-  doprecache = {
-    misc = {
-      -- not a curable in-game affliction? mark it so priority doesn't get set
-      uncurable = true,
-
-      isadvisable = function()
-        return (rift.doprecache and not sys.blockoutr and not svo.findbybal'herb' and not svo.doingaction'doprecache' and sys.canoutr) or false
-      end,
-
-      oncompleted = function()
-        -- check if we still need to precache, and if not, clear rift.doprecache
-        rift.checkprecache()
-
-        if rift.doprecache then
-          -- allow other outrs to catch up, then re-check again
-          if sys.blockoutr then killTimer(sys.blockoutr); sys.blockoutr = nil end
-          sys.blockoutr = tempTimer(sys.wait + svo.syncdelay(), function() sys.blockoutr = nil
-            svo.debugf("sys.blockoutr expired") svo.make_gnomes_work()
-            end)
-          svo.debugf("sys.blockoutr setup: ", debug.traceback())
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.dizziness)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('dizziness')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    shyness = {
+      herb = {
+        isadvisable = function()
+          return (affs.shyness and
+            not svo.doingaction('shyness') and not svo.usingbal('focus')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('shyness')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+        onstart = function() svo.eat(svo.dict.shyness.herb) end,
+  
+        empty = function() empty.eat_goldenseal() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.shyness and
+            not svo.doingaction('shyness')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('shyness')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
         end
-      end,
-
-      ontimeout = function()
-        rift.checkprecache()
-      end,
-
-      onstart = function()
-        for herb, _ in pairs(rift.precache) do
-          if rift.precache[herb] ~= 0 and rift.riftcontents[herb] ~= 0 and (rift.invcontents[herb] &lt; rift.precache[herb]) then
-            send(string.format("outr %s%s", (affs.addiction and "" or (rift.precache[herb] - rift.invcontents[herb].." ")), herb), conf.commandecho)
-            if sys.sync then return end
-          end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.shyness)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('shyness')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    epilepsy = {
+      herb = {
+        isadvisable = function()
+          return (affs.epilepsy and
+            not svo.doingaction('epilepsy') and not svo.usingbal('focus')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('epilepsy')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+        onstart = function() svo.eat(svo.dict.epilepsy.herb) end,
+  
+        empty = function() empty.eat_goldenseal() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.epilepsy and
+            not svo.doingaction('epilepsy')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('epilepsy')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
         end
-      end
-    }
-  },
-  prone = {
-    misc = {
-      isadvisable = function()
-        return (affs.prone and (not affs.paralysis or svo.doingaction'paralysis')
-          and (svo.haveskillset('weaponmastery') and (sk.didfootingattack or (bals.balance and bals.equilibrium and bals.leftarm and bals.rightarm)) or (bals.balance and bals.equilibrium and bals.leftarm and bals.rightarm))
-          and not svo.doingaction('prone') and not affs.sleep
-          and not affs.impale
-          and not affs.transfixed
-          and not affs.webbed and not affs.bound and not affs.roped
-          and not affs.crippledleftleg and not affs.crippledrightleg
-          and not affs.mangledleftleg and not affs.mangledrightleg
-          and not affs.mutilatedleftleg and not affs.mutilatedrightleg) or false
-      end,
-
-      oncompleted = function() svo.rmaff('prone') end,
-
-      onstart = function()
-if svo.haveskillset('weaponmastery') then
-        if sk.didfootingattack and conf.recoverfooting then
-          send("recover footing", conf.commandecho)
-          if affs.blackout then send("recover footing", conf.commandecho) end
-        else
-          send('stand', conf.commandecho)
-          if affs.blackout then send('stand', conf.commandecho) end
-        end
-else
-        send('stand', conf.commandecho)
-        if affs.blackout then send('stand', conf.commandecho) end
-end
-      end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.epilepsy)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('epilepsy')
+          codepaste.remove_focusable()
+        end,
+      }
     },
-    aff = {
-      oncompleted = function()
-        if not affs.prone then svo.addaffdict(svo.dict.prone) end
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('prone') end
-    },
-    onremoved = function() svo.donext() end,
-    onadded = function()
-      if affs.prone and affs.seriousconcussion then
-        sk.warn 'pulpable'
-      end
-    end
-  },
-  disrupt = {
-    gamename = 'disrupted',
-    misc = {
-      isadvisable = function()
-        return (affs.disrupt and not svo.doingaction('disrupt')
-          and not affs.confusion and not affs.sleep) or false
-      end,
-
-      oncompleted = function() svo.rmaff('disrupt') end,
-
-      oncured = function() svo.rmaff('disrupt') end,
-
-      action = 'concentrate',
-      onstart = function() send('concentrate', conf.commandecho) end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.disrupt)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('disrupt') end
-    }
-  },
-  lightpipes = {
-    physical = {
-      balanceless_act = true,
-      uncurable = true,
-
-      isadvisable = function()
-        return ((not pipes.valerian.arty and not pipes.valerian.lit and pipes.valerian.puffs &gt; 0 and not (pipes.valerian.id == 0)
-          or (not pipes.elm.arty and not pipes.elm.lit and pipes.elm.puffs &gt; 0 and not (pipes.elm.id == 0))
-          or (not pipes.skullcap.arty and not pipes.skullcap.lit and pipes.skullcap.puffs &gt; 0 and not (pipes.skullcap.id == 0))
-          or (not pipes.elm.arty2 and not pipes.elm.lit2 and pipes.elm.puffs2 &gt; 0 and not (pipes.elm.id2 == 0))
-          or (not pipes.valerian.arty2 and not pipes.valerian.lit2 and pipes.valerian.puffs2 &gt; 0 and not (pipes.valerian.id2 == 0))
-          or (not pipes.skullcap.arty2 and not pipes.skullcap.lit2 and pipes.skullcap.puffs2 &gt; 0 and not (pipes.skullcap.id2 == 0))
-          )
-        and (conf.relight or sk.forcelight_valerian or sk.forcelight_skullcap or sk.forcelight_elm)
-        and not (conf.serverside or svo.doingaction('lightskullcap') or svo.doingaction('lightelm') or svo.doingaction('lightvalerian') or svo.doingaction('lightpipes'))) or false
-      end,
-
-      oncompleted = function()
-        pipes.valerian.lit = true
-        pipes.valerian.lit2 = true
-        sk.forcelight_valerian = false
-        pipes.elm.lit = true
-        pipes.elm.lit2 = true
-        sk.forcelight_elm = false
-        pipes.skullcap.lit = true
-        pipes.skullcap.lit2 = true
-        sk.forcelight_skullcap = false
-
-        svo.lastlit('valerian')
-      end,
-
-      actions = {"light pipes"},
-      onstart = function()
-        if conf.gagrelight then
-          send("light pipes", false)
-        else
-          send("light pipes", conf.commandecho) end
-      end
-    }
-  },
-  fillskullcap = {
-    physical = {
-      balanceless_act = true,
-      herb = 'skullcap',
-      uncurable = true,
-      fillingid = 0,
-
-      mainpipeout = function()
-        return (pipes.skullcap.puffs &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.skullcap.id == 0)
-      end,
-
-      secondarypipeout = function()
-        return (pipes.skullcap.puffs2 &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.skullcap.id2 == 0)
-      end,
-
-      isadvisable = function()
-        return ((svo.dict.fillskullcap.physical.mainpipeout() or svo.dict.fillskullcap.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance() and not (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed) and not conf.serverside) or false
-      end,
-
-      oncompleted = function()
-        if svo.dict.fillskullcap.fillingid == pipes.skullcap.id then
-          pipes.skullcap.puffs = pipes.skullcap.maxpuffs or 10
-          pipes.skullcap.lit = false
-          rift.invcontents.skullcap = rift.invcontents.skullcap - 1
-          if rift.invcontents.skullcap &lt; 0 then rift.invcontents.skullcap = 0 end
-        else
-          pipes.skullcap.puffs2 = pipes.skullcap.maxpuffs2 or 10
-          pipes.skullcap.lit2 = false
-          rift.invcontents.skullcap = rift.invcontents.skullcap - 1
-          if rift.invcontents.skullcap &lt; 0 then rift.invcontents.skullcap = 0 end
-        end
-      end,
-
-      onstart = function()
-        if svo.dict.fillskullcap.physical.mainpipeout() then
-          svo.fillpipe('skullcap', pipes.skullcap.id)
-          svo.dict.fillskullcap.fillingid = pipes.skullcap.id
-        else
-          svo.fillpipe('skullcap', pipes.skullcap.id2)
-          svo.dict.fillskullcap.fillingid = pipes.skullcap.id2
-        end
-      end
-    }
-  },
-  fillelm = {
-    physical = {
-      balanceless_act = true,
-      herb = 'elm',
-      uncurable = true,
-      fillingid = 0,
-
-      mainpipeout = function()
-        return (pipes.elm.puffs &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.elm.id == 0)
-      end,
-
-      secondarypipeout = function()
-        return (pipes.elm.puffs2 &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.elm.id2 == 0)
-      end,
-
-      isadvisable = function()
-        return ((svo.dict.fillelm.physical.mainpipeout() or svo.dict.fillelm.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance()  and not (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed) and not conf.serverside) or false
-      end,
-
-      oncompleted = function()
-        if svo.dict.fillelm.fillingid == pipes.elm.id then
-          pipes.elm.puffs = pipes.elm.maxpuffs or 10
-          pipes.elm.lit = false
-          rift.invcontents.elm = rift.invcontents.elm - 1
-          if rift.invcontents.elm &lt; 0 then rift.invcontents.elm = 0 end
-        else
-          pipes.elm.puffs2 = pipes.elm.maxpuffs2 or 10
-          pipes.elm.lit2 = false
-          rift.invcontents.elm = rift.invcontents.elm - 1
-          if rift.invcontents.elm &lt; 0 then rift.invcontents.elm = 0 end
-        end
-      end,
-
-      onstart = function()
-        if svo.dict.fillelm.physical.mainpipeout() then
-          svo.fillpipe('elm', pipes.elm.id)
-          svo.dict.fillelm.fillingid = pipes.elm.id
-        else
-          svo.fillpipe('elm', pipes.elm.id2)
-          svo.dict.fillelm.fillingid = pipes.elm.id2
-        end
-      end
-    }
-  },
-  fillvalerian = {
-    physical = {
-      balanceless_act = true,
-      herb = 'valerian',
-      uncurable = true,
-      fillingid = 0,
-
-      mainpipeout = function()
-        return (pipes.valerian.puffs &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.valerian.id == 0)
-      end,
-
-      secondarypipeout = function()
-        return (pipes.valerian.puffs2 &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.valerian.id2 == 0)
-      end,
-
-      isadvisable = function()
-        if ((svo.dict.fillvalerian.physical.mainpipeout() or svo.dict.fillvalerian.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance() and not conf.serverside) then
-
-          if (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed) then
-            sk.warn 'emptyvalerianpipenorefill'
-            return false
-          else
-            return true
-          end
-        end
-      end,
-
-      oncompleted = function()
-        if svo.dict.fillvalerian.fillingid == pipes.valerian.id then
-          pipes.valerian.puffs = pipes.valerian.maxpuffs or 10
-          pipes.valerian.lit = false
-          rift.invcontents.valerian = rift.invcontents.valerian - 1
-          if rift.invcontents.valerian &lt; 0 then rift.invcontents.valerian = 0 end
-        else
-          pipes.valerian.puffs2 = pipes.valerian.maxpuffs2 or 10
-          pipes.valerian.lit2 = false
-          rift.invcontents.valerian = rift.invcontents.valerian - 1
-          if rift.invcontents.valerian &lt; 0 then rift.invcontents.valerian = 0 end
-        end
-      end,
-
-      onstart = function()
-        if svo.dict.fillvalerian.physical.mainpipeout() then
-          svo.fillpipe('valerian', pipes.valerian.id)
-          svo.dict.fillvalerian.fillingid = pipes.valerian.id
-        else
-          svo.fillpipe('valerian', pipes.valerian.id2)
-          svo.dict.fillvalerian.fillingid = pipes.valerian.id2
-        end
-      end
-    }
-  },
-  rewield = {
-    rewieldables = false,
-    physical = {
-      balanceless_act = true,
-      uncurable = true,
-
-      isadvisable = function()
-        return (conf.autorewield and svo.dict.rewield.rewieldables and not svo.doingaction'rewield' and not affs.impale and not affs.webbed and not affs.transfixed and not affs.roped and not affs.transfixed and sys.canoutr and not affs.mutilatedleftarm and not affs.mutilatedrightarm and not affs.mangledrightarm and not affs.mangledleftarm and not affs.crippledrightarm and not affs.crippledleftarm) or false
-      end,
-
-      oncompleted = function (id)
-        if not svo.dict.rewield.rewieldables then return end
-
-        for count, item in ipairs(svo.dict.rewield.rewieldables) do
-          if item.id == id then
-            table.remove(svo.dict.rewield.rewieldables, count)
-            break
-          end
-        end
-
-        if #svo.dict.rewield.rewieldables == 0 then
-          svo.dict.rewield.rewieldables = false
-        end
-      end,
-
-      failed = function()
-        svo.dict.rewield.rewieldables = false
-      end,
-
-      clear = function()
-        svo.dict.rewield.rewieldables = false
-      end,
-
-      onstart = function()
-        for _, t in pairs(svo.dict.rewield.rewieldables) do
-          send("wield "..t.id, conf.commandecho)
-          if sys.sync then return end
-        end
-      end
-    }
-  },
-  blackout = {
-    waitingfor = {
-      customwait = 60,
-
-      onstart = function() end,
-
-      oncompleted = function() svo.rmaff('blackout') end,
-
-      ontimeout = function() svo.rmaff('blackout') end
-    },
-    aff = {
-      oncompleted = function()
-        if affs.blackout then return end
-
-        svo.addaffdict(svo.dict.blackout)
-
-        tempTimer(4.5, function() if affs.blackout then svo.addaffdict(svo.dict.disrupt) svo.make_gnomes_work() end end)
-
-        -- prevent leprosy in blackout
-        if svo.enabledskills.necromancy then
-          svo.echof("Fighting a Necromancer - going to assume crippled limbs every now and then.")
-          tempTimer(3, function() if affs.blackout then svo.addaffdict(svo.dict.unknowncrippledlimb) svo.make_gnomes_work() end end)
-          tempTimer(5, function() if affs.blackout then svo.addaffdict(svo.dict.unknowncrippledlimb) svo.make_gnomes_work() end end)
-        end
-
-        if svo.enabledskills.curses then
-          svo.echof("Fighting a Shaman - going to check for asthma/anorexia.")
-          tempTimer(3, function() if affs.blackout then svo.affsp.anorexia = true; svo.affsp.asthma = true; svo.make_gnomes_work() end end)
-          tempTimer(5, function() if affs.blackout then svo.affsp.anorexia = true; svo.affsp.asthma = true; svo.make_gnomes_work() end end)
-        end
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('blackout') end,
-    },
-    onremoved = function()
-      svo.check_generics()
-      if sk.sylvan_eclipse then
-        sys.manualdiag = true
-      end
-
-      if not affs.recklessness then
-        svo.killaction(svo.dict.nomana.waitingfor)
-      end
-
-      if svo.dict.blackout.check_lust then
-        svo.echof("Checking allies for potential lust...")
-        send('allies', conf.commandecho)
-        svo.dict.blackout.check_lust = nil
-      end
-
-      tempTimer(0.5, function()
-        if not bals.equilibrium and not conf.serverside then svo.addaffdict(svo.dict.disrupt) end
-
-        if stats.currenthealth == 0 and conf.assumestats ~= 0 then
-          svo.reset.affs()
-          svo.reset.general()
-          svo.reset.defs()
-          conf.paused = true
-          echo"\n"svo.echof("We died.")
-          raiseEvent("svo config changed", 'paused')
-        end
-      end)
-
-      -- if we came out with full health and mana out of blackout, assume we've got recklessness meanwhile. don't do it in serverside curing though, because that doesn't assume the same
-      if (not svo.dict.blackout.addedon or svo.dict.blackout.addedon ~= os.time()) and stats.currenthealth == stats.maxhealth and stats.currentmana == stats.maxmana then
-        svo.addaffdict(svo.dict.recklessness)
-        svo.echof("suspicious full stats out of blackout - going to assume reckless.")
-        if conf.serverside then
-          svo.sendcuring("predict recklessness")
-        end
-      end
-    end,
-    onadded = function()
-      svo.check_generics()
-      svo.dict.blackout.addedon = os.time()
-    end
-  },
-  unknownany = {
-    count = 0,
-    reckhp = false, reckmana = false,
-    waitingfor = {
-      customwait = 999,
-
-      onstart = function() end,
-
-      empty = function() end
-    },
-    aff = {
-      oncompleted = function (number)
-
-        if ((svo.dict.unknownany.reckhp and stats.currenthealth == stats.maxhealth) or
-          (svo.dict.unknownany.reckmana and stats.currentmana == stats.maxmana)) then
-            svo.addaffdict(svo.dict.recklessness)
-
-            if conf.serverside then
-              svo.sendcuring("predict recklessness")
-            end
-
-            if number and number &gt; 1 then
-              -- take one off because one affliction is recklessness
-              codepaste.addunknownany(number-1)
-            end
-        else
-          codepaste.addunknownany(number)
-        end
-
-        svo.dict.unknownany.reckhp = false; svo.dict.unknownany.reckmana = false
-      end,
-
-      wrack = function()
-        -- if 3, then it was not hidden, ignore - affliction triggers will watch the aff
-        if svo.paragraph_length &gt;= 3 then return end
-
-        if ((svo.dict.unknownany.reckhp and stats.currenthealth == stats.maxhealth) or
-          (svo.dict.unknownany.reckmana and stats.currentmana == stats.maxmana)) then
-            svo.addaffdict(svo.dict.recklessness)
-
-            if conf.serverside then
-              svo.sendcuring("predict recklessness")
-            end
-        else
-          codepaste.addunknownany()
-        end
-
-        svo.dict.unknownany.reckhp = false; svo.dict.unknownany.reckmana = false
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('unknownany')
-        svo.dict.unknownany.count = 0
-      end,
-
-      -- to be used when you lost one unknown (for example, you saw a symptom for something else)
-      lost_level = function()
-        if not affs.unknownany then return end
-        affs.unknownany.p.count = affs.unknownany.p.count - 1
-        if affs.unknownany.p.count &lt;= 0 then
-          svo.rmaff('unknownany')
-          svo.dict.unknownany.count = 0
-        else
-          svo.updateaffcount(svo.dict.unknownany)
-        end
-      end
-    }
-  },
-  unknownmental = {
-    count = 0,
-    reckhp = false, reckmana = false,
-    focus = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (affs.unknownmental) or false
-      end,
-
-      oncompleted = function()
-        -- special: gets called on each focus mind cure, but we most of
-        -- the time don't have an unknown aff
-        if not affs.unknownmental then return end
-        affs.unknownmental.p.count = affs.unknownmental.p.count - 1
-        if affs.unknownmental.p.count &lt;= 0 then
-          svo.rmaff('unknownmental')
-          svo.dict.unknownmental.count = 0
-        else
-          svo.updateaffcount(svo.dict.unknownmental)
-        end
-
-        svo.lostbal_focus()
-      end,
-
-      onstart = function() send('focus mind', conf.commandecho) end,
-
-      empty = function()
-        svo.lostbal_focus()
-
-        svo.rmaff('unknownmental')
-      end
-    },
-    aff = {
-      oncompleted = function (number)
-        if ((svo.dict.unknownmental.reckhp and stats.currenthealth == stats.maxhealth) or
-          (svo.dict.unknownmental.reckmana and stats.currentmana == stats.maxmana)) then
-            svo.addaffdict(svo.dict.recklessness)
-
-            if conf.serverside then
-              svo.sendcuring("predict recklessness")
-            end
-
-            if number and number &gt; 1 then
-              local count = svo.dict.unknownany.count
-              svo.addaffdict(svo.dict.unknownany)
-              -- take one off because one affliction is recklessness
-              affs.unknownany.p.count = (count or 0) + (number - 1)
-              svo.updateaffcount(svo.dict.unknownany)
-            end
-        else
-          local count = svo.dict.unknownmental.count
-          svo.addaffdict(svo.dict.unknownmental)
-
-          svo.dict.unknownmental.count = (count or 0) + (number or 1)
-          svo.updateaffcount(svo.dict.unknownmental)
-        end
-
-        svo.dict.unknownmental.reckhp = false; svo.dict.unknownmental.reckmana = false
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('unknownmental')
-        svo.dict.unknownmental.count = 0
-      end,
-
-      -- to be used when you lost one focusable (for example, you saw a symptom for something else)
-      lost_level = function()
-        if not affs.unknownmental then return end
-        affs.unknownmental.p.count = affs.unknownmental.p.count - 1
-        if affs.unknownmental.p.count &lt;= 0 then
-          svo.rmaff('unknownmental')
-          svo.dict.unknownmental.count = 0
-        else
-          svo.updateaffcount(svo.dict.unknownmental)
-        end
-      end
-    }
-  },
-  unknowncrippledlimb = {
-    count = 0,
-    salve = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (affs.unknowncrippledlimb and not (affs.mutilatedrightarm or affs.mutilatedleftarm or affs.mangledleftarm or affs.mangledrightarm or affs.parestoarms) and not (affs.mutilatedrightleg or affs.mutilatedleftleg or affs.mangledleftleg or affs.mangledrightleg or affs.parestolegs)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('unknowncrippledlimb')
-      end,
-
-      applycure = {'mending', 'renewal'},
-      actions = {"apply mending", "apply renewal"},
-      onstart = function()
-        svo.apply(svo.dict.unknowncrippledlimb.salve)
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.apply_mending()
-      end,
-
-      fizzled = function()
-        svo.lostbal_salve()
-        -- if it fizzled, then it means we've got a resto break on arms or legs
-        -- applying resto without targetting a limb doesn't work, so try mending on both, see what happens
-        svo.rmaff('unknowncrippledlimb')
-        svo.addaffdict(svo.dict.unknowncrippledarm)
-        svo.addaffdict(svo.dict.unknowncrippledleg)
-        tempTimer(0, function() svo.show_info("some limb broken?", "It would seem an arm or a leg of yours is broken (the salve fizzled), not just crippled - going to work out which is it and fix it") end)
-      end,
-    },
-    aff = {
-      oncompleted = function (amount)
-        svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count + (amount or 1)
-        if svo.dict.unknowncrippledlimb.count &gt; 4 then svo.dict.unknowncrippledlimb.count = 4 end
-        svo.addaffdict(svo.dict.unknowncrippledlimb)
-        svo.updateaffcount(svo.dict.unknowncrippledlimb)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.dict.unknowncrippledlimb.count = 0
-        svo.rmaff('unknowncrippledlimb')
-      end,
-    },
-    onremoved = function()
-      if svo.dict.unknowncrippledlimb.count &lt;= 0 then return end
-
-      svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count - 1
-      if svo.dict.unknowncrippledlimb.count &lt;= 0 then return end
-      svo.addaffdict(svo.dict.unknowncrippledlimb)
-      svo.updateaffcount(svo.dict.unknowncrippledlimb)
-    end,
-  },
-  unknowncrippledarm = {
-    count = 0,
-    salve = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (affs.unknowncrippledarm and not (affs.mutilatedrightarm or affs.mutilatedleftarm or affs.mangledleftarm or affs.mangledrightarm or affs.parestoarms)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('unknowncrippledarm')
-      end,
-
-      actions = {"apply mending to arms", "apply mending", "apply renewal to arms", "apply renewal"},
-      applycure = {'mending', 'renewal'},
-      onstart = function()
-        svo.apply(svo.dict.unknowncrippledarm.salve, " to arms")
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.noeffect_mending_arms()
-      end,
-
-      fizzled = function (limb)
-        svo.lostbal_salve()
-        if limb and svo.dict['mangled'..limb] then svo.addaffdict(svo.dict['mangled'..limb]) end
-      end,
-    },
-    aff = {
-      oncompleted = function (amount)
-        svo.dict.unknowncrippledarm.count = svo.dict.unknowncrippledarm.count + (amount or 1)
-        if svo.dict.unknowncrippledarm.count &gt; 2 then svo.dict.unknowncrippledarm.count = 2 end
-        svo.addaffdict(svo.dict.unknowncrippledarm)
-        svo.updateaffcount(svo.dict.unknowncrippledarm)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.dict.unknowncrippledarm.count = 0
-        svo.rmaff('unknowncrippledarm')
-      end,
-    },
-    onremoved = function()
-      if svo.dict.unknowncrippledarm.count &lt;= 0 then return end
-
-      svo.dict.unknowncrippledarm.count = svo.dict.unknowncrippledarm.count - 1
-      if svo.dict.unknowncrippledarm.count &lt;= 0 then return end
-      svo.addaffdict(svo.dict.unknowncrippledarm)
-      svo.updateaffcount(svo.dict.unknowncrippledarm)
-    end,
-  },
-  unknowncrippledleg = {
-    count = 0,
-    salve = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (affs.unknowncrippledleg and not (affs.mutilatedrightleg or affs.mutilatedleftleg or affs.mangledleftleg or affs.mangledrightleg or affs.parestolegs)) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        svo.rmaff('unknowncrippledleg')
-      end,
-
-      actions = {"apply mending to legs", "apply mending", "apply renewal to legs", "apply renewal"},
-      applycure = {'mending', 'renewal'},
-      onstart = function()
-        svo.apply(svo.dict.unknowncrippledleg.salve, " to legs")
-      end,
-
-      noeffect = function()
-        svo.lostbal_salve()
-        empty.noeffect_mending_legs()
-      end,
-
-      fizzled = function (limb)
-        svo.lostbal_salve()
-        if limb and svo.dict['mangled'..limb] then svo.addaffdict(svo.dict['mangled'..limb]) end
-      end,
-    },
-    aff = {
-      oncompleted = function (amount)
-        svo.dict.unknowncrippledleg.count = svo.dict.unknowncrippledleg.count + (amount or 1)
-        if svo.dict.unknowncrippledleg.count &gt; 2 then svo.dict.unknowncrippledleg.count = 2 end
-        svo.addaffdict(svo.dict.unknowncrippledleg)
-        svo.updateaffcount(svo.dict.unknowncrippledleg)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.dict.unknowncrippledleg.count = 0
-        svo.rmaff('unknowncrippledleg')
-      end,
-    },
-    onremoved = function()
-      if svo.dict.unknowncrippledleg.count &lt;= 0 then return end
-
-      svo.dict.unknowncrippledleg.count = svo.dict.unknowncrippledleg.count - 1
-      if svo.dict.unknowncrippledleg.count &lt;= 0 then return end
-      svo.addaffdict(svo.dict.unknowncrippledleg)
-      svo.updateaffcount(svo.dict.unknowncrippledleg)
-    end,
-  },
-  unknowncure = {
-    count = 0,
-    waitingfor = {
-      customwait = 999,
-
-      onstart = function() end,
-
-      empty = function() end
-    },
-    aff = {
-      oncompleted = function (number)
-        local count = svo.dict.unknowncure.count
-        svo.addaffdict(svo.dict.unknowncure)
-
-        svo.dict.unknowncure.count = (count or 0) + (number or 1)
-        svo.updateaffcount(svo.dict.unknowncure)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('unknowncure')
-        svo.dict.unknowncure.count = 0
-      end
-    }
-  },
-
-
--- writhes
-  bound = {
-    misc = {
-      dontbatch = true,
-
-      isadvisable = function()
-        return (affs.bound and codepaste.writhe()) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.curingbound.waitingfor)
-      end,
-
-      action = 'writhe',
-      onstart = function() send('writhe', conf.commandecho) end,
-
-      helpless = function()
-        empty.writhe()
-      end,
-
-      impale = function()
-        svo.doaction(svo.dict.curingimpale.waitingfor)
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.bound)
-        signals.canoutr:emit()
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('bound') end,
-    },
-    onremoved = function() signals.canoutr:emit() end
-  },
-  curingbound = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function() svo.rmaff('bound') end,
-
-      onstart = function() end
-    }
-  },
-  webbed = {
-    misc = {
-      dontbatch = true,
-
-      isadvisable = function()
-        return (affs.webbed and codepaste.writhe() and not (bals.balance and bals.rightarm and bals.leftarm and svo.dict.dragonflex.misc.isadvisable()) and (not svo.haveskillset('voicecraft') or (not conf.dwinnu or not svo.dict.dwinnu.misc.isadvisable()))) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.curingwebbed.waitingfor)
-      end,
-
-      action = 'writhe',
-      onstart = function()
-        if math.random(1, 30) == 1 then
-          send("writhe wiggle wiggle", conf.commandecho)
-        else
-          send('writhe', conf.commandecho)
-        end
-      end,
-
-      helpless = function()
-        empty.writhe()
-      end,
-
-      impale = function()
-        svo.doaction(svo.dict.curingimpale.waitingfor)
-      end
-    },
-    aff = {
-      oncompleted = function()
-        affs.webbed = nil
-        svo.addaffdict(svo.dict.webbed)
-        signals.canoutr:emit()
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('webbed') end,
-    },
-    onremoved = function() signals.canoutr:emit() svo.donext() end
-  },
-  curingwebbed = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function() svo.rmaff('webbed') end,
-
-      onstart = function() end
-    }
-  },
-  roped = {
-    misc = {
-      dontbatch = true,
-
-      isadvisable = function()
-        return (affs.roped and codepaste.writhe() and not (bals.balance and bals.rightarm and bals.leftarm and svo.dict.dragonflex.misc.isadvisable()) and (not svo.haveskillset('voicecraft') or (not conf.dwinnu or not svo.dict.dwinnu.misc.isadvisable()))) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.curingroped.waitingfor)
-      end,
-
-      action = 'writhe',
-      onstart = function() send('writhe', conf.commandecho) end,
-
-      helpless = function()
-        empty.writhe()
-      end,
-
-      impale = function()
-        svo.doaction(svo.dict.curingimpale.waitingfor)
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.roped)
-        signals.canoutr:emit()
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('roped') end,
-    },
-    onremoved = function() signals.canoutr:emit() svo.donext() end
-  },
-  curingroped = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function() svo.rmaff('roped') end,
-
-      onstart = function() end
-    }
-  },
-  hoisted = {
-    misc = {
-      dontbatch = true,
-      uncurable = true,
-
-      isadvisable = function()
-        return (affs.hoisted and codepaste.writhe() and bals.balance and bals.rightarm and bals.leftarm) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.curinghoisted.waitingfor)
-      end,
-
-      action = 'writhe',
-      onstart = function() send('writhe', conf.commandecho) end,
-
-      helpless = function()
-        empty.writhe()
-      end,
-
-      impale = function()
-        svo.doaction(svo.dict.curingimpale.waitingfor)
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.hoisted)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('hoisted') end,
-    }
-  },
-  curinghoisted = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function() svo.rmaff('hoisted') end,
-
-      onstart = function() end
-    }
-  },
-  transfixed = {
-    gamename = 'transfixation',
-    misc = {
-      dontbatch = true,
-
-      isadvisable = function()
-        return (affs.transfixed and codepaste.writhe()) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.curingtransfixed.waitingfor)
-      end,
-
-      action = 'writhe',
-      onstart = function() send('writhe', conf.commandecho) end,
-
-      helpless = function()
-        empty.writhe()
-      end,
-
-      impale = function()
-        svo.doaction(svo.dict.curingimpale.waitingfor)
-      end
-    },
-    aff = {
-      oncompleted = function()
-        if not conf.aillusion or ((not affs.blindaff and not defc.blind) or svo.lifevision.l.blindaff_aff or svo.lifevision.l.blind_herb or svo.lifevision.l.blind_misc) then
-          svo.affsp.transfixed = nil
-          svo.addaffdict(svo.dict.transfixed)
-        end
-
-        signals.canoutr:emit()
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('transfixed') end,
-    },
-    onremoved = function() signals.canoutr:emit() svo.donext() end
-  },
-  curingtransfixed = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function() svo.rmaff('transfixed') end,
-
-      onstart = function() end
-    }
-  },
-  impale = {
-    gamename = 'impaled',
-    misc = {
-      dontbatch = true,
-
-
-      isadvisable = function()
-        return (affs.impale and not svo.doingaction('curingimpale') and not svo.doingaction('impale') and bals.balance and bals.rightarm and bals.leftarm) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.curingimpale.waitingfor)
-      end,
-
-      action = 'writhe',
-      onstart = function() send('writhe', conf.commandecho) end,
-
-      helpless = function()
-        empty.writhe()
-      end,
-
-      dragged = function() svo.rmaff('impale') end,
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.impale)
-        signals.canoutr:emit()
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('impale') end,
-    },
-    onremoved = function() signals.canoutr:emit() end
-  },
-  curingimpale = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function() svo.rmaff('impale') end,
-
-      withdrew = function() svo.rmaff('impale') end,
-
-      dragged = function() svo.rmaff('impale') end,
-
-      onstart = function() end
-    }
-  },
-  dragonflex = {
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (conf.dragonflex and ((affs.webbed and not svo.ignore.webbed) or (affs.roped and not svo.ignore.roped)) and codepaste.writhe() and not affs.paralysis and defc.dragonform and bals.balance and not svo.doingaction'impale') or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff{'webbed', 'roped'}
-      end,
-
-      action = 'dragonflex',
-      onstart = function() send('dragonflex', conf.commandecho) end
-    },
-  },
-
-  -- anti-illusion checks, grouped by symptom similarity
-  checkslows = {
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (next(svo.affsp) and (svo.affsp.retardation or svo.affsp.aeon or svo.affsp.truename)) or false
-      end,
-
-      oncompleted = function() end,
-
-      sluggish = function()
-        if svo.affsp.retardation then
-          svo.affsp.retardation = nil
-          svo.addaffdict(svo.dict.retardation)
-          signals.newroom:unblock(sk.check_retardation)
-        elseif svo.affsp.aeon then
-          svo.affsp.aeon = nil
-
-          svo.addaffdict(svo.dict.aeon)
-          defences.lost('speed')
+    impatience = {
+      herb = {
+        isadvisable = function()
+          -- curing impatience before hypochondria will make it get re-applied
+          return (affs.impatience and not affs.madness and not svo.usingbal('focus')  and not affs.hypochondria) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('impatience')
+          svo.lostbal_herb()
+  
+          -- if serverside cures impatience before we can even validate it, cancel it
+          svo.affsp.impatience = nil
+          svo.killaction(svo.dict.checkimpatience.misc)
+        end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+        onstart = function() svo.eat(svo.dict.impatience.herb) end,
+  
+        empty = function() empty.eat_goldenseal() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.impatience)
           signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        elseif svo.affsp.truename then
-          svo.affsp.truename = nil
-
-          svo.addaffdict(svo.dict.aeon)
-          defences.lost('speed')
-          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        end
-
-        sk.checkaeony()
-        signals.changecuring:emit()
-        codepaste.badaeon()
-      end,
-
-      onclear = function()
-        if svo.affsp.retardation then
-          svo.affsp.retardation = nil
-        elseif svo.affsp.aeon then
-          svo.affsp.aeon = nil
-        elseif svo.affsp.truename then
-          svo.affsp.truename = nil
-        end
-      end,
-
-      onstart = function()
-        send('say', false)
-      end
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('impatience') end,
+      }
     },
-    aff = {
-      notagameaff = true,
-      oncompleted = function (which)
-      if svo.paragraph_length &gt; 2 or svo.ignore.checkslows then
-          if which == 'truename' then which = 'aeon' end
-
-          svo.addaffdict(svo.dict[which])
-          svo.killaction(svo.dict.checkslows.misc)
-
-          if which == 'aeon' then defences.lost('speed') end
-          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-
-          sk.checkaeony()
-          signals.changecuring:emit()
+    stupidity = {
+      herb = {
+        isadvisable = function()
+          return (affs.stupidity and
+            not svo.doingaction('stupidity') and not svo.usingbal('focus')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('stupidity')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+        onstart = function() svo.eat(svo.dict.stupidity.herb) end,
+  
+        empty = function() empty.eat_goldenseal() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.stupidity and
+            not svo.doingaction('stupidity') and not affs.madness) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('stupidity')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.stupidity)
+          sk.stupidity_count = 0
           codepaste.badaeon()
-
-          if which == 'retardation' then
-            signals.newroom:unblock(sk.check_retardation)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('stupidity')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    crushedthroat = {
+      salve = {
+        isadvisable = function()
+          return affs.crushedthroat or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('crushedthroat')
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.apply_mending_head()
+        end,
+  
+        empty = function()
+          empty.apply_mending_head()
+        end,
+  
+        applycure = {'mending'},
+        actions = {"apply mending to head"},
+        onstart = function()
+          svo.apply(svo.dict.crushedthroat.salve, " to head")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.crushedthroat)
+          sk.crushedthroat_count = 0
+          codepaste.badaeon()
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('crushedthroat')
+        end,
+      }
+    },
+    guilt = {
+      herb = {
+        isadvisable = function()
+          return (affs.guilt and
+            not svo.doingaction('guilt')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('guilt')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'lobelia', 'argentum'},
+        onstart = function() svo.eat(svo.dict.guilt.herb) end,
+  
+        empty = function() empty.eat_lobelia() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.guilt)
+          sk.guilt_count = 0
+          codepaste.badaeon()
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('guilt')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    tenderskin = {
+      herb = {
+        isadvisable = function()
+          return (affs.tenderskin and
+            not svo.doingaction('tenderskin')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('tenderskin')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'lobelia', 'argentum'},
+        onstart = function() svo.eat(svo.dict.tenderskin.herb) end,
+  
+        empty = function() empty.eat_lobelia() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.tenderskin)
+          sk.tenderskin_count = 0
+          codepaste.badaeon()
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('tenderskin')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    spiritburn = {
+      herb = {
+        isadvisable = function()
+          return (affs.spiritburn and
+            not svo.doingaction('spiritburn')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('spiritburn')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'lobelia', 'argentum'},
+        onstart = function() svo.eat(svo.dict.spiritburn.herb) end,
+  
+        empty = function() empty.eat_lobelia() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.spiritburn)
+          sk.spiritburn_count = 0
+          codepaste.badaeon()
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('spiritburn')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    masochism = {
+      herb = {
+        isadvisable = function()
+          return (affs.masochism and not affs.madness and
+            not svo.doingaction('masochism')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('masochism')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'lobelia', 'argentum'},
+        onstart = function() svo.eat(svo.dict.masochism.herb) end,
+  
+        empty = function() empty.eat_lobelia() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.masochism and not affs.madness and
+            not svo.doingaction('masochism')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('masochism')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.masochism)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('masochism')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    recklessness = {
+      herb = {
+        isadvisable = function()
+          return (affs.recklessness and not affs.madness and
+            not svo.doingaction('recklessness')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('recklessness')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'lobelia', 'argentum'},
+        onstart = function() svo.eat(svo.dict.recklessness.herb) end,
+  
+        empty = function() empty.eat_lobelia() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.recklessness and not affs.madness and
+            not svo.doingaction('recklessness')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('recklessness')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function (data)
+          if data and data.attacktype and data.attacktype == 'domination' and (data.atline+1 == getLastLineNumber('main')
+            or (data.atline+1 == getLastLineNumber('main') and
+              svo.find_until_last_paragraph("The gremlin races between your legs, throwing you off-balance.", 'exact'))) then
+            svo.addaffdict(svo.dict.recklessness)
+          elseif not conf.aillusion or
+            (stats.maxhealth == stats.currenthealth and stats.maxmana == stats.currentmana) then
+            svo.addaffdict(svo.dict.recklessness)
           end
-        else
-          svo.affsp[which] = true
+        end,
+  
+        -- used for addaff to skip all checks
+        forced = function()
+          svo.addaffdict(svo.dict.recklessness)
         end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('recklessness')
+          codepaste.remove_focusable()
+        end,
+      },
+      onremoved = function()
+        svo.check_generics()
+        if not affs.blackout then
+          svo.killaction(svo.dict.nomana.waitingfor)
+        end
+        signals.before_prompt_processing:block(svo.valid.check_recklessness)
       end,
-
-      truename = function()
-        svo.affsp.truename = true
+      onadded = function()
+        signals.before_prompt_processing:unblock(svo.valid.check_recklessness)
       end,
     },
-  },
-
-  checkanorexia = {
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (svo.affsp.anorexia) or false
-      end,
-
-      oncompleted = function() end,
-
-      blehfood = function()
-        svo.addaffdict(svo.dict.anorexia)
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        svo.affsp.anorexia = nil
-      end,
-
-      onclear = function()
-        svo.affsp.anorexia = nil
-      end,
-
-      onstart = function()
-        send("eat something", false)
-      end
+    justice = {
+      herb = {
+        isadvisable = function()
+          return (affs.justice and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity') or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('justice')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'bellwort', 'cuprum'},
+        onstart = function() svo.eat(svo.dict.justice.herb) end,
+  
+        empty = function() empty.eat_bellwort() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.justice)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('justice') end,
+      }
     },
-    aff = {
-      notagameaff = true,
-      oncompleted = function()
-        if svo.paragraph_length &gt; 2 then
-          svo.addaffdict(svo.dict.anorexia)
+    generosity = {
+      herb = {
+        isadvisable = function()
+          return (affs.generosity and
+            not svo.doingaction('generosity') and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity')or svo.haveskillset('valour')) or not svo.dict.rage.misc.isadvisable())) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('generosity')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'bellwort', 'cuprum'},
+        onstart = function() svo.eat(svo.dict.generosity.herb) end,
+  
+        empty = function() empty.eat_bellwort() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.generosity and
+            not svo.doingaction('generosity') and (not (svo.haveskillset('discipline') or svo.haveskillset('malignity')or svo.haveskillset('valour') or svo.haveskillset('dominion')) or not svo.dict.rage.misc.isadvisable())) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('generosity')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.generosity)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('generosity')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    weakness = {
+      gamename = 'weariness',
+      herb = {
+        isadvisable = function()
+          return (affs.weakness and
+            not svo.doingaction('weakness')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('weakness')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'kelp', 'aurum'},
+        onstart = function() svo.eat(svo.dict.weakness.herb) end,
+  
+        empty = function() empty.eat_kelp() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.weakness)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('weakness')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    vertigo = {
+      herb = {
+        isadvisable = function()
+          return (affs.vertigo and not affs.madness and
+            not svo.doingaction('vertigo')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('vertigo')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'lobelia', 'argentum'},
+        onstart = function() svo.eat(svo.dict.vertigo.herb) end,
+  
+        empty = function() empty.eat_lobelia() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.vertigo and not affs.madness and
+            not svo.doingaction('vertigo')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('vertigo')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.vertigo)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('vertigo')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    loneliness = {
+      herb = {
+        isadvisable = function()
+          return (affs.loneliness and not affs.madness and not svo.doingaction('loneliness')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('loneliness')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'lobelia', 'argentum'},
+        onstart = function() svo.eat(svo.dict.loneliness.herb) end,
+  
+        empty = function() empty.eat_lobelia() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.loneliness and not affs.madness and not svo.doingaction('loneliness')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('loneliness')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.loneliness)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('loneliness')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    dementia = {
+      herb = {
+        isadvisable = function()
+          return (affs.dementia and not affs.madness and not svo.doingaction('dementia')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('dementia')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ash', 'stannum'},
+        onstart = function() svo.eat(svo.dict.dementia.herb) end,
+  
+        empty = function() empty.eat_ash() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.dementia and not affs.madness and not svo.doingaction('dementia')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('dementia')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.dementia)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('dementia') end,
+      }
+    },
+    paranoia = {
+      herb = {
+        isadvisable = function()
+          return (affs.paranoia and not affs.madness and not svo.doingaction('paranoia')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('paranoia')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ash', 'stannum'},
+        onstart = function() svo.eat(svo.dict.paranoia.herb) end,
+  
+        empty = function() empty.eat_ash() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.paranoia and not affs.madness and not svo.doingaction('paranoia')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('paranoia')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.paranoia)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('paranoia') end,
+      }
+    },
+    hypersomnia = {
+      herb = {
+        isadvisable = function()
+          return (affs.hypersomnia and not affs.madness) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('hypersomnia')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ash', 'stannum'},
+        onstart = function() svo.eat(svo.dict.hypersomnia.herb) end,
+  
+        empty = function() empty.eat_ash() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.hypersomnia)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('hypersomnia') end,
+      }
+    },
+    hallucinations = {
+      herb = {
+        isadvisable = function()
+          return (affs.hallucinations and not affs.madness and not svo.doingaction('hallucinations')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('hallucinations')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ash', 'stannum'},
+        onstart = function() svo.eat(svo.dict.hallucinations.herb) end,
+  
+        empty = function() empty.eat_ash() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.hallucinations and not affs.madness and not svo.doingaction('hallucinations')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('hallucinations')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.hallucinations)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('hallucinations') end,
+      }
+    },
+    confusion = {
+      herb = {
+        isadvisable = function()
+          return (affs.confusion and
+            not svo.doingaction('confusion') and not affs.madness) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('confusion')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ash', 'stannum'},
+        onstart = function() svo.eat(svo.dict.confusion.herb) end,
+  
+        empty = function() empty.eat_ash() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.confusion and
+            not svo.doingaction('confusion') and not affs.madness) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('confusion')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.confusion)
           signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-          svo.killaction(svo.dict.checkanorexia.misc)
-        else
-          svo.affsp.anorexia = true
-        end
-      end
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('confusion')
+          codepaste.remove_focusable()
+        end,
+      }
     },
-  },
-
-  checkparalysis = {
-    description = "anti-illusion check for paralysis",
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return false -- hardcoded to be off, as there's no known solution currently that works
-        --return (svo.affsp.paralysis and not affs.sleep and (not conf.waitparalysisai or (bals.balance and bals.equilibrium)) and not affs.roped) or false
-      end,
-
-      oncompleted = function() end,
-
-      paralysed = function()
-        svo.addaffdict(svo.dict.paralysis)
-
-        if svo.dict.relapsing.saw_with_checkable == 'paralysis' then
-          svo.dict.relapsing.saw_with_checkable = nil
-          svo.addaffdict(svo.dict.relapsing)
+    agoraphobia = {
+      herb = {
+        isadvisable = function()
+          return (affs.agoraphobia and
+            not svo.doingaction('agoraphobia')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('agoraphobia')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'lobelia', 'argentum'},
+        onstart = function() svo.eat(svo.dict.agoraphobia.herb) end,
+  
+        empty = function() empty.eat_lobelia() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.agoraphobia and
+            not svo.doingaction('agoraphobia')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('agoraphobia')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
         end
-
-        if type(svo.affsp.paralysis) == 'string' then
-          svo.addaffdict(svo.dict[svo.affsp.paralysis])
-        end
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-
-        svo.affsp.paralysis = nil
-      end,
-
-      onclear = function()
-        svo.affsp.paralysis = nil
-      end,
-
-      onstart = function()
-        send("fling paralysis", false)
-      end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.agoraphobia)
+          codepaste.remove_focusable()
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('agoraphobia') end,
+      }
     },
-    aff = {
-      notagameaff = true,
-      oncompleted = function (withaff) -- ie, 'darkshade' - add the additional aff if we have paralysis
-        -- disabled, as fling no longer works and illusions are not so prevalent
-        if true then
-        -- if svo.paragraph_length &gt; 2 or (not (bals.balance and bals.equilibrium) and not conf.waitparalysisai) then -- if it's not an illusion for sure, or if we have waitparalysisai off and don't have both balance/eq, accept it as paralysis right now
+    claustrophobia = {
+      herb = {
+        isadvisable = function()
+          return (affs.claustrophobia and
+            not svo.doingaction('claustrophobia')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('claustrophobia')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'lobelia', 'argentum'},
+        onstart = function() svo.eat(svo.dict.claustrophobia.herb) end,
+  
+        empty = function() empty.eat_lobelia() end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.claustrophobia and
+            not svo.doingaction('claustrophobia')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('claustrophobia')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.claustrophobia)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('claustrophobia')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    paralysis = {
+      herb = {
+        isadvisable = function()
+          return (affs.paralysis) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('paralysis')
+          svo.lostbal_herb()
+          svo.killaction(svo.dict.checkparalysis.misc)
+        end,
+  
+        eatcure = {'bloodroot', 'magnesium'},
+        onstart = function() svo.eat(svo.dict.paralysis.herb) end,
+  
+        empty = function() empty.eat_bloodroot() end
+      },
+      aff = {
+        oncompleted = function()
           svo.addaffdict(svo.dict.paralysis)
           signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-          svo.killaction(svo.dict.checkparalysis.misc)
-          if withaff then svo.addaffdict(svo.dict[withaff]) end
-        -- else -- else, it gets added to be checked later if we have waitparalysisai on and don't have balance or eq
-        --   svo.affsp.paralysis = withaff or true
-        end
-      end
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('paralysis') end,
+      },
+      onremoved = function() svo.affsp.paralysis = nil svo.donext() end
     },
-  },
-
-  checkimpatience = {
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (svo.affsp.impatience and not affs.sleep and bals.focus and conf.focus) or false
-      end,
-
-      oncompleted = function() end,
-
-      impatient = function()
-        if not affs.impatience then
-          svo.addaffdict(svo.dict.impatience)
-          svo.echof("Looks like the impatience is real.")
-        end
-
-        svo.affsp.impatience = nil
-      end,
-
-      -- if serverside cures impatience before we can even validate it, cancel it
-      oncancel = function()
-        svo.affsp.impatience = nil
-        svo.killaction(svo.dict.checkimpatience.misc)
-      end,
-
-      onclear = function()
-        if svo.affsp.impatience then
-          svo.lostbal_focus()
-          if svo.affsp.impatience ~= 'quiet' then
-            svo.echof("The impatience earlier was actually an illusion, ignoring it.")
-          end
-          svo.affsp.impatience = nil
-        end
-      end,
-
-      onstart = function()
-        send('focus', false)
-      end
-    },
-    aff = {
-      notagameaff = true,
-      oncompleted = function (option)
-        if svo.paragraph_length &gt; 2 then
-          svo.addaffdict(svo.dict.impatience)
-          svo.killaction(svo.dict.checkimpatience.misc)
-        else
-          svo.affsp.impatience = option and option or true
-        end
-      end
-    },
-  },
-
-  checkasthma = {
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (svo.affsp.asthma and conf.breath and bals.balance and bals.equilibrium) or false
-      end,
-
-      oncompleted = function() end,
-
-      weakbreath = function()
-        svo.addaffdict(svo.dict.asthma)
-        local r = svo.findbybal('smoke')
-        if r then
-          svo.killaction(svo.dict[r.action_name].smoke)
-        end
-
-        if svo.dict.relapsing.saw_with_checkable == 'asthma' then
-          svo.dict.relapsing.saw_with_checkable = nil
-          svo.addaffdict(svo.dict.relapsing)
-        end
-
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        svo.affsp.asthma = nil
-        codepaste.badaeon()
-      end,
-
-      onclear = function()
-        svo.affsp.asthma = nil
-      end,
-
-      onstart = function() send('hold breath', conf.commandecho) end
-    },
-    smoke = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (svo.affsp.asthma and not svo.dict.checkasthma.misc.isadvisable() and codepaste.smoke_valerian_pipe()) or false
-      end,
-
-      oncompleted = function() svo.lostbal_smoke() end,
-
-      badlungs = function()
-        svo.addaffdict(svo.dict.asthma)
-        local r = svo.findbybal('smoke')
-        if r then
-          svo.killaction(svo.dict[r.action_name].smoke)
-        end
-
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-        svo.affsp.asthma = nil
-      end,
-
-      -- mucous can hit when we aren't even afflicted, so it's moot. Have to wait for it to clear up
-      mucous = function() end,
-
-      onclear = function()
-        svo.affsp.asthma = nil
-        svo.lostbal_smoke()
-      end,
-
-      empty = function()
-        svo.affsp.asthma = nil
-        svo.lostbal_smoke()
-      end,
-
-      smokecure = {'valerian', 'realgar'},
-      onstart = function()
-        send("smoke " .. pipes.valerian.id, conf.commandecho)
-      end
-    },
-    aff = {
-      notagameaff = true,
-      oncompleted = function (oldhp)
-      if svo.paragraph_length &gt; 2 or (oldhp and stats.currenthealth &lt; oldhp) or (svo.paragraph_length == 2 and svo.find_until_last_paragraph("aura of weapons rebounding disappears", 'substring')) then
+    asthma = {
+      herb = {
+        isadvisable = function()
+          return (affs.asthma) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('asthma')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'kelp', 'aurum'},
+        onstart = function() svo.eat(svo.dict.asthma.herb) end,
+  
+        empty = function() empty.eat_kelp() end
+      },
+      aff = {
+        oncompleted = function()
           svo.addaffdict(svo.dict.asthma)
           local r = svo.findbybal('smoke')
           if r then
             svo.killaction(svo.dict[r.action_name].smoke)
           end
-
-          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-          svo.killaction(svo.dict.checkasthma.misc)
-
-          -- if we were checking and we got a verified aff, kill verification
-          if svo.actions.checkasthma_smoke then
-            svo.killaction(svo.dict.checkasthma.smoke)
-          end
-        else
-          svo.affsp.asthma = true
-        end
-      end
-    },
-  },
-
-  checkhypersomnia = {
-    description = "anti-illusion check for hypersomnia",
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (svo.affsp.hypersomnia and not affs.sleep) or false
-      end,
-
-      oncompleted = function() end,
-
-      hypersomnia = function()
-        svo.addaffdict(svo.dict.hypersomnia)
-
-        svo.affsp.hypersomnia = nil
-      end,
-
-      onclear = function()
-        svo.affsp.hypersomnia = nil
-      end,
-
-      onstart = function() send('insomnia', conf.commandecho) end
-    },
-    aff = {
-      notagameaff = true,
-      oncompleted = function()
-        -- can't check hypersomnia with insomina up - it'll give the insomnia
-        -- def line
-        if svo.paragraph_length &gt; 2 or defc.insomnia then
-          svo.addaffdict(svo.dict.hypersomnia)
-          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-          svo.killaction(svo.dict.checkhypersomnia.misc)
-        else
-          svo.affsp.hypersomnia = true
-        end
-      end
-    },
-  },
-
-  checkstun = {
-    templifevision = false, -- stores the lifevision actions that will be wiped until confirmed
-    tempactions = false, -- stores the actions queue items that will be wiped until confirmed
-    time = 0,
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (svo.affsp.stun) or false
-      end,
-
-      oncompleted = function (data)
-        -- 'fromstun' is given to us if we just had started checking for stun with checkstun_misc, and stun wore off before we could finish - for this rare scenario, we complete checkstun
-        if data ~= 'fromstun' then svo.dict.stun.aff.oncompleted(svo.dict.checkstun.time) end
-        svo.dict.checkstun.time = 0
-        svo.affsp.stun = nil
-        tempTimer(0, function()
-          if not svo.dict.checkstun.templifevision then return end
-
-          svo.lifevision.l = deepcopy(svo.dict.checkstun.templifevision)
-          svo.dict.checkstun.templifevision = nil
-
-          if svo.lifevision.l.checkstun_aff then
-            svo.lifevision.l:set('checkstun_aff', nil)
-          end
-
-          for k,v in svo.dict.checkstun.tempactions:iter() do
-            if svo.actions[k] then
-              svo.debugf("%s already exists, overwriting it", k)
-            else
-              svo.debugf("re-added %s", k)
-            end
-
-            svo.actions[k] = v
-          end
-
-          svo.dict.checkstun.tempactions = nil
-          svo.send_in_the_gnomes()
-        end)
-      end,
-
-      onclear = function()
-        svo.affsp.stun = nil
-        svo.dict.checkstun.templifevision = nil
-        svo.dict.checkstun.tempactions = nil
-      end,
-
-      onstart = function()
-        send("eat something", false)
-      end
-    },
-    aff = {
-      -- this is an affliction for svo's purposes, but not in the game. Although it would be best if the 'aff' balance was replaced with something else
-      notagameaff = true,
-      oncompleted = function (num)
-      if svo.paragraph_length &gt; 2 then
-          svo.dict.stun.aff.oncompleted()
-          svo.killaction(svo.dict.checkstun.misc)
-        elseif not affs.sleep and not conf.paused then -- let autodetection take care of after we wake up. otherwise, a well timed stun &amp; stun symptom on awake can trick us. if paused, let it through as well, because we don't want to kill affs
-          svo.affsp.stun = true
-          svo.dict.checkstun.time = num
-          svo.dict.checkstun.templifevision = deepcopy(svo.lifevision.l)
-          svo.dict.checkstun.tempactions = deepcopy(svo.actions)
-          sk.stopprocessing = true
-        end
-      end
-    },
-  },
-
-  checkwrithes = {
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (next(svo.affsp) and ((svo.affsp.impale and not affs.transfixed and not affs.webbed and not affs.roped) or (svo.affsp.webbed and not affs.transfixed and not affs.roped) or svo.affsp.transfixed)) or false
-      end,
-
-      oncompleted = function() end,
-
-      webbily = function()
-        svo.affsp.webbed = nil
-        svo.addaffdict(svo.dict.webbed)
-        signals.canoutr:emit()
-      end,
-
-      impaly = function()
-        svo.affsp.impale = nil
-        svo.addaffdict(svo.dict.impale)
-        signals.canoutr:emit()
-      end,
-
-      transfixily = function()
-        svo.affsp.transfixed = nil
-        svo.addaffdict(svo.dict.transfixed)
-        signals.canoutr:emit()
-      end,
-
-      onclear = function()
-        svo.affsp.impale = nil
-        svo.affsp.webbed = nil
-        svo.affsp.transfixed = nil
-      end,
-
-      onstart = function()
-        send('outr', false)
-      end
-    },
-    aff = {
-      notagameaff = true,
-      oncompleted = function (which)
-        if svo.paragraph_length &gt; 2 then
-          svo.addaffdict(svo.dict[which])
-          svo.killaction(svo.dict.checkwrithes.misc)
-        else
-          svo.affsp[which] = true
-        end
-      end,
-
-      impale = function (oldhp)
-        if (oldhp and stats.currenthealth &lt; oldhp) then
-          svo.addaffdict(svo.dict.impale)
-          signals.canoutr:emit()
-        else
-          svo.affsp.impale = true
-        end
-      end
-    }
-  },
-  amnesia = {
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (affs.amnesia) or false
-      end,
-
-      oncompleted = function() end,
-
-      onstart = function()
-        send("touch stuff", conf.commandecho)
-        svo.rmaff('amnesia')
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.amnesia)
-
-        -- cancel what we were doing, do it again
-        if sys.sync then
-          local result
-          for balance,actions in pairs(svo.bals_in_use) do
-            if balance ~= 'waitingfor' and balance ~= 'gone' and balance ~= 'aff' and next(actions) then result = select(2, next(actions)) break end
-          end
-          if result then
-            svo.killaction(svo.dict[result.action_name][result.balance])
-          end
-
-          svo.conf.send_bypass = true
-          send("touch stuff", conf.commandecho)
-          svo.conf.send_bypass = false
-        end
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('amnesia') end,
-    }
-  },
-
-  -- uncurable
-  stun = {
-    waitingfor = {
-      customwait = 1,
-
-      isadvisable = function()
-        return false
-      end,
-
-      ontimeout = function()
-        svo.rmaff('stun')
-
-        if svo.dict.checkstun.templifevision then
-          svo.debugf("stun timed out = restoring checkstun lifevisions")
-          svo.dict.checkstun.misc.oncompleted('fromstun')
-          svo.make_gnomes_work()
-        end
-
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('stun')
-
-        if svo.dict.checkstun.templifevision then
-          svo.debugf("stun finished = restoring checkstun lifevisions")
-          svo.dict.checkstun.misc.oncompleted('fromstun')
-        end
-      end
-    },
-    aff = {
-      oncompleted = function (num)
-        if affs.stun then return end
-
-        svo.dict.stun.waitingfor.customwait = (num and num ~= 0) and num or 1
-        svo.addaffdict(svo.dict.stun)
-        svo.doaction(svo.dict.stun.waitingfor)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('stun')
-        svo.killaction(svo.dict.stun.waitingfor)
-      end,
-    },
-    onremoved = function() svo.donext() end
-  },
-  unconsciousness = {
-    waitingfor = {
-      customwait = 7,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      ontimeout = function()
-        svo.rmaff('unconsciousness')
-        svo.make_gnomes_work()
-      end,
-
-      oncompleted = function()
-        svo.rmaff('unconsciousness')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.unconsciousness)
-        if not svo.actions.unconsciousness_waitingfor then svo.doaction(svo.dict.unconsciousness.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('unconsciousness')
-        svo.killaction(svo.dict.unconsciousness.waitingfor)
-      end,
-    },
-    onremoved = function() svo.donext() end
-  },
-  swellskin = { -- eating any herb cures it
-    waitingfor = {
-      customwait = 999,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('swellskin')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.swellskin)
-        if not svo.actions.swellskin_waitingfor then svo.doaction(svo.dict.swellskin.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('swellskin')
-        svo.killaction(svo.dict.swellskin.waitingfor)
-      end,
-    }
-  },
-  pinshot = {
-    waitingfor = {
-      customwait = 20, -- lasts 18s
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      ontimeout = function()
-        svo.rmaff('pinshot')
-        svo.make_gnomes_work()
-      end,
-
-      oncompleted = function()
-        svo.rmaff('pinshot')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.pinshot)
-        if not svo.actions.pinshot_waitingfor then svo.doaction(svo.dict.pinshot.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('pinshot')
-        svo.killaction(svo.dict.pinshot.waitingfor)
-      end,
-    }
-  },
-  dehydrated = {
-    waitingfor = {
-      customwait = 45, -- lasts 45s
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      ontimeout = function()
-        svo.rmaff('dehydrated')
-        svo.make_gnomes_work()
-      end,
-
-      oncompleted = function()
-        svo.rmaff('dehydrated')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.dehydrated)
-        if not svo.actions.dehydrated_waitingfor then svo.doaction(svo.dict.dehydrated.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('dehydrated')
-        svo.killaction(svo.dict.dehydrated.waitingfor)
-      end,
-    }
-  },
-  timeflux = {
-    waitingfor = {
-      customwait = 50, -- lasts 50s
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      ontimeout = function()
-        svo.rmaff('timeflux')
-        svo.make_gnomes_work()
-      end,
-
-      oncompleted = function()
-        svo.rmaff('timeflux')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.timeflux)
-        if not svo.actions.timeflux_waitingfor then svo.doaction(svo.dict.timeflux.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('timeflux')
-        svo.killaction(svo.dict.timeflux.waitingfor)
-      end,
-    }
-  },
-  inquisition = {
-    waitingfor = {
-      customwait = 30, -- ??
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('inquisition')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.inquisition)
-        if not svo.actions.inquisition_waitingfor then svo.doaction(svo.dict.inquisition.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('inquisition')
-        svo.killaction(svo.dict.inquisition.waitingfor)
-      end,
-    }
-  },
-  lullaby = {
-    waitingfor = {
-      customwait = 45, -- takes 45s
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('lullaby')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.lullaby)
-        if not svo.actions.lullaby_waitingfor then svo.doaction(svo.dict.lullaby.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('lullaby')
-        svo.killaction(svo.dict.lullaby.waitingfor)
-      end,
-    }
-  },
-  corrupted = {
-    waitingfor = {
-      customwait = 999, -- time increases
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function() svo.rmaff('corrupted') end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.corrupted)
-        if not svo.actions.corrupted_waitingfor then svo.doaction(svo.dict.corrupted.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('corrupted')
-        svo.killaction(svo.dict.corrupted.waitingfor)
-      end,
-    }
-  },
-  mucous = {
-    waitingfor = {
-      customwait = 6,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function() svo.rmaff('mucous') end,
-
-      ontimeout = function()
-        svo.rmaff('mucous')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.mucous)
-        if not svo.actions.mucous_waitingfor then svo.doaction(svo.dict.mucous.waitingfor) end
-
-        local r = svo.findbybal('smoke')
-        if r then
-          svo.killaction(svo.dict[r.action_name].smoke)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('mucous')
-        svo.killaction(svo.dict.mucous.waitingfor)
-      end,
-    }
-  },
-  phlogistication = {
-    waitingfor = {
-      customwait = 999, -- time increases
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('phlogistication')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.phlogistication)
-        if not svo.actions.phlogistication_waitingfor then svo.doaction(svo.dict.phlogistication.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('phlogistication')
-        svo.killaction(svo.dict.phlogistication.waitingfor)
-      end,
-    }
-  },
-  vitrification = {
-    waitingfor = {
-      customwait = 999,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('vitrification')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.vitrification)
-        if not svo.actions.vitrification_waitingfor then svo.doaction(svo.dict.vitrification.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('vitrification')
-        svo.killaction(svo.dict.vitrification.waitingfor)
-      end,
-    }
-  },
-
-  icing = {
-    waitingfor = {
-      customwait = 30, -- ??
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('icing')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.icing)
-        if not svo.actions.icing_waitingfor then svo.doaction(svo.dict.icing.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('icing')
-        svo.killaction(svo.dict.icing.waitingfor)
-      end,
-    }
-  },
-  burning = {
-    waitingfor = {
-      customwait = 30, -- ??
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('burning')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.burning)
-        if not svo.actions.burning_waitingfor then svo.doaction(svo.dict.burning.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('burning')
-        svo.killaction(svo.dict.burning.waitingfor)
-      end,
-    }
-  },
-  latched = {
-    waitingfor = {
-      customwait = 20, -- not sure how this is cured yet exactly
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('latched')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.latched)
-        codepaste.badaeon()
-        if not svo.actions.latched_waitingfor then svo.doaction(svo.dict.latched.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('latched')
-        svo.killaction(svo.dict.latched.waitingfor)
-      end,
-    }
-  },
-  voided = {
-    waitingfor = {
-      customwait = 20, -- lasts 20s tops, 15s in some stances. out-times multiple pommelstrikes
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('voided')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.voided)
-        codepaste.badaeon()
-        if not svo.actions.voided_waitingfor then svo.doaction(svo.dict.voided.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('voided')
-        svo.killaction(svo.dict.voided.waitingfor)
-      end,
-    }
-  },
-  hamstring = {
-	  gamename = "hamstrung",
-    waitingfor = {
-      customwait = 10,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      ontimeout = function()
-        if affs.hamstring then
-          svo.rmaff('hamstring')
-          svo.echof("Hamstring should have worn off by now, removing it.")
-        end
-      end,
-
-      oncompleted = function()
-        svo.rmaff('hamstring')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.hamstring)
-        if not svo.actions.hamstring_waitingfor then svo.doaction(svo.dict.hamstring.waitingfor) end
-      end,
-
-      renew = function()
-        svo.addaffdict(svo.dict.hamstring)
-
-        -- hamstrings timer gets renewed on hit
-        if svo.actions.hamstring_waitingfor then
-          svo.killaction(svo.dict.hamstring.waitingfor)
-        end
-        svo.doaction(svo.dict.hamstring.waitingfor)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('hamstring')
-        svo.killaction(svo.dict.hamstring.waitingfor)
-      end,
-    }
-  },
-  galed = {
-    waitingfor = {
-      customwait = 10,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('galed')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.galed)
-        if not svo.actions.galed_waitingfor then svo.doaction(svo.dict.galed.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('galed')
-        svo.killaction(svo.dict.galed.waitingfor)
-      end,
-    }
-  },
-  rixil = {
-    -- will double the cooldown period of the next focus ability.
-    waitingfor = {
-      customwait = 999,
-
-      isadvisable = function()
-        return false
-      end,
-
-      ontimeout = function() end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('rixil')
-        svo.killaction(svo.dict.rixil.waitingfor)
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.rixil)
-        if svo.actions.rixil_waitingfor then svo.killaction(svo.dict.rixil.waitingfor) end
-        svo.doaction(svo.dict.rixil.waitingfor)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('rixil')
-        svo.killaction(svo.dict.rixil.waitingfor)
-      end,
-    }
-  },
-  hecate = {
-    waitingfor = {
-      customwait = 22, -- seems to last at least 18s per log
-
-      isadvisable = function()
-        return false
-      end,
-
-      ontimeout = function()
-        svo.rmaff('hecate')
-        svo.killaction(svo.dict.hecate.waitingfor)
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('hecate')
-        svo.killaction(svo.dict.hecate.waitingfor)
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.hecate)
-        if svo.actions.hecate_waitingfor then svo.killaction(svo.dict.hecate.waitingfor) end
-        svo.doaction(svo.dict.hecate.waitingfor)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('hecate')
-        svo.killaction(svo.dict.hecate.waitingfor)
-      end,
-    }
-  },
-  palpatar = {
-    waitingfor = {
-      customwait = 999,
-
-      isadvisable = function()
-        return false
-      end,
-
-      ontimeout = function() end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('palpatar')
-        svo.killaction(svo.dict.palpatar.waitingfor)
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.palpatar)
-        if svo.actions.palpatar_waitingfor then svo.killaction(svo.dict.palpatar.waitingfor) end
-        svo.doaction(svo.dict.palpatar.waitingfor)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('palpatar')
-        svo.killaction(svo.dict.palpatar.waitingfor)
-      end,
-    }
-  },
-  -- extends tree balance by 10s now
-  ninkharsag = {
-    waitingfor = {
-      customwait = 60, -- it lasts a minute
-
-      isadvisable = function()
-        return false
-      end,
-
-      ontimeout = function() svo.rmaff('ninkharsag') end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('ninkharsag')
-        svo.killaction(svo.dict.ninkharsag.waitingfor)
-      end,
-
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.ninkharsag)
-        if svo.actions.ninkharsag_waitingfor then svo.killaction(svo.dict.ninkharsag.waitingfor) end
-        svo.doaction(svo.dict.ninkharsag.waitingfor)
-      end,
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('ninkharsag')
-        svo.killaction(svo.dict.ninkharsag.waitingfor)
-      end,
-
-      -- anti-illusion-checked aff hiding. in 'gone' because 'aff' resets the timer with checkaction, waitingfor has some other effect
-      hiddencures = function (amount)
-        local curableaffs = svo.gettreeableaffs()
-
-        -- if we saw more ninkharsag lines than affs we've got, we can remove the affs safely
-        if amount &gt;= #curableaffs then
-          svo.rmaff(curableaffs)
-        else
-          -- otherwise add an unknown aff - so we eventually diagnose to see what is our actual aff status like.
-          -- this does mess with the aff counts, but it is better than not diagnosing ever.
-          codepaste.addunknownany()
-        end
-      end
-    }
-  },
-  cadmus = {
-    -- focusing will give one of: lethargy, clumsiness, haemophilia, healthleech, sensitivity, darkshade
-    waitingfor = {
-      customwait = 999,
-
-      isadvisable = function()
-        return false
-      end,
-
-      ontimeout = function() end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('cadmus')
-        svo.killaction(svo.dict.cadmus.waitingfor)
-      end
-    },
-    aff = {
-      -- oldmaxhp is an argument
-      oncompleted = function (_)
-        svo.addaffdict(svo.dict.cadmus)
-        if svo.actions.cadmus_waitingfor then svo.killaction(svo.dict.cadmus.waitingfor) end
-        svo.doaction(svo.dict.cadmus.waitingfor)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('cadmus')
-        svo.killaction(svo.dict.cadmus.waitingfor)
-      end,
-    }
-  },
-  stain = {
-    waitingfor = {
-      customwait = 60*2+20, -- lasts 2min, but varies, so let's go with 140s
-
-      isadvisable = function()
-        return false
-      end,
-
-      ontimeout = function()
-        svo.rmaff('stain')
-        svo.echof("Taking a guess, I think stain expired by now.")
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('stain')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function (oldmaxhp)
-        -- oldmaxhp doesn't come from diag, it is optional
-        if (not conf.aillusion) or (oldmaxhp and (stats.maxhealth &lt; oldmaxhp)) then
-          svo.addaffdict(svo.dict.stain)
+  
           signals.after_lifevision_processing:unblock(cnrl.checkwarning)
           codepaste.badaeon()
-          if svo.actions.stain_waitingfor then svo.killaction(svo.dict.stain.waitingfor) end
-          svo.doaction(svo.dict.stain.waitingfor)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('asthma') end,
+      }
+    },
+    clumsiness = {
+      herb = {
+        isadvisable = function()
+          return (affs.clumsiness) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('clumsiness')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'kelp', 'aurum'},
+        onstart = function() svo.eat(svo.dict.clumsiness.herb) end,
+  
+        empty = function() empty.eat_kelp() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.clumsiness)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('clumsiness') end,
+      }
+    },
+    sensitivity = {
+      herb = {
+        isadvisable = function()
+          return (affs.sensitivity) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('sensitivity')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'kelp', 'aurum'},
+        onstart = function() svo.eat(svo.dict.sensitivity.herb) end,
+  
+        empty = function() empty.eat_kelp() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.sensitivity)
+        end,
+  
+        -- used by AI to check if we're deaf when we got sensi
+        checkdeaf = function()
+          -- if deafness was stripped, then prompt flags would have removed it at this point and defc.deaf wouldn't be set
+          -- also check back to see if deafness went instead, like from bloodleech:
+          -- A bloodleech leaps at you, clamping with teeth onto exposed flesh and secreting some foul toxin into your bloodstream. You stumble as you are afflicted with sensitivity.$Your hearing is suddenly restored.
+          -- or dragoncurse: A sudden sense of panic overtakes you as the draconic curse manifests, afflicting you with sensitivity.$Your hearing is suddenly restored.
+          -- however, don't go off on dstab: Bob pricks you twice in rapid succession with her dirk.$Your hearing is suddenly restored.$A prickly, stinging sensation spreads through your body.
+          if svo.find_until_last_paragraph("Your hearing is suddenly restored.", 'exact') and not svo.find_until_last_paragraph("A prickly, stinging sensation spreads through your body.", 'exact') then return end
+  
+          if not conf.aillusion or (not defc.deaf and not affs.deafaff) then
+            svo.addaffdict(svo.dict.sensitivity)
+          end
         end
-      end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('sensitivity') end,
+      }
     },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('stain')
-        svo.killaction(svo.dict.stain.waitingfor)
-      end,
-    }
-  },
-  depression = {
-    herb = {
-      isadvisable = function()
-        return affs.depression or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('depression')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-      onstart = function() svo.eat(svo.dict.depression.herb) end,
-
-      empty = function() empty.eat_goldenseal() end
+    healthleech = {
+      herb = {
+        isadvisable = function()
+          return (affs.healthleech) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('healthleech')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'kelp', 'aurum'},
+        onstart = function() svo.eat(svo.dict.healthleech.herb) end,
+  
+        empty = function() empty.eat_kelp() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.healthleech)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('healthleech') end,
+      }
     },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.depression)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('depression') end,
-    }
-  },
-  parasite = {
-    herb = {
-      isadvisable = function()
-        return affs.parasite or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('parasite')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'kelp', 'aurum'},
-      onstart = function() svo.eat(svo.dict.parasite.herb) end,
-
-      empty = function() empty.eat_kelp() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.parasite)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('parasite') end,
-    }
-  },
-  retribution = {
-    herb = {
-      isadvisable = function()
-        return affs.retribution or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('retribution')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'bellwort', 'cuprum'},
-      onstart = function() svo.eat(svo.dict.retribution.herb) end,
-
-      empty = function() empty.eat_bellwort() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.retribution)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('retribution') end,
-    }
-  },
-  shadowmadness = {
-    herb = {
-      isadvisable = function()
-        return affs.shadowmadness or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('shadowmadness')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-      onstart = function() svo.eat(svo.dict.shadowmadness.herb) end,
-
-      empty = function() empty.eat_goldenseal() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.shadowmadness)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('shadowmadness') end,
-    }
-  },
-  timeloop = {
-    herb = {
-      isadvisable = function()
-        return affs.timeloop or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('timeloop')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'bellwort', 'cuprum'},
-      onstart = function() svo.eat(svo.dict.timeloop.herb) end,
-
-      empty = function() empty.eat_bellwort() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.timeloop)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('timeloop') end,
-    }
-  },
-  degenerate = {
-    waitingfor = {
-      customwait = 0, -- seems to last 6 seconds per degenerate affliction when boosted, set below
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('degenerate')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        local timeout = 0
-        for _, aff in ipairs(empty.degenerateaffs) do
-          timeout = timeout + (affs[aff] and 7 or 0)
+    relapsing = {
+      -- if it's an aff that can be checked, remove it's action and add an appropriate checkaff. Then if the checkaff succeeds, add the relapsing too.
+      saw_with_checkable = false,
+      gamename = 'scytherus',
+      herb = {
+        isadvisable = function()
+          return (affs.relapsing) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('relapsing')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ginseng', 'ferrum'},
+        onstart = function() svo.eat(svo.dict.relapsing.herb) end,
+  
+        empty = function() empty.eat_ginseng() end
+      },
+      --[[
+        relapsing:  ai off, accept everything
+                    ai on, accept everything only if we do have relapsing, or it's a checkable symptom -&gt; undeaf/unblind, blind/deaf, camus, else -&gt; ignore
+  
+        implementation: generic affs get called to aff.oncompleted, otherwise specialities deal with aff.&lt;func&gt;
+      ]]
+      aff = {
+        -- this goes off when there is no AI or we got a generic affliction that doesn't mean much
+        oncompleted = function()
+          -- don't mess with anything special if we have it confirmed
+          if affs.relapsing then return end
+  
+          if not conf.aillusion or svo.lifevision.l.diag_physical then
+            svo.addaffdict(svo.dict.relapsing)
+            svo.dict.relapsing.saw_with_checkable = nil
+          else
+            if svo.actions.checkparalysis_aff then
+              svo.dict.relapsing.saw_with_checkable = 'paralysis'
+            elseif not svo.pl.tablex.find_if(svo.actions:keys(), function (key) return string.find(key, 'check', 1, true) end) then
+              -- don't process the rest of the affs it gives if it's not checkable and we don't have relapsing already
+              sk.stopprocessing = true
+            end
+          end
+          svo.dict.relapsing.aff.hitvitality = nil
+        end,
+  
+        forced = function()
+          svo.addaffdict(svo.dict.relapsing)
+        end,
+  
+        camus = function (oldhp)
+          if not conf.aillusion or
+            ((not affs.recklessness and stats.currenthealth &lt; oldhp) -- health went down without recklessness
+             or (svo.dict.relapsing.aff.hitvitality and ((100/stats.maxhealth)* stats.currenthealth) &lt;= 60)) then -- or we're above due to vitality
+            svo.addaffdict(svo.dict.relapsing)
+            svo.dict.relapsing.aff.hitvitality = nil
+            svo.dict.relapsing.saw_with_checkable = nil
+          end
+        end,
+  
+        sumac = function (oldhp)
+          if not conf.aillusion or
+            ((not affs.recklessness and stats.currenthealth &lt; oldhp) -- health went down without recklessness
+             or (svo.dict.relapsing.aff.hitvitality and ((100/stats.maxhealth)* stats.currenthealth) &lt;= 60)) then -- or we're above due to vitality
+            svo.addaffdict(svo.dict.relapsing)
+            svo.dict.relapsing.aff.hitvitality = nil
+            svo.dict.relapsing.saw_with_checkable = nil
+          end
+        end,
+  
+        oleander = function (hadblind)
+          if not conf.aillusion or (not hadblind and (defc.blind or affs.blindaff)) then
+            svo.addaffdict(svo.dict.relapsing)
+            svo.dict.relapsing.saw_with_checkable = nil
+          end
+        end,
+  
+        colocasia = function (hadblindordeaf)
+          if not conf.aillusion or (not hadblindordeaf and (defc.blind or affs.blindaff or defc.deaf or affs.deafaff)) then
+            svo.addaffdict(svo.dict.relapsing)
+            svo.dict.relapsing.saw_with_checkable = nil
+          end
+        end,
+  
+        oculus = function (hadblind)
+          if not conf.aillusion or (hadblind and not (defc.blind or affs.blindaff)) then
+            svo.addaffdict(svo.dict.relapsing)
+            svo.dict.relapsing.saw_with_checkable = nil
+          end
+        end,
+  
+        prefarar = function (haddeaf)
+          if not conf.aillusion or (haddeaf and not (defc.deaf or affs.deafaff)) then
+            svo.addaffdict(svo.dict.relapsing)
+            svo.dict.relapsing.saw_with_checkable = nil
+          end
+        end,
+  
+        asthma = function()
+          if not conf.aillusion or svo.lifevision.l.diag_physical then
+            svo.addaffdict(svo.dict.relapsing)
+            svo.dict.relapsing.saw_with_checkable = nil
+          else
+            if svo.actions.checkasthma_aff then
+              svo.dict.relapsing.saw_with_checkable = 'asthma'
+            elseif not svo.pl.tablex.find_if(svo.actions:keys(), function (key) return string.find(key, 'check', 1, true) end) then
+              -- don't process the rest of the affs it gives.
+              sk.stopprocessing = true
+            end
+          end
+          svo.dict.relapsing.aff.hitvitality = nil
         end
-        svo.dict.degenerate.waitingfor.customwait = timeout
-        svo.addaffdict(svo.dict.degenerate)
-        if not svo.actions.degenerate_waitingfor then svo.doaction(svo.dict.degenerate.waitingfor) end
-      end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('relapsing')
+          svo.dict.relapsing.saw_with_checkable = nil
+        end,
+      }
     },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('degenerate')
-        svo.killaction(svo.dict.degenerate.waitingfor)
-      end,
-    }
-  },
-  deteriorate = {
-    waitingfor = {
-      customwait = 0, -- seems to last 6 seconds per deteriorate affliction when boosted, set below
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('deteriorate')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        local timeout = 0
-        for _, aff in ipairs(empty.deteriorateaffs) do
-          timeout = timeout + (affs[aff] and 7 or 0)
+    darkshade = {
+      herb = {
+        isadvisable = function()
+          return (affs.darkshade) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('darkshade')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ginseng', 'ferrum'},
+        onstart = function() svo.eat(svo.dict.darkshade.herb) end,
+  
+        empty = function() empty.eat_ginseng() end
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          if not conf.aillusion or (not oldhp or stats.currenthealth &lt; oldhp) then
+            svo.addaffdict(svo.dict.darkshade)
+          end
+        end,
+  
+        forced = function()
+          svo.addaffdict(svo.dict.darkshade)
         end
-        svo.dict.deteriorate.waitingfor.customwait = timeout
-        svo.addaffdict(svo.dict.deteriorate)
-        if not svo.actions.deteriorate_waitingfor then svo.doaction(svo.dict.deteriorate.waitingfor) end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('darkshade') end,
+      }
+    },
+    lethargy = {
+      herb = {
+        isadvisable = function()
+          -- curing lethargy before hypochondria or torntendons will make it get re-applied
+          return (affs.lethargy and not affs.madness and not affs.hypochondria) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('lethargy')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ginseng', 'ferrum'},
+        onstart = function() svo.eat(svo.dict.lethargy.herb) end,
+  
+        empty = function() empty.eat_ginseng() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.lethargy)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('lethargy') end,
+      }
+    },
+    illness = {
+      gamename = 'nausea',
+      herb = {
+        isadvisable = function()
+          -- curing illness before hypochondria will make it get re-applied
+          return (affs.illness and not affs.madness and not affs.hypochondria) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('illness')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ginseng', 'ferrum'},
+        onstart = function() svo.eat(svo.dict.illness.herb) end,
+  
+        empty = function() empty.eat_ginseng() end
+      },
+      aff = {
+        oncompleted = function()
+          if not svo.find_until_last_paragraph("Your enhanced constitution allows you to shrug off the nausea.", 'exact') then
+            svo.addaffdict(svo.dict.illness)
+          end
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('illness') end,
+      }
+    },
+    addiction = {
+      herb = {
+        isadvisable = function()
+          -- curing addiction before hypochondria or skullfractures will make it get re-applied
+          return (affs.addiction and not affs.madness and not affs.hypochondria) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('addiction')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ginseng', 'ferrum'},
+        onstart = function() svo.eat(svo.dict.addiction.herb) end,
+  
+        empty = function() empty.eat_ginseng() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.addiction)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('addiction') end,
+      },
+      onremoved = function()
+        rift.checkprecache()
       end
     },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('deteriorate')
-        svo.killaction(svo.dict.deteriorate.waitingfor)
-      end,
-    }
-  },
-  hatred = {
-    waitingfor = {
-      customwait = 15,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('hatred')
-        svo.make_gnomes_work()
-      end
+    haemophilia = {
+      herb = {
+        isadvisable = function()
+          return (affs.haemophilia) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('haemophilia')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ginseng', 'ferrum'},
+        onstart = function() svo.eat(svo.dict.haemophilia.herb) end,
+  
+        empty = function() empty.eat_ginseng() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.haemophilia)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('haemophilia') end,
+      }
     },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.hatred)
-        if not svo.actions.hatred_waitingfor then svo.doaction(svo.dict.hatred.waitingfor) end
-      end
+    hypochondria = {
+      herb = {
+        isadvisable = function()
+          return (affs.hypochondria) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('hypochondria')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'kelp', 'aurum'},
+        onstart = function() svo.eat(svo.dict.hypochondria.herb) end,
+  
+        empty = function() empty.eat_kelp() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.hypochondria)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('hypochondria') end,
+      }
     },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('hatred')
-        svo.killaction(svo.dict.hatred.waitingfor)
-      end,
-    }
-  },
-  paradox = {
-    count = 0,
-    blocked_herb = "",
-    boosted = {
-      oncompleted = function()
-        svo.dict.paradox.count = 10
-        svo.updateaffcount(svo.dict.paradox)
-      end
-    },
-    weakened = {
-      oncompleted = function()
-        codepaste.remove_stackableaff('paradox', true)
-      end
-    },
-    aff = {
-      oncompleted = function (herb)
-        svo.dict.paradox.count = 5
-        svo.dict.paradox.blocked_herb = herb
-        svo.addaffdict(svo.dict.paradox)
-        svo.affl['paradox'].herb = herb
-        svo.updateaffcount(svo.dict.paradox)
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('paradox')
-        svo.dict.paradox.count = 0
-        svo.dict.paradox.blocked_herb = ""
-      end,
-    }
-  },
-  mindravaged = {
-    waitingfor = {
-      customwait = 30, -- Honestly not sure how long this lasts, but this seems about right; need someone to make sure
-
-      isadvisable = function ()
-        return false
-      end,
-
-      onstart = function () end,
-
-      oncompleted = function ()
-        svo.rmaff("mindravaged")
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function ()
-        svo.addaffdict(svo.dict.mindravaged)
-        if not svo.actions.mindravaged_waitingfor then svo.doaction(svo.dict.mindravaged.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function ()
-        svo.rmaff("burning")
-        svo.killaction(svo.dict.mindravaged.waitingfor)
-      end,
-    }
-  },
-  unweavingbody = {
-    count = 0,
-    name = 'unweavingbody',
-    gamename = 'unweavingbody',
-    herb = {
-      aspriority = 0,
-      spriority = 0,
-
-      isadvisable = function ()
-        return affs.unweavingbody or false
-      end,
-
-      oncompleted = function ()
-        svo.rmaff("unweavingbody")
-        svo.dict.unweavingbody.count = 0
-        svo.lostbal_herb()
-      end,
-
-      cured = function()
-        svo.lostbal_herb()
-        svo.rmaff("unweavingbody")
-        svo.dict.unweavingbody.count = 0
-      end,
-
-      eatcure = {"ginseng", "ferrum"},
-      onstart = function ()
-        svo.eat(svo.dict.unweavingbody.herb)
-      end,
-
-      empty = function()
-        svo.empty.eat_ginseng()
-      end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(dict.unweavingbody)
-        svo.updateaffcount(svo.dict.unweavingbody)
-      end
-    },
-    gone = {
-      oncompleted = function ()
-        svo.rmaff("unweavingbody")
-        svo.dict.unweavingbody.count = 0
-      end,
-
-      general_cure = function(amount, dontkeep)
-        svo.rmaff("unweavingbody")
-        svo.dict.unweavingbody.count = 0
-      end,
-
-      general_cured = function(amount)
-        svo.rmaff("unweavingbody")
-        svo.dict.unweavingbody.count = 0
-      end
-    }
-  },
-  unweavingmind = {
-    count = 0,
-    name = 'unweavingmind',
-    gamename = 'unweavingmind',
-    herb = {
-      aspriority = 0,
-      spriority = 0,
-
-      isadvisable = function ()
-        return svo.affs.unweavingmind or false
-      end,
-
-      oncompleted = function ()
-        svo.rmaff("unweavingmind")
-        svo.dict.unweavingmind.count = 0
-        svo.lostbal_herb()
-      end,
-
-      cured = function()
-        svo.lostbal_herb()
-        svo.rmaff("unweavingmind")
-        svo.dict.unweavingmind.count = 0
-      end,
-
-      eatcure = {"goldenseal", "plumbum"},
-      onstart = function ()
-        svo.eat(svo.dict.unweavingmind.herb)
-      end,
-
-      empty = function()
-        svo.empty.eat_goldenseal()
-      end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.unweavingmind)
-        svo.updateaffcount(svo.dict.unweavingmind)
-      end
-    },
-    gone = {
-      oncompleted = function ()
-        svo.rmaff("unweavingmind")
-        svo.dict.unweavingmind.count = 0
-      end,
-
-      general_cure = function(amount, dontkeep)
-        svo.rmaff("unweavingmind")
-        svo.dict.unweavingmind.count = 0
-      end,
-
-      general_cured = function(amount)
-        svo.rmaff("unweavingmind")
-        svo.dict.unweavingmind.count = 0
-      end,
-    }
-  },
-  unweavingspirit = {
-    count = 0,
-    name = 'unweavingspirit',
-    gamename = 'unweavingspirit',
-    smoke = {
-      isadvisable = function()
-        return (svo.affs.unweavingspirit and codepaste.smoke_elm_pipe()) or false
-      end,
-
-      oncompleted = function()
-        svo.updateaffcount(svo.dict.unweavingspirit)
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-      end,
-
-      cured = function()
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-        svo.rmaff("unweavingspirit")
-        svo.dict.unweavingspirit.count = 0
-      end,
-
-      smokecure = {'elm', 'cinnabar'},
-      onstart = function()
-        send("smoke " .. pipes.elm.id, conf.commandecho)
-      end,
-
-      empty = function()
-        svo.empty.smoke_elm()
-        svo.lostbal_smoke()
-        sk.elm_smokepuff()
-      end
-    },
-    aff = {
-      oncompleted = function (number)
-        svo.addaffdict(svo.dict.unweavingspirit)
-        svo.updateaffcount(svo.dict.unweavingspirit)
-      end
-    },
-    gone = {
-      oncompleted = function ()
-        svo.rmaff("unweavingspirit")
-        svo.dict.unweavingspirit.count = 0
-      end,
-
-      general_cure = function(amount, dontkeep)
-        svo.updateaffcount(svo.dict.unweavingspirit)
-      end,
-
-      general_cured = function(amount)
-        svo.rmaff("unweavingspirit")
-        svo.dict.unweavingspirit.count = 0
-      end
-    }
-  },
-  retardation = {
-    waitingfor = {
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function() svo.rmaff('retardation') end
-    },
-    aff = {
-      oncompleted = function()
-        if not affs.retardation then
-          svo.addaffdict(svo.dict.retardation)
+  
+  -- smoke cures
+    aeon = {
+      smoke = {
+        isadvisable = function()
+          return (affs.aeon and codepaste.smoke_elm_pipe()) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('aeon')
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
+        end,
+  
+        smokecure = {'elm', 'cinnabar'},
+        onstart = function()
+          send("smoke " .. pipes.elm.id, conf.commandecho)
+        end,
+  
+        empty = function()
+          empty.smoke_elm()
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.aeon)
+          svo.affsp.aeon = nil
+          defences.lost('speed')
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
           sk.checkaeony()
           signals.changecuring:emit()
-          signals.newroom:unblock(sk.check_retardation)
+          codepaste.badaeon()
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('aeon') end,
+      },
+      onremoved = function()
+        svo.affsp.aeon = nil
+        sk.retardation_count = 0
+        sk.checkaeony()
+        signals.changecuring:emit()
+      end
+    },
+    hellsight = {
+      smoke = {
+        isadvisable = function()
+          return (affs.hellsight and not affs.inquisition and codepaste.smoke_valerian_pipe()) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('hellsight')
+          svo.lostbal_smoke()
+          sk.valerian_smokepuff()
+        end,
+  
+        smokecure = {'valerian', 'realgar'},
+        onstart = function()
+          send("smoke " .. pipes.valerian.id, conf.commandecho)
+        end,
+  
+        empty = function()
+          empty.smoke_valerian()
+          svo.lostbal_smoke()
+          sk.valerian_smokepuff()
+        end,
+  
+        inquisition = function()
+          svo.addaffdict(svo.dict.inquisition)
+          sk.valerian_smokepuff()
         end
-      end,
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.hellsight)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('hellsight') end,
+      }
     },
-    gone = {
-      oncompleted = function() svo.rmaff('retardation') end,
-    },
-    onremoved = function()
-      svo.affsp.retardation = nil
-      sk.checkaeony()
-      signals.changecuring:emit()
-      signals.newroom:block(sk.check_retardation)
-    end,
-    onadded = function()
-      signals.newroom:unblock(sk.check_retardation)
-    end
-  },
+    deadening = {
+      smoke = {
+        isadvisable = function()
+          return (affs.deadening and codepaste.smoke_elm_pipe()) or false
+        end,
   
+        oncompleted = function()
+          svo.rmaff('deadening')
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
+        end,
   
-  nomana = {
-    waitingfor = {
-      customwait = 30,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-      ontimeout = function()
-        echo"\n"svo.echof("Hm, maybe we have enough mana for mana skills now...")
-        svo.killaction(svo.dict.nomana.waitingfor)
-        svo.make_gnomes_work()
-      end
-    }
-  },
+        smokecure = {'elm', 'cinnabar'},
+        onstart = function()
+          send("smoke " .. pipes.elm.id, conf.commandecho)
+        end,
   
-  mycalium = {
-    herb = {
-      isadvisable = function()
-        return affs.mycalium or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('mycalium')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-      onstart = function() svo.eat(svo.dict.mycalium.herb) end,
-
-      empty = function() empty.eat_goldenseal() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.mycalium)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('mycalium') end,
-    }
-  },
-  
-  flushings = {
-    herb = {
-      isadvisable = function()
-        return affs.flushings or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('flushings')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'ginseng', 'ferrum'},
-      onstart = function() svo.eat(svo.dict.flushings.herb) end,
-
-      empty = function() empty.eat_ginseng() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.flushings)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('flushings') end,
-    }
-  },
-
-  rebbies = {
-    herb = {
-      isadvisable = function()
-        return affs.rebbies or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('rebbies')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'kelp', 'aurum'},
-      onstart = function() svo.eat(svo.dict.rebbies.herb) end,
-
-      empty = function() empty.eat_kelp() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.rebbies)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('rebbies') end,
-    }
-  },
-  
-  sandfever = {
-    herb = {
-      isadvisable = function()
-        return affs.sandfever or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('sandfever')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'goldenseal', 'plumbum'},
-      onstart = function() svo.eat(svo.dict.sandfever.herb) end,
-
-      empty = function() empty.eat_goldenseal() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.sandfever)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('sandfever') end,
-    }
-  },
-  
-  pyramides = {
-    herb = {
-      isadvisable = function()
-        return affs.pyramides or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('pyramides')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'bloodroot', 'magnesium'},
-      onstart = function() svo.eat(svo.dict.pyramides.herb) end,
-
-      empty = function() empty.eat_bloodroot() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.pyramides)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('pyramides') end,
-    }
-  },
-
-  ensorcelled = {
-    waitingfor = {
-      customwait = 20,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('ensorcelled')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.ensorcelled)
-        if not svo.actions.ensorcelled_waitingfor then svo.doaction(svo.dict.ensorcelled.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('ensorcelled')
-        svo.killaction(svo.dict.ensorcelled.waitingfor)
-      end,
-    }
-  },
-
-  latency = {
-    waitingfor = {
-      customwait = 13,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-
-      oncompleted = function()
-        svo.rmaff('latency')
-        svo.make_gnomes_work()
-      end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.latency)
-        if not svo.actions.latency_waitingfor then svo.doaction(svo.dict.latency.waitingfor) end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.rmaff('latency')
-        svo.killaction(svo.dict.latency.waitingfor)
-        svo.echof("Latency gone. Can sip immunity now")
-      end,
-    }
-  },
-
-  indifference = {
-    herb = {
-      isadvisable = function()
-        return affs.indifference or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff('indifference')
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'bellwort', 'cuprum'},
-      onstart = function() svo.eat(svo.dict.indifference.herb) end,
-
-      empty = function() empty.eat_bellwort() end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.indifference)
-      end,
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('indifference') end,
-    }
-  },
-
-  -- random actions that should be protected by AI
-  givewarning = {
-    happened = {
-      oncompleted = function (tbl)
-        if tbl and tbl.initialmsg then
-          echo"\n\n"
-          svo.echof("Careful: %s", tbl.initialmsg)
-          echo"\n"
+        empty = function()
+          empty.smoke_elm()
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
         end
-
-        if tbl and tbl.prefixwarning then
-          local duration = tbl.duration or 4
-          local startin = tbl.startin or 0
-          cnrl.warning = tbl.prefixwarning or ""
-
-          -- timer for starting
-          if not conf.warningtype then return end
-
-          tempTimer(startin, function()
-
-            if cnrl.warnids[tbl.prefixwarning] then killTrigger(cnrl.warnids[tbl.prefixwarning]) end
-
-              cnrl.warnids[tbl.prefixwarning] = tempRegexTrigger('^', [[
-                if ((svo.conf.warningtype == 'prompt' and isPrompt()) or svo.conf.warningtype == 'all' or svo.conf.warningtype == 'right') and getCurrentLine() ~= "" and not svo.gagline then
-                  svo.prefixwarning()
-                end
-              ]])
-            end)
-
-          -- timer for ending
-          tempTimer(startin+duration, function() killTrigger(cnrl.warnids[tbl.prefixwarning]) end)
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.deadening)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('deadening') end,
+      }
+    },
+    madness = {
+      gamename = 'whisperingmadness',
+      smoke = {
+        isadvisable = function()
+          return (affs.madness and codepaste.smoke_elm_pipe() and not affs.hecate) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('madness')
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
+        end,
+  
+        smokecure = {'elm', 'cinnabar'},
+        onstart = function()
+          send("smoke " .. pipes.elm.id, conf.commandecho)
+        end,
+  
+        empty = function()
+          empty.smoke_elm()
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
+        end,
+  
+        hecate = function()
+          sk.elm_smokepuff()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.madness)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('madness') end,
+      }
+    },
+    tension = {
+      smoke = {
+        isadvisable = function()
+          return (affs.tension and codepaste.smoke_elm_pipe()) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('tension')
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
+        end,
+  
+        smokecure = {'elm', 'cinnabar'},
+        onstart = function()
+          send("smoke " .. pipes.elm.id, conf.commandecho)
+        end,
+  
+        empty = function()
+          empty.smoke_elm()
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.tension)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('tension') end,
+      }
+    },
+    -- valerian cures
+    slickness = {
+      smoke = {
+        isadvisable = function()
+          return (affs.slickness and codepaste.smoke_valerian_pipe() and not svo.doingaction'slickness') or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('slickness')
+          svo.lostbal_smoke()
+          sk.valerian_smokepuff()
+        end,
+  
+        smokecure = {'valerian', 'realgar'},
+        onstart = function()
+          send("smoke " .. pipes.valerian.id, conf.commandecho)
+        end,
+  
+        empty = function()
+          empty.smoke_valerian()
+          svo.lostbal_smoke()
+          sk.valerian_smokepuff()
+        end
+      },
+      herb = {
+        isadvisable = function()
+          return (affs.slickness and not affs.anorexia and not svo.doingaction'slickness' and not affs.stain) or false -- anorexia is redundant, but just in for now
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('slickness')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'bloodroot', 'magnesium'},
+        onstart = function() svo.eat(svo.dict.slickness.herb) end,
+  
+        empty = function() empty.eat_bloodroot() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.slickness)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('slickness') end,
+      }
+    },
+    disloyalty = {
+      smoke = {
+        isadvisable = function()
+          return (affs.disloyalty and codepaste.smoke_valerian_pipe()) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('disloyalty')
+          svo.lostbal_smoke()
+          sk.valerian_smokepuff()
+        end,
+  
+        smokecure = {'valerian', 'realgar'},
+        onstart = function()
+          send("smoke " .. pipes.valerian.id, conf.commandecho)
+        end,
+  
+        empty = function()
+          empty.smoke_valerian()
+          svo.lostbal_smoke()
+          sk.valerian_smokepuff()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.disloyalty)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('disloyalty') end,
+      }
+    },
+    manaleech = {
+      smoke = {
+        isadvisable = function()
+          return (affs.manaleech and codepaste.smoke_valerian_pipe()) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('manaleech')
+          svo.lostbal_smoke()
+          sk.valerian_smokepuff()
+        end,
+  
+        smokecure = {'valerian', 'realgar'},
+        onstart = function()
+          send("smoke " .. pipes.valerian.id, conf.commandecho)
+        end,
+  
+        empty = function()
+          empty.smoke_valerian()
+          svo.lostbal_smoke()
+          sk.valerian_smokepuff()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.manaleech)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('manaleech') end,
+      }
+    },
+  
+  
+    -- restoration cures
+    heartseed = {
+      salve = {
+        isadvisable = function()
+          return (affs.heartseed and not affs.mildtrauma) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingheartseed.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to torso", "apply restoration", "apply reconstructive to torso", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.heartseed.salve, " to torso")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.heartseed.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.heartseed)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('heartseed') end,
+      }
+    },
+    curingheartseed = {
+      waitingfor = {
+        customwait = 6, -- 4 to cure
+  
+        oncompleted = function() svo.rmaff('heartseed') end,
+  
+        ontimeout = function() svo.rmaff('heartseed') end,
+  
+        noeffect = function() svo.rmaff('heartseed') end,
+  
+        onstart = function()
+          -- add blocking of the cure coming too early if it'll become necessary.
+        end,
+      }
+    },
+    calcifiedskull = {
+      salve = {
+        isadvisable = function()
+          return (affs.calcifiedskull and not affs.mildconcussion) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingcalcifiedskull.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to head", "apply restoration", "apply reconstructive to head", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.calcifiedskull.salve, " to head")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.calcifiedskull.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.calcifiedskull)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('calcifiedskull') end,
+      }
+    },
+    curingcalcifiedskull = {
+      waitingfor = {
+        customwait = 6, -- 4 to cure
+  
+        oncompleted = function() svo.rmaff('calcifiedskull') end,
+  
+        ontimeout = function() svo.rmaff('calcifiedskull') end,
+  
+        noeffect = function() svo.rmaff('calcifiedskull') end,
+  
+        onstart = function()
+          -- add blocking of the cure coming too early if it'll become necessary.
+        end,
+      }
+    },
+    calcifiedtorso = {
+      salve = {
+        isadvisable = function()
+          return (affs.calcifiedtorso and not affs.mildtrauma) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingcalcifiedtorso.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to torso", "apply restoration", "apply reconstructive to torso", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.calcifiedtorso.salve, " to torso")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.calcifiedtorso.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.calcifiedtorso)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('calcifiedtorso') end,
+      }
+    },
+    curingcalcifiedtorso = {
+      waitingfor = {
+        customwait = 6, -- 4 to cure
+  
+        oncompleted = function() svo.rmaff('calcifiedtorso') end,
+  
+        ontimeout = function() svo.rmaff('calcifiedtorso') end,
+  
+        noeffect = function() svo.rmaff('calcifiedtorso') end,
+  
+        onstart = function()
+          -- add blocking of the cure coming too early if it'll become necessary.
+        end,
+      }
+    },
+    hypothermia = {
+      salve = {
+        isadvisable = function()
+          return (affs.hypothermia and not affs.mildtrauma) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curinghypothermia.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to torso", "apply restoration", "apply reconstructive to torso", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.hypothermia.salve, " to torso")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.hypothermia.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.hypothermia)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('hypothermia') end,
+      }
+    },
+    curinghypothermia = {
+      waitingfor = {
+        customwait = 6, -- 4 to cure
+  
+        oncompleted = function() svo.rmaff('hypothermia') end,
+  
+        ontimeout = function() svo.rmaff('hypothermia') end,
+  
+        noeffect = function() svo.rmaff('hypothermia') end,
+  
+        onstart = function()
+          -- add blocking of the cure coming too early if it'll become necessary.
+        end,
+      }
+    },
+    tonguetied = {
+      salve = {
+        isadvisable = function()
+          return (affs.tonguetied) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingtonguetied.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to head", "apply restoration", "apply reconstructive to head", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.tonguetied.salve, " to head")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.tonguetied.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.tonguetied)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('tonguetied') end,
+      }
+    },
+    curingtonguetied = {
+      waitingfor = {
+        customwait = 6, -- 4 to cure
+  
+        oncompleted = function() svo.rmaff('tonguetied') end,
+  
+        ontimeout = function() svo.rmaff('tonguetied') end,
+  
+        noeffect = function() svo.rmaff('tonguetied') end,
+  
+        onstart = function()
+          -- add blocking of the cure coming too early if it'll become necessary.
+        end,
+      }
+    },
+  
+    mutilatedrightleg = {
+      gamename = 'mangledrightleg',
+      salve = {
+        isadvisable = function()
+          return (affs.mutilatedrightleg) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingmutilatedrightleg.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to legs", "apply restoration", "apply reconstructive to legs", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.mutilatedrightleg.salve, " to legs")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.mutilatedrightleg.salve.oncompleted()
+        end,
+  
+        -- in blackout, this goes through quietly
+        ontimeout = function()
+          if affs.blackout then
+            svo.dict.mutilatedrightleg.salve.oncompleted()
+          end
+        end,
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          codepaste.addrestobreakleg('mutilatedrightleg', oldhp)
+        end,
+  
+        tekura = function (oldhp)
+          codepaste.addrestobreakleg('mutilatedrightleg', oldhp, true)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mutilatedrightleg') end,
+      }
+    },
+    curingmutilatedrightleg = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('mutilatedrightleg')
+          svo.addaffdict(svo.dict.mangledrightleg)
+  
+          local result = svo.checkany(svo.dict.curingmutilatedleftleg.waitingfor, svo.dict.curingmangledrightleg.waitingfor, svo.dict.curingmangledleftleg.waitingfor, svo.dict.curingparestolegs.waitingfor)
+  
+          if result then
+            svo.killaction(svo.dict[result.action_name].waitingfor)
+          end
+        end,
+  
+        ontimeout = function()
+          if affs.mutilatedrightleg then
+            svo.rmaff('mutilatedrightleg')
+            svo.addaffdict(svo.dict.mangledrightleg)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        oncuredleft = function()
+          svo.rmaff('mutilatedrightleg')
+          svo.addaffdict(svo.dict.mangledrightleg)
+        end,
+  
+        noeffect = function() svo.rmaff('mutilatedrightleg') end
+      }
+    },
+    parestolegs = {
+      salve = {
+        uncurable = true,
+  
+        customwaitf = function()
+          return not affs.blackout and 0 or 4 -- can't see applies in blackout
+        end,
+  
+        isadvisable = function()
+          return (affs.parestolegs) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingparestolegs.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to legs", "apply restoration", "apply reconstructive to legs", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.parestolegs.salve, " to legs")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.parestolegs.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.parestolegs)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('parestolegs') end,
+      }
+    },
+    curingparestolegs = {
+      waitingfor = {
+        customwait = 4,
+  
+        oncompleted = function()
+          svo.rmaff('parestolegs')
+  
+          local result = svo.checkany(svo.dict.curingmutilatedrightleg.waitingfor, svo.dict.curingmutilatedleftleg.waitingfor, svo.dict.curingmangledrightleg.waitingfor, svo.dict.curingmangledleftleg.waitingfor)
+  
+          if result then
+            svo.killaction(svo.dict[result.action_name].waitingfor)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        ontimeout = function() svo.rmaff('parestolegs') end,
+  
+        noeffect = function() svo.rmaff('parestolegs') end
+      }
+    },
+    mangledrightleg = {
+      gamename = 'damagedrightleg',
+      salve = {
+        isadvisable = function()
+          return (affs.mangledrightleg and not (affs.mutilatedrightleg or affs.mutilatedleftleg)) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingmangledrightleg.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to legs", "apply restoration", "apply reconstructive to legs", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.mangledrightleg.salve, " to legs")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.mangledrightleg.salve.oncompleted()
+        end,
+  
+        -- in blackout, this goes through quietly
+        ontimeout = function()
+          if affs.blackout then
+            svo.dict.mangledrightleg.salve.oncompleted()
+          end
+        end,
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          codepaste.addrestobreakleg('mangledrightleg', oldhp)
+        end,
+  
+        tekura = function (oldhp)
+          codepaste.addrestobreakleg('mangledrightleg', oldhp, true)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mangledrightleg') end,
+      }
+    },
+    curingmangledrightleg = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('parestolegs')
+          svo.rmaff('mangledrightleg')
+          svo.addaffdict(svo.dict.crippledrightleg)
+  
+          local result = svo.checkany(svo.dict.curingmutilatedrightleg.waitingfor, svo.dict.curingmutilatedleftleg.waitingfor, svo.dict.curingmangledleftleg.waitingfor, svo.dict.curingparestolegs.waitingfor)
+  
+          if result then
+            svo.killaction(svo.dict[result.action_name].waitingfor)
+          end
+        end,
+  
+        ontimeout = function()
+          if affs.mangledrightleg then
+            svo.rmaff('mangledrightleg')
+            svo.addaffdict(svo.dict.crippledrightleg)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        oncuredleft = function()
+          svo.rmaff('mangledrightleg')
+          svo.addaffdict(svo.dict.crippledrightleg)
+        end,
+  
+        noeffect = function() svo.rmaff('mangledrightleg') end
+      }
+    },
+    crippledrightleg = {
+      gamename = 'brokenrightleg',
+      salve = {
+        isadvisable = function()
+          return (affs.crippledrightleg and not (affs.mutilatedrightleg or affs.mangledrightleg or affs.parestolegs)) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('crippledrightleg')
+  
+          if affs.unknowncrippledlimb then
+            svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count - 1
+            if svo.dict.unknowncrippledlimb.count &lt;= 0 then svo.rmaff'unknowncrippledlimb' else svo.updateaffcount(svo.dict.unknowncrippledlimb) end
+          end
+  
+          if not affs.unknowncrippledleg then return end
+          svo.dict.unknowncrippledleg.count = svo.dict.unknowncrippledleg.count - 1
+          if svo.dict.unknowncrippledleg.count &lt;= 0 then svo.rmaff'unknowncrippledleg' else svo.updateaffcount(svo.dict.unknowncrippledleg) end
+        end,
+  
+        applycure = {'mending', 'renewal'},
+        actions = {"apply mending to legs", "apply mending", "apply renewal to legs", "apply renewal"},
+        onstart = function()
+          svo.apply(svo.dict.crippledrightleg.salve, " to legs")
+        end,
+  
+        fizzled = function()
+          svo.lostbal_salve()
+          svo.addaffdict(svo.dict.mangledrightleg)
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.noeffect_mending_legs()
+        end,
+  
+        -- sometimes restoration can lag out and hit when this goes - ignore
+        empty = function() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.crippledrightleg)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('crippledrightleg') end,
+      }
+    },
+    mutilatedleftleg = {
+      gamename = 'mangledleftleg',
+      salve = {
+        isadvisable = function()
+          return (affs.mutilatedleftleg) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingmutilatedleftleg.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to legs", "apply restoration", "apply reconstructive to legs", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.mutilatedleftleg.salve, " to legs")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.mutilatedleftleg.salve.oncompleted()
+        end,
+  
+        -- in blackout, this goes through quietly
+        ontimeout = function()
+          if affs.blackout then
+            svo.dict.mutilatedleftleg.salve.oncompleted()
+          end
+        end,
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          codepaste.addrestobreakleg('mutilatedleftleg', oldhp)
+        end,
+  
+        tekura = function (oldhp)
+          codepaste.addrestobreakleg('mutilatedleftleg', oldhp, true)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mutilatedleftleg') end,
+      }
+    },
+    curingmutilatedleftleg = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('mutilatedleftleg')
+          svo.addaffdict(svo.dict.mangledleftleg)
+  
+          local result = svo.checkany(svo.dict.curingmutilatedrightleg.waitingfor, svo.dict.curingmangledrightleg.waitingfor, svo.dict.curingmangledleftleg.waitingfor, svo.dict.curingparestolegs.waitingfor)
+  
+          if result then
+            svo.killaction(svo.dict[result.action_name].waitingfor)
+          end
+        end,
+  
+        ontimeout = function()
+          if affs.mutilatedleftleg then
+            svo.rmaff('mutilatedleftleg')
+            svo.addaffdict(svo.dict.mangledleftleg)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        oncuredleft = function()
+          svo.rmaff('mutilatedleftleg')
+          svo.addaffdict(svo.dict.mangledleftleg)
+        end,
+  
+        noeffect = function() svo.rmaff('mutilatedleftleg') end
+      }
+    },
+    mangledleftleg = {
+      gamename = 'damagedleftleg',
+      salve = {
+        isadvisable = function()
+          return (affs.mangledleftleg and not (affs.mutilatedrightleg or affs.mutilatedleftleg)) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingmangledleftleg.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to legs", "apply restoration", "apply reconstructive to legs", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.mangledleftleg.salve, " to legs")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.mangledleftleg.salve.oncompleted()
+        end,
+  
+        -- in blackout, this goes through quietly
+        ontimeout = function()
+          if affs.blackout then
+            svo.dict.mangledleftleg.salve.oncompleted()
+          end
+        end,
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          codepaste.addrestobreakleg('mangledleftleg', oldhp)
+        end,
+  
+        tekura = function (oldhp)
+          codepaste.addrestobreakleg('mangledleftleg', oldhp, true)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mangledleftleg') end,
+      }
+    },
+    curingmangledleftleg = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('parestolegs')
+          svo.rmaff('mangledleftleg')
+          svo.addaffdict(svo.dict.crippledleftleg)
+  
+          local result = svo.checkany(svo.dict.curingmutilatedrightleg.waitingfor, svo.dict.curingmutilatedleftleg.waitingfor, svo.dict.curingmangledrightleg.waitingfor, svo.dict.curingparestolegs.waitingfor)
+  
+          if result then
+            svo.killaction(svo.dict[result.action_name].waitingfor)
+          end
+        end,
+  
+        ontimeout = function()
+          if affs.mangledleftleg then
+            svo.rmaff('mangledleftleg')
+            svo.addaffdict(svo.dict.crippledleftleg)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        oncuredleft = function()
+          svo.rmaff('mangledleftleg')
+          svo.addaffdict(svo.dict.crippledleftleg)
+        end,
+  
+        noeffect = function() svo.rmaff('mangledleftleg') end
+      }
+    },
+    crippledleftleg = {
+      gamename = 'brokenleftleg',
+      salve = {
+        isadvisable = function()
+          return (affs.crippledleftleg and not (affs.mutilatedleftleg or affs.mangledleftleg or affs.parestolegs)) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('crippledleftleg')
+  
+          if affs.unknowncrippledlimb then
+            svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count - 1
+            if svo.dict.unknowncrippledlimb.count &lt;= 0 then svo.rmaff'unknowncrippledlimb' else svo.updateaffcount(svo.dict.unknowncrippledlimb) end
+          end
+  
+          if not affs.unknowncrippledleg then return end
+          svo.dict.unknowncrippledleg.count = svo.dict.unknowncrippledleg.count - 1
+          if svo.dict.unknowncrippledleg.count &lt;= 0 then svo.rmaff'unknowncrippledleg' else svo.updateaffcount(svo.dict.unknowncrippledleg) end
+        end,
+  
+        applycure = {'mending', 'renewal'},
+        actions = {"apply mending to legs", "apply mending", "apply renewal to legs", "apply renewal"},
+        onstart = function()
+          svo.apply(svo.dict.crippledleftleg.salve, " to legs")
+        end,
+  
+        fizzled = function()
+          svo.lostbal_salve()
+          svo.addaffdict(svo.dict.mangledleftleg)
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.noeffect_mending_legs()
+        end,
+  
+        -- sometimes restoration can lag out and hit when this goes - ignore
+        empty = function() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.crippledleftleg)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('crippledleftleg') end,
+      }
+    },
+    parestoarms = {
+      salve = {
+        uncurable = true,
+  
+        customwaitf = function()
+          return not affs.blackout and 0 or 4 -- can't see applies in blackout
+        end,
+  
+        isadvisable = function()
+          return (affs.parestoarms) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingparestoarms.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to arms", "apply restoration", "apply reconstructive to arms", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.parestoarms.salve, " to arms")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.parestoarms.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.parestoarms)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('parestoarms') end,
+      }
+    },
+    curingparestoarms = {
+      waitingfor = {
+        customwait = 4,
+  
+        oncompleted = function()
+          svo.rmaff('parestoarms')
+  
+          local result = svo.checkany(svo.dict.curingmutilatedrightarm.waitingfor, svo.dict.curingmutilatedleftarm.waitingfor, svo.dict.curingmangledrightarm.waitingfor, svo.dict.curingmangledleftarm.waitingfor)
+  
+          if result then
+            svo.killaction(svo.dict[result.action_name].waitingfor)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        ontimeout = function() svo.rmaff('parestoarms') end,
+  
+        noeffect = function() svo.rmaff('parestoarms') end
+      }
+    },
+    mutilatedleftarm = {
+      gamename = 'mangledleftarm',
+      salve = {
+        isadvisable = function()
+          return (affs.mutilatedleftarm) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingmutilatedleftarm.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to arms", "apply restoration", "apply reconstructive to arms", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.mutilatedleftarm.salve, " to arms")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.mutilatedleftarm.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          codepaste.addrestobreakarm('mutilatedleftarm', oldhp)
+        end,
+  
+        tekura = function (oldhp)
+          codepaste.addrestobreakarm('mutilatedleftarm', oldhp, true)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mutilatedleftarm') end,
+      },
+      onremoved = function() signals.canoutr:emit() end
+    },
+    curingmutilatedleftarm = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('mutilatedleftarm')
+          svo.addaffdict(svo.dict.mangledleftarm)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+  
+          local result = svo.checkany(svo.dict.curingmutilatedrightarm.waitingfor, svo.dict.curingmangledrightarm.waitingfor, svo.dict.curingmangledleftarm.waitingfor, svo.dict.curingparestoarms.waitingfor)
+  
+          if result then
+            svo.killaction(svo.dict[result.action_name].waitingfor)
+          end
+        end,
+  
+        ontimeout = function()
+          if affs.mutilatedleftarm then
+            svo.rmaff('mutilatedleftarm')
+            svo.addaffdict(svo.dict.mangledleftarm)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        oncuredleft = function()
+          svo.rmaff('mutilatedleftarm')
+          svo.addaffdict(svo.dict.mangledleftarm)
+        end,
+  
+        noeffect = function() svo.rmaff('mutilatedleftarm') end
+      }
+    },
+    mangledleftarm = {
+      gamename = 'damagedleftarm',
+      salve = {
+        isadvisable = function()
+          return (affs.mangledleftarm and not (affs.mutilatedrightarm or affs.mutilatedleftarm)) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingmangledleftarm.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to arms", "apply restoration", "apply reconstructive to arms", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.mangledleftarm.salve, " to arms")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.mangledleftarm.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          codepaste.addrestobreakarm('mangledleftarm', oldhp)
+        end,
+  
+        tekura = function (oldhp)
+          codepaste.addrestobreakarm('mangledleftarm', oldhp, true)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mangledleftarm') end,
+      },
+      onremoved = function() signals.canoutr:emit() end
+    },
+    curingmangledleftarm = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('parestoarms')
+          svo.rmaff('mangledleftarm')
+          svo.addaffdict(svo.dict.crippledleftarm)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+  
+          local result = svo.checkany(svo.dict.curingmutilatedrightarm.waitingfor, svo.dict.curingmutilatedleftarm.waitingfor, svo.dict.curingmangledrightarm.waitingfor, svo.dict.curingparestoarms.waitingfor)
+  
+          if result then
+            svo.killaction(svo.dict[result.action_name].waitingfor)
+          end
+        end,
+  
+        ontimeout = function()
+          if affs.mangledleftarm then
+            svo.rmaff('mangledleftarm')
+            svo.addaffdict(svo.dict.crippledleftarm)
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        oncuredleft = function()
+          svo.rmaff('mangledleftarm')
+          svo.addaffdict(svo.dict.crippledleftarm)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+        end,
+  
+        noeffect = function() svo.rmaff('mangledleftarm') end
+      }
+    },
+    crippledleftarm = {
+      gamename = 'brokenleftarm',
+      salve = {
+        isadvisable = function()
+          return (affs.crippledleftarm and not (affs.mutilatedleftarm or affs.mangledleftarm or affs.parestoarms)) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('crippledleftarm')
+  
+          if affs.unknowncrippledlimb then
+            svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count - 1
+            if svo.dict.unknowncrippledlimb.count &lt;= 0 then svo.rmaff'unknowncrippledlimb' else svo.updateaffcount(svo.dict.unknowncrippledlimb) end
+          end
+  
+          if not affs.unknowncrippledarm then return end
+          svo.dict.unknowncrippledarm.count = svo.dict.unknowncrippledarm.count - 1
+          if svo.dict.unknowncrippledarm.count &lt;= 0 then svo.rmaff'unknowncrippledarm' else svo.updateaffcount(svo.dict.unknowncrippledarm) end
+        end,
+  
+        applycure = {'mending', 'renewal'},
+        actions = {"apply mending to arms", "apply mending", "apply renewal to arms", "apply renewal"},
+        onstart = function()
+          svo.apply(svo.dict.crippledleftarm.salve, " to arms")
+        end,
+  
+        fizzled = function()
+          svo.lostbal_salve()
+          svo.addaffdict(svo.dict.mangledleftarm)
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.noeffect_mending_arms()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.crippledleftarm)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          signals.canoutr:emit()
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('crippledleftarm') end,
+      },
+      onremoved = function() signals.canoutr:emit() end
+    },
+    mutilatedrightarm = {
+      gamename = 'mangledrightarm',
+      salve = {
+        isadvisable = function()
+          return (affs.mutilatedrightarm) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingmutilatedrightarm.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to arms", "apply restoration", "apply reconstructive to arms", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.mutilatedrightarm.salve, " to arms")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.mutilatedrightarm.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          codepaste.addrestobreakarm('mutilatedrightarm', oldhp)
+        end,
+  
+        tekura = function (oldhp)
+          codepaste.addrestobreakarm('mutilatedrightarm', oldhp, true)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mutilatedrightarm') end,
+      },
+      onremoved = function() signals.canoutr:emit() end
+    },
+    curingmutilatedrightarm = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('mutilatedrightarm')
+          svo.addaffdict(svo.dict.mangledrightarm)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+  
+          local result = svo.checkany(svo.dict.curingmutilatedleftarm.waitingfor, svo.dict.curingmangledrightarm.waitingfor, svo.dict.curingmangledleftarm.waitingfor, svo.dict.curingparestoarms.waitingfor)
+  
+          if result then
+            svo.killaction(svo.dict[result.action_name].waitingfor)
+          end
+        end,
+  
+        ontimeout = function()
+          if affs.mutilatedrightarm then
+            svo.rmaff('mutilatedrightarm')
+            svo.addaffdict(svo.dict.mangledrightarm)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        oncuredleft = function()
+          svo.rmaff('mutilatedleftarm')
+          svo.addaffdict(svo.dict.mangledleftarm)
+        end,
+  
+        noeffect = function() svo.rmaff('mutilatedrightarm') end
+      }
+    },
+    mangledrightarm = {
+      gamename = 'damagedrightarm',
+      salve = {
+        isadvisable = function()
+          return (affs.mangledrightarm and not (affs.mutilatedrightarm or affs.mutilatedleftarm)) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingmangledrightarm.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to arms", "apply restoration", "apply reconstructive to arms", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.mangledrightarm.salve, " to arms")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.mangledrightarm.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          codepaste.addrestobreakarm('mangledrightarm', oldhp)
+        end,
+  
+        tekura = function (oldhp)
+          codepaste.addrestobreakarm('mangledrightarm', oldhp, true)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mangledrightarm') end,
+      },
+      onremoved = function() signals.canoutr:emit() end
+    },
+    curingmangledrightarm = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('mangledrightarm')
+          svo.rmaff('parestoarms')
+          svo.addaffdict(svo.dict.crippledrightarm)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+  
+          local result = svo.checkany(svo.dict.curingmutilatedrightarm.waitingfor, svo.dict.curingmutilatedleftarm.waitingfor, svo.dict.curingmangledleftarm.waitingfor, svo.dict.curingparestoarms.waitingfor)
+  
+          if result then
+            svo.killaction(svo.dict[result.action_name].waitingfor)
+          end
+        end,
+  
+        ontimeout = function()
+          if affs.mangledrightarm then
+            svo.rmaff('mangledrightarm')
+            svo.addaffdict(svo.dict.crippledrightarm)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        oncuredleft = function()
+          svo.rmaff('mangledleftarm')
+          svo.addaffdict(svo.dict.crippledleftarm)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+        end,
+  
+        noeffect = function() svo.rmaff('mangledrightarm') end
+      }
+    },
+    crippledrightarm = {
+      gamename = 'brokenrightarm',
+      salve = {
+        isadvisable = function()
+          return (affs.crippledrightarm and not (affs.mutilatedrightarm or affs.mangledrightarm or affs.parestoarms)) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('crippledrightarm')
+  
+          if affs.unknowncrippledlimb then
+            svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count - 1
+            if svo.dict.unknowncrippledlimb.count &lt;= 0 then svo.rmaff'unknowncrippledlimb' else svo.updateaffcount(svo.dict.unknowncrippledlimb) end
+          end
+  
+          if not affs.unknowncrippledarm then return end
+          svo.dict.unknowncrippledarm.count = svo.dict.unknowncrippledarm.count - 1
+          if svo.dict.unknowncrippledarm.count &lt;= 0 then svo.rmaff'unknowncrippledarm' else svo.updateaffcount(svo.dict.unknowncrippledarm) end
+        end,
+  
+        applycure = {'mending', 'renewal'},
+        actions = {"apply mending to arms", "apply mending", "apply renewal to arms", "apply renewal"},
+        onstart = function()
+          svo.apply(svo.dict.crippledrightarm.salve, " to arms")
+        end,
+  
+        fizzled = function()
+          svo.lostbal_salve()
+          svo.addaffdict(svo.dict.mangledrightarm)
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.noeffect_mending_arms()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.crippledrightarm)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          signals.canoutr:emit()
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('crippledrightarm') end,
+      },
+      onremoved = function() signals.canoutr:emit() end
+    },
+    laceratedthroat = {
+      salve = {
+        isadvisable = function()
+          return (affs.laceratedthroat) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curinglaceratedthroat.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to head", "apply restoration", "apply reconstructive to head", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.laceratedthroat.salve, " to head")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.laceratedthroat.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.laceratedthroat)
+        end,
+  
+        -- separated, so we can use it normally if necessary - another class might get it
+        sylvanhit = function (oldhp)
+          if not conf.aillusion or (not affs.recklessness and stats.currenthealth &lt; oldhp) then
+            svo.addaffdict(svo.dict.laceratedthroat)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('laceratedthroat') end,
+      }
+    },
+    curinglaceratedthroat = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('laceratedthroat')
+          svo.addaffdict(svo.dict.slashedthroat)
+        end,
+  
+        onstart = function() end,
+  
+        noeffect = function()
+          svo.rmaff('laceratedthroat')
+          svo.addaffdict(svo.dict.slashedthroat)
+        end
+      }
+    },
+    slashedthroat = {
+      salve = {
+        isadvisable = function()
+          return (affs.slashedthroat) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('slashedthroat')
+        end,
+  
+        noeffect = function()
+          empty.apply_epidermal_head()
+        end,
+  
+        empty = function()
+          empty.apply_epidermal_head()
+        end,
+  
+        applycure = {'epidermal', 'sensory'},
+        actions = {"apply epidermal to head", "apply epidermal", "apply sensory to head", "apply sensory"},
+        onstart = function()
+          svo.apply(svo.dict.slashedthroat.salve, " to head")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.slashedthroat)
+        end,
+  
+        -- separated, so we can use it normally if necessary - another class might get it
+        sylvanhit = function (oldhp)
+          if not conf.aillusion or (not affs.recklessness and stats.currenthealth &lt; oldhp) then
+            svo.addaffdict(svo.dict.slashedthroat)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('slashedthroat') end,
+      }
+    },
+    serioustrauma = {
+      salve = {
+        isadvisable = function()
+          return (affs.serioustrauma) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingserioustrauma.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to torso", "apply restoration", "apply reconstructive to torso", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.serioustrauma.salve, " to torso")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.serioustrauma.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          if not conf.aillusion or not oldhp or oldhp &gt; stats.currenthealth or svo.paragraph_length &gt;= 3 then
+            if affs.mildtrauma then svo.rmaff('mildtrauma') end
+            svo.addaffdict(svo.dict.serioustrauma)
+          end
+        end,
+  
+        forced = function()
+          if affs.mildtrauma then svo.rmaff('mildtrauma') end
+          svo.addaffdict(svo.dict.serioustrauma)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('serioustrauma') end,
+      }
+    },
+    curingserioustrauma = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('serioustrauma')
+          svo.addaffdict(svo.dict.mildtrauma)
+        end,
+  
+        ontimeout = function()
+          if affs.serioustrauma then
+            svo.rmaff('serioustrauma')
+            svo.addaffdict(svo.dict.mildtrauma)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        noeffect = function()
+          svo.rmaff('serioustrauma')
+          svo.rmaff('mildtrauma')
+        end
+      }
+    },
+    mildtrauma = {
+      salve = {
+        isadvisable = function()
+          return (affs.mildtrauma) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingmildtrauma.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to torso", "apply restoration", "apply reconstructive to torso", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.mildtrauma.salve, " to torso")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.mildtrauma.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          if not conf.aillusion or not oldhp or oldhp &gt; stats.currenthealth or svo.paragraph_length &gt;= 3 then
+            svo.addaffdict(svo.dict.mildtrauma)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mildtrauma') end,
+      }
+    },
+    curingmildtrauma = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function() svo.rmaff('mildtrauma') end,
+  
+        ontimeout = function() svo.rmaff('mildtrauma') end,
+  
+        onstart = function() end,
+  
+        noeffect = function() svo.rmaff('mildtrauma') end
+      }
+    },
+    seriousconcussion = {
+      gamename = 'mangledhead',
+      salve = {
+        isadvisable = function()
+          return (affs.seriousconcussion) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingseriousconcussion.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to head", "apply restoration", "apply reconstructive to head", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.seriousconcussion.salve, " to head")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.seriousconcussion.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          if not conf.aillusion or not oldhp or oldhp &gt; stats.currenthealth or svo.paragraph_length &gt;= 3 then
+            if affs.mildconcussion then svo.rmaff('mildconcussion') end
+            svo.addaffdict(svo.dict.seriousconcussion)
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          end
+        end,
+  
+        forced = function()
+          if affs.mildconcussion then svo.rmaff('mildconcussion') end
+          svo.addaffdict(svo.dict.seriousconcussion)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('seriousconcussion') end,
+      },
+      onadded = function()
+        if affs.prone and affs.seriousconcussion then
+          sk.warn 'pulpable'
         end
       end
-    }
-  },
-  stolebalance = {
-    happened = {
-      oncompleted = function (balance)
-        svo['lostbal_'..balance]()
-      end
-    }
-  },
-  gotbalance = {
-    happened = {
+    },
+    curingseriousconcussion = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function()
+          svo.rmaff('seriousconcussion')
+          svo.addaffdict(svo.dict.mildconcussion)
+        end,
+  
+        ontimeout = function()
+          if affs.seriousconcussion then
+            svo.rmaff('seriousconcussion')
+            svo.addaffdict(svo.dict.mildconcussion)
+          end
+        end,
+  
+        onstart = function() end,
+  
+        noeffect = function()
+          svo.rmaff('seriousconcussion')
+          svo.rmaff('mildconcussion')
+        end
+      }
+    },
+    mildconcussion = {
+      gamename = 'damagedhead',
+      salve = {
+        isadvisable = function()
+          return (affs.mildconcussion) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+  
+          svo.doaction(svo.dict.curingmildconcussion.waitingfor)
+        end,
+  
+        applycure = {'restoration', 'reconstructive'},
+        actions = {"apply restoration to head", "apply restoration", "apply reconstructive to head", "apply reconstructive"},
+        onstart = function()
+          svo.apply(svo.dict.mildconcussion.salve, " to head")
+        end,
+  
+        -- we get no msg from an application of this
+        empty = function()
+          svo.dict.mildconcussion.salve.oncompleted()
+        end
+      },
+      aff = {
+        oncompleted = function (oldhp)
+          if not conf.aillusion or not oldhp or oldhp &gt; stats.currenthealth or svo.paragraph_length &gt;= 3 then
+            svo.addaffdict(svo.dict.mildconcussion)
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          end
+        end,
+  
+        forced = function()
+          svo.addaffdict(svo.dict.mildconcussion)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mildconcussion') end,
+      }
+    },
+    curingmildconcussion = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function() svo.rmaff('mildconcussion') end,
+  
+        ontimeout = function() svo.rmaff('mildconcussion') end,
+  
+        onstart = function() end,
+  
+        noeffect = function() svo.rmaff('mildconcussion') end
+      }
+    },
+  
+  
+  -- salve cures
+    anorexia = {
+      salve = {
+        isadvisable = function()
+          return (affs.anorexia and not svo.doingaction'anorexia') or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('anorexia')
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.apply_epidermal_body()
+        end,
+  
+        empty = function()
+          empty.apply_epidermal_body()
+        end,
+  
+        applycure = {'epidermal', 'sensory'},
+        actions = {"apply epidermal to body", "apply epidermal", "apply sensory to body", "apply sensory"},
+        onstart = function()
+          svo.apply(svo.dict.anorexia.salve, " to body")
+        end
+      },
+      focus = {
+        isadvisable = function()
+          return (affs.anorexia and
+            not svo.doingaction('anorexia')) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('anorexia')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.anorexia)
+          codepaste.badaeon()
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('anorexia')
+          codepaste.remove_focusable()
+        end,
+      }
+    },
+    
+    ablaze = {           
+      gamename = 'burning',
+      onservereignore = function()
+        return ((svo.defdefup[svo.defs.mode].torch or svo.defkeepup[svo.defs.mode].torch) and 
+        (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady"))
+      end,
+      salve = {
+        isadvisable = function()
+          return (affs.ablaze and not (defdefup[defs.mode].torch or (conf.keepup and defkeepup[defs.mode].torch) and 
+          (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady"))) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('ablaze')
+          if defc.torch and (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady") then
+            defences.lost('torch')
+          end
+        end,
+  
+        all = function()
+          svo.lostbal_salve()
+          codepaste.remove_burns()
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        empty = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        applycure = {'mending'},
+        actions = {"apply mending to body", "apply mending"},
+        onstart = function()
+          svo.apply(svo.dict.ablaze.salve, " to body")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          if ((defdefup[defs.mode].torch) or (conf.keepup and defkeepup[defs.mode].torch)) and 
+          (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady") then
+            defences.got('torch')
+          else
+            codepaste.remove_burns('ablaze')
+            svo.addaffdict(svo.dict.ablaze)
+          end
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          local currentburn = sk.current_burn()
+          svo.rmaff(currentburn)
+          if defc.torch and (svo.me.class == "fire Elemental Lord" or svo.me.class == "fire Elemental Lady") then
+            defences.lost('torch')
+          end
+        end,
+  
+        -- used in blackout and passive curing where multiple levels could be cured at once
+        generic_reducelevel = function(amount)
+          -- if no amount is specified, find the current level and take it down a notch
+          if not amount then
+            local reduceto, currentburn = sk.previous_burn(), sk.current_burn()
+  
+            svo.rmaff(currentburn)
+            svo.addaffdict(svo.dict[reduceto])
+          else -- amount is specified
+            local reduceto, currentburn = sk.previous_burn(amount), sk.current_burn()
+            svo.rmaff(currentburn)
+  
+            if not reduceto then reduceto = 'ablaze' end
+            svo.addaffdict(svo.dict[reduceto])
+          end
+        end
+      }
+    },
+    severeburn = {
+      salve = {
+        irregular = true,
+  
+        isadvisable = function()
+          return (affs.severeburn) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('severeburn')
+          svo.addaffdict(svo.dict.ablaze)
+        end,
+  
+        all = function()
+          svo.lostbal_salve()
+          codepaste.remove_burns()
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        empty = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        applycure = {'mending', 'renewal'},
+        actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal"},
+        onstart = function()
+          svo.apply(svo.dict.severeburn.salve, " to body")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          codepaste.remove_burns('severeburn')
+          svo.addaffdict(svo.dict.severeburn)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('severeburn') end,
+      }
+    },
+    extremeburn = {
+      salve = {
+        irregular = true,
+  
+        isadvisable = function()
+          return (affs.extremeburn) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('extremeburn')
+          svo.addaffdict(svo.dict.severeburn)
+        end,
+  
+        all = function()
+          svo.lostbal_salve()
+          codepaste.remove_burns()
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        empty = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        applycure = {'mending', 'renewal'},
+        actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal"},
+        onstart = function()
+          svo.apply(svo.dict.extremeburn.salve, " to body")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          codepaste.remove_burns('extremeburn')
+          svo.addaffdict(svo.dict.extremeburn)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('extremeburn') end,
+      }
+    },
+    charredburn = {
+      salve = {
+        irregular = true,
+  
+        isadvisable = function()
+          return (affs.charredburn) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('charredburn')
+          svo.addaffdict(svo.dict.extremeburn)
+        end,
+  
+        all = function()
+          svo.lostbal_salve()
+          codepaste.remove_burns()
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        empty = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        applycure = {'mending', 'renewal'},
+        actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal"},
+        onstart = function()
+          svo.apply(svo.dict.charredburn.salve, " to body")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          codepaste.remove_burns('charredburn')
+          svo.addaffdict(svo.dict.charredburn)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('charredburn') end,
+      }
+    },
+    meltingburn = {
+      salve = {
+        irregular = true,
+  
+        isadvisable = function()
+          return (affs.meltingburn) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('meltingburn')
+          svo.addaffdict(svo.dict.charredburn)
+        end,
+  
+        all = function()
+          svo.lostbal_salve()
+          codepaste.remove_burns()
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        empty = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        applycure = {'mending', 'renewal'},
+        actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal"},
+        onstart = function()
+          svo.apply(svo.dict.meltingburn.salve, " to body")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          codepaste.remove_burns('meltingburn')
+          svo.addaffdict(svo.dict.meltingburn)
+  
+          sk.warn 'golemdestroyable'
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('meltingburn') end,
+      }
+    },
+    selarnia = {
+      salve = {
+        isadvisable = function()
+          return (affs.selarnia) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('selarnia')
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        empty = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        applycure = {'mending', 'renewal'},
+        actions = {"apply mending to body", "apply mending", "apply renewal to body", "apply renewal", "apply mending to torso", "apply renewal to torso"},
+        onstart = function()
+          svo.apply(svo.dict.selarnia.salve, " to body")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.selarnia)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('selarnia') end,
+      }
+    },
+    itching = {
+      salve = {
+        isadvisable = function()
+          return (affs.itching) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('itching')
+        end,
+  
+        noeffect = function()
+          empty.apply_epidermal_body()
+        end,
+  
+        empty = function()
+          empty.apply_epidermal_body()
+        end,
+  
+        applycure = {'epidermal', 'sensory'},
+        actions = {"apply epidermal to body", "apply epidermal", "apply sensory to body", "apply sensory"},
+        onstart = function()
+          svo.apply(svo.dict.itching.salve, " to body")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.itching)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('itching') end,
+      }
+    },
+    stuttering = {
+      salve = {
+        isadvisable = function()
+          return (affs.stuttering and not affs.tonguetied) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('stuttering')
+        end,
+  
+        noeffect = function()
+          empty.apply_epidermal_head()
+        end,
+  
+        empty = function()
+          empty.apply_epidermal_head()
+        end,
+  
+        applycure = {'epidermal', 'sensory'},
+        actions = {"apply epidermal to head", "apply epidermal", "apply sensory to head", "apply sensory"},
+        onstart = function()
+          svo.apply(svo.dict.stuttering.salve, " to head")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.stuttering)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('stuttering') end,
+      }
+    },
+    scalded = {
+      salve = {
+        isadvisable = function()
+          return (affs.scalded and not defc.blind and not affs.blindaff) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('scalded')
+        end,
+  
+        noeffect = function()
+          empty.apply_epidermal_head()
+        end,
+  
+        empty = function()
+          empty.apply_epidermal_head()
+        end,
+  
+        applycure = {'epidermal', 'sensory'},
+        actions = {"apply epidermal to head", "apply epidermal", "apply sensory to head", "apply sensory"},
+        onstart = function()
+          svo.apply(svo.dict.scalded.salve, " to head")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.scalded)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('scalded') end,
+      }
+    },
+    numbedleftarm = {
+      waitingfor = {
+        customwait = 15, -- lasts 15s
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        ontimeout = function()
+          svo.rmaff('numbedleftarm')
+          svo.make_gnomes_work()
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('numbedleftarm')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.numbedleftarm)
+          if not svo.actions.numbedleftarm_waitingfor then svo.doaction(svo.dict.numbedleftarm.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('numbedleftarm')
+          svo.killaction(svo.dict.numbedleftarm.waitingfor)
+        end,
+      }
+    },
+    numbedrightarm = {
+      waitingfor = {
+        customwait = 8, -- lasts 8s
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        ontimeout = function()
+          svo.rmaff('numbedrightarm')
+          svo.make_gnomes_work()
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('numbedrightarm')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.numbedrightarm)
+          if not svo.actions.numbedrightarm_waitingfor then svo.doaction(svo.dict.numbedrightarm.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('numbedrightarm')
+          svo.killaction(svo.dict.numbedrightarm.waitingfor)
+        end,
+      }
+    },
+  revealed = {
+      waitingfor = {
+        customwait = 80, -- lasts 80s
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        ontimeout = function()
+          svo.rmaff('revealed')
+          svo.make_gnomes_work()
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('revealed')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.revealed)
+          if not svo.actions.revealed_waitingfor then svo.doaction(svo.dict.revealed.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('revealed')
+          svo.killaction(svo.dict.revealed.waitingfor)
+        end,
+      }
+    },
+    blindaff = {
+      gamename = 'blind',
+      onservereignore = function()
+        return (svo.defdefup[svo.defs.mode].blind or svo.defkeepup[svo.defs.mode].blind)
+      end,
+      salve = {
+        isadvisable = function()
+          return (affs.blindaff and not ((sys.deffing and defdefup[defs.mode].blind) or
+            (conf.keepup and defkeepup[defs.mode].blind)) or affs.scalded) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('blindaff')
+          defences.lost('blind')
+  
+          local restoreaff, restoredef
+          if affs.deafaff then restoreaff = true end
+          if defc.deaf then restoredef = true end
+  
+          empty.apply_epidermal_head()
+  
+          if restoreaff then svo.addaffdict(svo.dict.deafaff) end
+          if restoredef then defences.got('deaf') end
+        end,
+  
+        noeffect = function()
+          empty.apply_epidermal_head()
+        end,
+  
+        empty = function()
+          empty.apply_epidermal_head()
+        end,
+  
+        applycure = {'epidermal'},
+        actions = {"apply epidermal to head", "apply epidermal"},
+        onstart = function()
+          svo.apply(svo.dict.blindaff.salve, " to head")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          if (defdefup[defs.mode].blind) or (conf.keepup and defkeepup[defs.mode].blind) or
+            (svo.me.class == 'Apostate' or defc.mindseye) then
+            defences.got('blind')
+          else
+            svo.addaffdict(svo.dict.blindaff)
+          end
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('blindaff')
+          defences.lost('blind')
+        end,
+      }
+    },
+    deafaff = {
+      gamename = 'deaf',
+      onservereignore = function()
+        return (svo.defdefup[svo.defs.mode].deaf or svo.defkeepup[svo.defs.mode].deaf)
+      end,
+      salve = {
+        isadvisable = function()
+          return (affs.deafaff and not ((sys.deffing and defdefup[defs.mode].deaf) or
+            (conf.keepup and defkeepup[defs.mode].deaf))) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('deafaff')
+          defences.lost('deaf')
+        end,
+  
+        noeffect = function()
+          empty.apply_epidermal_head()
+        end,
+  
+        empty = function()
+          empty.apply_epidermal_head()
+        end,
+  
+        applycure = {'epidermal', 'sensory'},
+        actions = {"apply epidermal to head", "apply epidermal", "apply sensory to head", "apply sensory"},
+        onstart = function()
+          svo.apply(svo.dict.deafaff.salve, " to head")
+        end
+      },
+      aff = {
+        oncompleted = function()
+          if (defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf) or defc.mindseye then
+            defences.got('deaf')
+          else
+            svo.addaffdict(svo.dict.deafaff)
+          end
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('deafaff')
+          defences.lost('deaf')
+        end,
+      }
+    },
+  
+    shivering = {
+      salve = {
+        isadvisable = function()
+          return (affs.shivering and not affs.frozen and not affs.hypothermia) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('shivering')
+        end,
+  
+        noeffect = function() svo.lostbal_salve() end,
+  
+        gotcaloricdef = function (hypothermia)
+          if not hypothermia then svo.rmaff({'frozen', 'shivering'}) end
+          svo.dict.caloric.salve.oncompleted ()
+        end,
+  
+        applycure = {'caloric', 'exothermic'},
+        actions = {"apply caloric to body", "apply caloric", "apply exothermic to body", "apply exothermic"},
+        onstart = function()
+          svo.apply(svo.dict.shivering.salve, " to body")
+        end,
+  
+        empty = function()
+          svo.lostbal_salve()
+          svo.rmaff('shivering')
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.shivering)
+          defences.lost('caloric')
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('shivering') end,
+      }
+    },
+    frozen = {
+      salve = {
+        isadvisable = function()
+          return (affs.frozen and not affs.hypothermia) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('frozen')
+          svo.addaffdict(svo.dict.shivering)
+        end,
+  
+        noeffect = function() svo.lostbal_salve() end,
+  
+        gotcaloricdef = function (hypothermia)
+          if not hypothermia then svo.rmaff({'frozen', 'shivering'}) end
+          svo.dict.caloric.salve.oncompleted ()
+        end,
+  
+        applycure = {'caloric', 'exothermic'},
+        actions = {"apply caloric to body", "apply caloric", "apply exothermic to body", "apply exothermic"},
+        onstart = function()
+          svo.apply(svo.dict.frozen.salve, " to body")
+        end,
+  
+        empty = function()
+          svo.lostbal_salve()
+          svo.rmaff('frozen')
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.frozen)
+          defences.lost('caloric')
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('frozen') end
+      }
+    },
+  
+  -- purgatives
+    voyria = {
+      purgative = {
+        isadvisable = function()
+          return not affs.latency and ((affs.voyria) or false)
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_purgative()
+          svo.rmaff('voyria')
+        end,
+  
+        sipcure = {'immunity', 'antigen'},
+        onstart = function()
+          svo.sip(svo.dict.voyria.purgative)
+        end,
+  
+        noeffect = function()
+          svo.rmaff('voyria')
+          svo.lostbal_purgative()
+        end,
+  
+        empty = function()
+          svo.lostbal_purgative()
+          empty.sip_immunity()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.voyria)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('voyria') end
+      }
+    },
+  
+  
+  -- misc
+    lovers = {
+      map = {},
       tempmap = {},
-      oncompleted = function()
-        for _, balance in ipairs(svo.dict.gotbalance.happened.tempmap) do
-          if not bals[balance] then
-            bals[balance] = true
-
-            raiseEvent("svo got balance", balance)
-
-            svo.endbalancewatch(balance)
-
-            -- this concern should be separated into its own
-            if balance == 'tree' then
-              killTimer(sys.treetimer)
+      physical = {
+        balanceful_act = true,
+        dontbatch = true,
+  
+        isadvisable = function()
+          return (affs.lovers and not svo.doingaction('lovers')) or false
+        end,
+  
+        oncompleted = function (whom)
+          svo.dict.lovers.map[whom] = nil
+          if not next(svo.dict.lovers.map) then
+            svo.rmaff('lovers')
+          end
+        end,
+  
+        onclear = function()
+          svo.dict.lovers.tempmap = {}
+        end,
+  
+        nobody = function()
+          if svo.dict.lovers.rejecting then
+            svo.dict.lovers.map[svo.dict.lovers.rejecting] = nil
+            svo.dict.lovers.rejecting = nil
+          end
+  
+          if not next(svo.dict.lovers.map) then
+            svo.rmaff('lovers')
+          end
+        end,
+  
+        onstart = function()
+          svo.dict.lovers.rejecting = next(svo.dict.lovers.map)
+          if not svo.dict.lovers.rejecting then -- if we added it via some manual way w/o a name, this failsafe will catch &amp; remove it
+            svo.rmaff('lovers')
+            return
+          end
+  
+          send("reject " .. svo.dict.lovers.rejecting, conf.commandecho)
+        end
+      },
+      aff = {
+        oncompleted = function (whom)
+          if not svo.dict.lovers.tempmap and not whom then return end
+  
+          svo.addaffdict(svo.dict.lovers)
+          for _, name in ipairs(svo.dict.lovers.tempmap) do
+            svo.dict.lovers.map[name] = true
+          end
+          svo.dict.lovers.tempmap = {}
+  
+          if whom then
+            svo.dict.lovers[whom] = true
+          end
+  
+          svo.affl.lovers = {names = svo.dict.lovers.map}
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('lovers')
+          svo.dict.lovers.map = {}
+        end,
+      }
+    },
+    fear = {
+      misc = {
+        isadvisable = function()
+          return (affs.fear and not affs.horror and not svo.doingaction('fear')) or false
+        end,
+  
+        oncompleted = function() svo.rmaff('fear') end,
+  
+        action = 'compose',
+        onstart = function() send('compose', conf.commandecho) end
+      },
+      focus = {
+        isadvisable = function()
+          return false
+          --[[return (affs.fear and
+            not svo.doingaction('fear')) or false]]
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('fear')
+          svo.lostbal_focus()
+        end,
+  
+        action = 'focus',
+        onstart = function() send('focus', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          empty.focus()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.fear)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('fear')
+          codepaste.remove_focusable()
+        end
+      }
+    },
+    sleep = {
+      misc = {
+        isadvisable = function()
+          return (affs.sleep and
+            not svo.doingaction('curingsleep') and not svo.doingaction('sleep')) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.curingsleep.waitingfor)
+        end,
+  
+        actions = {'wake', "wake up"},
+        onstart = function() send('wake up', conf.commandecho) end,
+  
+        -- ???
+        empty = function() end
+      },
+      aff = {
+        oncompleted = function()
+          if not affs.sleep then svo.addaffdict(svo.dict.sleep) defences.lost('insomnia') end
+        end,
+  
+        symptom = function()
+          if not affs.sleep then svo.addaffdict(svo.dict.sleep) defences.lost('insomnia') end
+          svo.addaffdict(svo.dict.prone)
+  
+          -- reset non-wait things we were doing, because they got cancelled by the stun
+          if affs.sleep or svo.actions.sleep_aff then
+            for _,v in svo.actions:iter() do
+              if v.p.balance ~= 'waitingfor' and v.p.balance ~= 'aff' and v.p.name ~= 'sleep_misc' then
+                svo.killaction(svo.dict[v.p.action_name][v.p.balance])
+              end
             end
           end
         end
-        svo.dict.gotbalance.happened.tempmap = {}
-      end,
-
-      oncancel = function()
-        svo.dict.gotbalance.happened.tempmap = {}
-      end
-    }
-  },
-  gothit = {
-    happened = {
-      tempmap = {},
-      oncompleted = function()
-        for name, class in pairs(svo.dict.gothit.happened.tempmap) do
-          if name == '?' then
-            raiseEvent("svo got hit by", class)
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('sleep') end,
+      }
+    },
+    curingsleep = {
+      waitingfor = {
+        customwait = 999,
+  
+        oncompleted = function()
+          svo.rmaff('sleep')
+  
+          -- reset sleep so we try waking up again after being awoken and slept at once (like in a dsl or a delph snipe)
+          if svo.actions.sleep_misc then
+            svo.killaction(svo.dict.sleep.misc)
+          end
+        end,
+  
+        onstart = function() end
+      }
+    },
+    bleeding = {
+      count = 0,
+      -- affs.bleeding.spammingbleed is used to throttle bleed spamming so it doesn't get out of control
+      misc = {
+        -- managed outside priorities
+        uncurable = true,
+  
+        isadvisable = function()
+          if affs.bleeding and not svo.doingaction('bleeding') and not affs.bleeding.spammingbleed and not affs.haemophilia and not affs.sleep and svo.can_usemana() and conf.clot then
+            if (not affs.corrupted and svo.dict.bleeding.count &gt;= conf.bleedamount) then
+              return true
+            elseif (affs.corrupted and svo.dict.bleeding.count &gt;= conf.manableedamount) then
+              if stats.currenthealth &gt;= sys.corruptedhealthmin then
+                return true
+              else
+                sk.warn 'cantclotmana'
+                return false
+              end
+            end
+          else return false end
+        end,
+  
+        -- by default, oncompleted means a clot went through okay
+        oncompleted = function()
+          svo.dict.bleeding.saw_haemophilia = nil
+        end,
+  
+        -- oncured in this case means that we actually cured it; don't have any more bleeding
+        oncured = function()
+          if affs.bleeding and affs.bleeding.spammingbleed then killTimer(affs.bleeding.spammingbleed); affs.bleeding.spammingbleed = nil end
+          svo.rmaff('bleeding')
+          svo.dict.bleeding.count = 0
+          svo.dict.bleeding.saw_haemophilia = nil
+        end,
+  
+        nomana = function()
+          if not svo.actions.nomana_waitingfor and stats.currentmana ~= 0 then
+            svo.echof("Seems we're out of mana.")
+            svo.doaction(svo.dict.nomana.waitingfor)
+          end
+  
+          svo.dict.bleeding.saw_haemophilia = nil
+          if affs.bleeding and affs.bleeding.spammingbleed then killTimer(affs.bleeding.spammingbleed); affs.bleeding.spammingbleed = nil end
+        end,
+  
+        haemophilia = function()
+          if svo.dict.bleeding.saw_haemophilia then
+            svo.addaffdict(svo.dict.haemophilia)
+            svo.echof("Seems like we do have haemophilia for real.")
           else
-            raiseEvent("svo got hit by", class, name)
+            svo.dict.bleeding.saw_haemophilia = true
+          end
+          if affs.bleeding and affs.bleeding.spammingbleed then killTimer(affs.bleeding.spammingbleed); affs.bleeding.spammingbleed = nil end
+        end,
+  
+        action = 'clot',
+        onstart = function()
+          local show = conf.commandecho and not conf.gagclot
+          send('clot', show)
+  
+          -- don't optimize with corruption for now (but do if need need be)
+          if not sys.sync and ((not affs.corrupted and svo.stats.mp &gt;= 70 and (svo.dict.bleeding.count and svo.dict.bleeding.count &gt;= 200))
+              or (affs.corrupted and stats.currenthealth+500 &gt;= sys.corruptedhealthmin)) then
+            send('clot', show)
+            send('clot', show)
+  
+            -- after sending a bunch of clots, wait a bit before doing it again
+            if affs.bleeding then
+              if affs.bleeding.spammingbleed then killTimer(affs.bleeding.spammingbleed); affs.bleeding.spammingbleed = nil end
+              affs.bleeding.spammingbleed = tempTimer(svo.getping(), function() affs.bleeding.spammingbleed = nil; svo.make_gnomes_work() end)
+            end
           end
         end
-        svo.dict.gothit.happened.tempmap = {}
-      end,
-
-      oncancel = function()
-        svo.dict.gothit.happened.tempmap = {}
-      end
-    }
-  },
-
--- general defences
-  rebounding = {
-    blocked = false, -- we need to block off in blackout, because otherwise we waste sips
-    smoke = {
-      def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].rebounding and not defc.rebounding) or (conf.keepup and defkeepup[defs.mode].rebounding and not defc.rebounding)) and codepaste.smoke_skullcap_pipe() and not svo.doingaction('waitingonrebounding') and not svo.dict.rebounding.blocked) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.waitingonrebounding.waitingfor)
-        sk.skullcap_smokepuff()
-        svo.lostbal_smoke()
-      end,
-
-      alreadygot = function()
-        defences.got('rebounding')
-        sk.skullcap_smokepuff()
-        svo.lostbal_smoke()
-      end,
-
-      ontimeout = function()
-        if not affs.blackout then return end
-
-        svo.dict.rebounding.blocked = true
-        tempTimer(3, function() svo.dict.rebounding.blocked = false; svo.make_gnomes_work() end)
-      end,
-
-      smokecure = {'skullcap', 'malachite'},
-      onstart = function()
-        send("smoke " .. pipes.skullcap.id, conf.commandecho)
-      end,
-
-      empty = function()
-        svo.dict.rebounding.smoke.oncompleted()
-      end
-    }
-  },
-  waitingonrebounding = {
-    waitingfor = {
-      customwait = 9,
-
-      onstart = function() raiseEvent("svo rebounding start") end,
-
-      oncompleted = function() defences.got('rebounding') end,
-
-      deathtarot = function() -- nothing happens! It just doesn't come up :/
-      end,
-
-      -- expend torso cancels rebounding coming up
-      expend = function()
-        if svo.actions.waitingonrebounding_waitingfor then
-          svo.killaction(svo.dict.waitingonrebounding.waitingfor)
+      },
+      aff = {
+        oncompleted = function (amount)
+          svo.addaffdict(svo.dict.bleeding)
+          -- TODO: affs.count vs svo.dict.count?
+          affs.bleeding.p.count = amount or (affs.bleeding.p.count + 200)
+          svo.updateaffcount(svo.dict.bleeding)
+  
+          -- remove bleeding if we've had it for a while and didn't clot it up
+          if sk.smallbleedremove then killTimer(sk.smallbleedremove) end
+          sk.smallbleedremove = tempTimer(conf.smallbleedremove or 8, function()
+            sk.smallbleedremove = nil
+            if not affs.bleeding then return end
+  
+            if svo.dict.bleeding.count &lt;= conf.bleedamount or svo.dict.bleeding.count &lt;= conf.manableedamount then
+              svo.rmaff('bleeding')
+            end
+          end)
         end
-      end,
-    }
-  },
-  frost = {
-    purgative = {
-      def = true,
-      undeffable = true,
-
-      isadvisable = function()
-        return ((sys.deffing and defdefup[defs.mode].frost and not defc.frost) or (conf.keepup and defkeepup[defs.mode].frost and not defc.frost)) or false
-      end,
-
-      oncompleted = function()
-        defences.got('frost')
-        if svo.haveskillset('metamorphosis') then
-          defences.got('temperance')
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('bleeding') end,
+      },
+      onremoved = function()
+        svo.dict.bleeding.count = 0
+        if sk.smallbleedremove then
+          killTimer(sk.smallbleedremove)
+          sk.smallbleedremove = nil
         end
-      end,
-
-      sipcure = {'frost', 'endothermia'},
-
-      onstart = function()
-        svo.sip(svo.dict.frost.purgative)
-      end,
-
-      empty = function() defences.got('frost') end,
-
-      noeffect = function() defences.got('frost') end
+      end
     },
-    gone = {
-      oncompleted = function()
-        if svo.haveskillset('metamorphosis') then
-          defences.lost('temperance')
-        end
-      end
-    }
-  },
-  venom = {
-    gamename = 'poisonresist',
-    purgative = {
-      def = true,
-
-      isadvisable = function()
-        return ((sys.deffing and defdefup[defs.mode].venom and not defc.venom) or (conf.keepup and defkeepup[defs.mode].venom and not defc.venom)) or false
-      end,
-
-      oncompleted = function() defences.got('venom') end,
-
-      noeffect = function() defences.got('venom') end,
-
-      sipcure = {'venom', 'toxin'},
-
-      onstart = function()
-        svo.sip(svo.dict.venom.purgative)
-      end,
-
-      empty = function() defences.got('venom') end
-    }
-  },
-  levitation = {
-    gamename = 'levitating',
-    purgative = {
-      def = true,
-
-      isadvisable = function()
-        return ((sys.deffing and defdefup[defs.mode].levitation and not defc.levitation) or (conf.keepup and defkeepup[defs.mode].levitation and not defc.levitation)) or false
-      end,
-
-      oncompleted = function() defences.got('levitation') end,
-
-      noeffect = function() defences.got('levitation') end,
-
-      sipcure = {'levitation', 'hovering'},
-
-      onstart = function()
-        svo.sip(svo.dict.levitation.purgative)
-      end,
-
-      empty = function() defences.got('levitation') end
-    }
-  },
-  speed = {
-    blocked = false, -- we need to block off in blackout, because otherwise we waste sips
-    purgative = {
-      def = true,
-
-      isadvisable = function()
-        return (not defc.speed and ((sys.deffing and defdefup[defs.mode].speed) or (conf.keepup and defkeepup[defs.mode].speed)) and not svo.doingaction('curingspeed') and not svo.doingaction('speed') and not svo.dict.speed.blocked and not me.manualdefcheck) or false
-      end,
-
-      oncompleted = function (def)
-        if def then defences.got('speed')
-        else
-          if affs.palpatar then
-            svo.dict.curingspeed.waitingfor.customwait = 10
-          else
-            svo.dict.curingspeed.waitingfor.customwait = 7
+    touchtree = {
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          if not next(affs) or not bals.tree or svo.doingaction('touchtree') or affs.sleep or not conf.tree or affs.stun
+           or affs.unconsciousness or affs.numbedrightarm or affs.numbedleftarm or affs.paralysis or affs.webbed
+            or affs.bound or affs.transfixed or affs.roped or affs.impale or ((affs.crippledleftarm or affs.mangledleftarm
+             or affs.mutilatedleftarm) and (affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm))
+              or codepaste.nonstdcure() then return false end
+  
+          for name, func in pairs(svo.tree) do
+            if not me.disabledtreefunc[name] then
+              local s,m = pcall(func[1])
+              if s and m then return true end
+            end
           end
-
-          svo.doaction(svo.dict.curingspeed.waitingfor)
+        end,
+  
+        oncompleted = function (aff)
+          -- small heuristic - shivering can be upgraded to frozen
+          if aff == 'shivering' and not affs.shivering and affs.frozen then
+            svo.rmaff('frozen')
+          -- handle levels of burns
+  
+          elseif aff == "all burns" then
+            codepaste.remove_burns()
+  
+          elseif aff == 'burn' then
+            local previousburn, currentburn = sk.previous_burn(), sk.current_burn()
+  
+            if not currentburn then
+              codepaste.remove_burns()
+            else
+              svo.rmaff(currentburn)
+              svo.addaffdict(svo.dict[previousburn])
+            end
+  
+          elseif aff == 'skullfractures' then
+            svo.updateaffcount(svo.dict.skullfractures)
+  
+          elseif aff == "skullfractures cured" then
+            svo.rmaff('skullfractures')
+            svo.dict.skullfractures.count = 0
+  
+          elseif aff == 'crackedribs' then
+            svo.updateaffcount(svo.dict.crackedribs)
+          
+          elseif aff == "crackedribs cured" then
+            svo.rmaff('crackedribs')
+            svo.dict.crackedribs.count = 0
+  
+          elseif aff == 'wristfractures' then
+            svo.updateaffcount(svo.dict.wristfractures)
+  
+          elseif aff == "wristfractures cured" then
+            svo.rmaff('wristfractures')
+            svo.dict.wristfractures.count = 0
+  
+          elseif aff == 'torntendons' then
+            svo.updateaffcount(svo.dict.torntendons)
+  
+          elseif aff == "torntendons cured" then
+            svo.rmaff('torntendons')
+            svo.dict.torntendons.count = 0
+  
+          else
+            svo.rmaff(aff)
+          end
+  
+          svo.lostbal_tree()
+        end,
+  
+        action = "touch tree",
+        onstart = function() send('touch tree', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_tree()
+          empty.tree()
+        end,
+  
+        offbal = function() svo.lostbal_tree() end
+      }
+    },
+    restore = {
+      physical = {
+        balanceful_act = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          if not next(affs) or not conf.restore or svo.usingbal('salve') or codepaste.balanceful_codepaste() or
+            codepaste.nonstdcure() then return false end
+  
+          for name, func in pairs(svo.restore) do
+            if not me.disabledrestorefunc[name] then
+              local s,m = pcall(func[1])
+              if s and m then svo.debugf("restore: %s strat went off", name) return true end
+            end
+          end
+        end,
+  
+        oncompleted = function (number)
+          if number then
+            -- empty
+            if number+1 == getLineNumber() then
+              svo.dict.unknowncrippledlimb.count = 0
+              svo.dict.unknowncrippledarm.count = 0
+              svo.dict.unknowncrippledleg.count = 0
+              svo.rmaff({'crippledleftarm', 'crippledleftleg', 'crippledrightarm', 'crippledrightleg', 'unknowncrippledarm', 'unknowncrippledleg', 'unknowncrippledlimb'})
+            end
+          end
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+        end,
+  
+        action = 'restore',
+        onstart = function() send('restore', conf.commandecho) end
+      }
+    },
+    dragonheal = {
+      physical = {
+        balanceful_act = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          if not next(affs) or not defc.dragonform or not conf.dragonheal or not bals.dragonheal or codepaste.balanceful_codepaste() or codepaste.nonstdcure() or (affs.recklessness and affs.weakness) then return false end
+  
+          for name, func in pairs(svo.dragonheal) do
+            if not me.disableddragonhealfunc[name] then
+              local s,m = pcall(func[1])
+              if s and m then return true end
+            end
+          end
+        end,
+  
+        oncompleted = function (number)
+          if number then
+            -- empty
+            if number+1 == getLineNumber() then
+              empty.dragonheal()
+            end
+          end
+  
+          svo.lostbal_dragonheal()
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+        end,
+  
+        nobalance = function() svo.lostbal_dragonheal() end,
+  
+        action = 'dragonheal',
+        onstart = function() send('dragonheal', conf.commandecho) end
+      }
+    },
+    defcheck = {
+      physical = {
+        balanceful_act = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          return (bals.balance and bals.equilibrium and me.manualdefcheck and not svo.doingaction('defcheck')) or false
+        end,
+  
+        oncompleted = function()
+          me.manualdefcheck = false
+          svo.process_defs()
+        end,
+  
+        ontimeout = function()
+          me.manualdefcheck = false
+        end,
+  
+        action = 'def',
+        onstart = function() send('def', conf.commandecho) end
+      },
+    },
+    diag = {
+      physical = {
+        balanceful_act = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          return ((sys.manualdiag or (affs.unknownmental and affs.unknownmental.p.count &gt;= conf.unknownfocus) or (affs.unknownany and affs.unknownany.p.count &gt;= conf.unknownany)) and bals.balance and bals.equilibrium and not svo.doingaction('diag')) or false
+        end,
+  
+        oncompleted = function()
+          sys.manualdiag = false
+          sk.diag_list = {}
+          svo.rmaff('unknownmental')
+          svo.rmaff('unknownany')
+          svo.dict.unknownmental.count = 0
+          svo.dict.unknownany.count = 0
+          svo.dict.bleeding.saw_haemophilia = nil
+          svo.dict.relapsing.saw_with_checkable = nil
+  
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+        end,
+  
+        actions = {'diag', 'diagnose', "diag me", "diagnose me"},
+        onstart = function() send('diag', conf.commandecho) end
+      },
+    },
+    block = {
+      gamename = 'blocking',
+      physical = {
+        blockingdir = "",
+        balanceless_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          if defc.block and ((conf.keepup and not defkeepup[defs.mode].block and not sys.deffing) or (sys.deffing and not defdefup[defs.mode].block)) and not svo.doingaction'block' then return true end
+  
+          return (
+            ((sys.deffing and defdefup[defs.mode].block) or (conf.keepup and defkeepup[defs.mode].block and not sys.deffing))
+            and (not defc.block or svo.dict.block.physical.blockingdir ~= conf.blockingdir)
+            and not svo.doingaction'block'
+            and (not sys.enabledgmcp or (gmcp.Room and gmcp.Room.Info.exits[conf.blockingdir]))
+            and not codepaste.balanceful_codepaste()
+            and not affs.prone
+            and (not svo.haveskillset('metamorphosis') or (defc.riding or defc.elephant or defc.dragonform or defc.hydra))
+            and (not svo.haveskillset('subterfuge') or not defc.phase)
+          ) or false
+        end,
+  
+        oncompleted = function (dir)
+          if dir then
+            svo.dict.block.physical.blockingdir = sk.anytoshort(dir)
+          else --workaround for looping
+            svo.dict.block.physical.blockingdir = conf.blockingdir
+          end
+          defences.got('block')
+        end,
+  
+        -- in case of failing to block, register that the action has been completed
+        failed = function() end,
+  
+        onstart = function()
+          if (not defc.block or svo.dict.block.physical.blockingdir ~= conf.blockingdir) then
+            send("block "..tostring(conf.blockingdir), conf.commandecho)
+          else
+            send('unblock', conf.commandecho)
+          end
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('block')
+          svo.dict.block.physical.blockingdir = ""
+  
+          if svo.actions.block_physical then
+            svo.killaction(svo.dict.block.physical)
+          end
         end
-      end,
-
-      ontimeout = function()
-        if not affs.blackout then return end
-
-        svo.dict.speed.blocked = true
-        tempTimer(3, function() svo.dict.speed.blocked = false; svo.make_gnomes_work() end)
-      end,
-
-      noeffect = function() defences.got('speed') end,
-
-      sipcure = {'speed', 'haste'},
-
-      onstart = function()
-        svo.sip(svo.dict.speed.purgative)
-      end,
-
-      empty = function()
-        svo.dict.speed.purgative.oncompleted ()
+      }
+    },
+    doparry = {
+      physical = {
+        balanceless_act = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          return (not sys.sp_satisfied and not sys.blockparry and not affs.paralysis
+            and not svo.doingaction('doparry') and ((svo.haveskillset('tekura') and conf.guarding) or conf.parry) and not codepaste.balanceful_codepaste()
+            -- blademasters can parry with their sword sheathed, and monks don't need to wield anything
+            and ((svo.haveskillset('tekura') or svo.me.class == 'Blademaster') or ((not sys.enabledgmcp or defc.dragonform) or (next(me.wielded) and sk.have_parryable())))
+            and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function (limb)
+          local t = svo.sps.parry_currently
+          for currentlimb, _ in pairs(t) do t[currentlimb] = false end
+          t[limb] = true
+          svo.check_sp_satisfied()
+        end,
+  
+        onstart = function()
+          if svo.sps.something_to_parry() then
+            for name, limb in pairs(svo.sp_config.parry_shouldbe) do
+              if limb and limb ~= svo.sps.parry_currently[name] then
+  if not (svo.haveskillset('tekura') and conf.guarding) then
+                send(string.format("%sparry %s", (not defc.dragonform and "" or 'claw'), name), conf.commandecho)
+  else
+                send(string.format("%s %s", (not defc.dragonform and 'guard' or 'clawparry'), name), conf.commandecho)
+  end
+                return
+              end
+            end
+          elseif type(svo.sp_config.parry) == 'string' and svo.sp_config.parry == 'manual' then
+            -- check if we need to unparry in manual
+            for limb, status in pairs(svo.sps.parry_currently) do
+              if status ~= svo.sp_config.parry_shouldbe[limb] then
+  if not (svo.haveskillset('tekura') and conf.guarding) then
+               send(string.format("%sparry nothing", (not defc.dragonform and "" or 'claw')), conf.commandecho)
+  else
+               send(string.format("%s nothing", (not defc.dragonform and 'guard' or 'clawparry')), conf.commandecho)
+  end
+               return
+              end
+            end
+  
+            -- got here? nothing to do...
+            svo.sys.sp_satisfied = true
+          elseif svo.sp_config.priority[1] and not svo.sps.parry_currently[svo.sp_config.priority[1]] then
+  if not (svo.haveskillset('tekura') and conf.guarding) then
+            send(string.format("%sparry %s", (not defc.dragonform and "" or 'claw'), svo.sp_config.priority[1]), conf.commandecho)
+  else
+            send(string.format("%s %s", (not defc.dragonform and 'guard' or 'clawparry'), svo.sp_config.priority[1]), conf.commandecho)
+  end
+          else -- got here? nothing to do...
+            svo.sys.sp_satisfied = true end
+        end,
+  
+        none = function()
+          for limb, _ in pairs(svo.sps.parry_currently) do
+            svo.sps.parry_currently[limb] = false
+          end
+  
+          svo.check_sp_satisfied()
+        end
+      }
+    },
+    doprecache = {
+      misc = {
+        -- not a curable in-game affliction? mark it so priority doesn't get set
+        uncurable = true,
+  
+        isadvisable = function()
+          return (rift.doprecache and not sys.blockoutr and not svo.findbybal'herb' and not svo.doingaction'doprecache' and sys.canoutr) or false
+        end,
+  
+        oncompleted = function()
+          -- check if we still need to precache, and if not, clear rift.doprecache
+          rift.checkprecache()
+  
+          if rift.doprecache then
+            -- allow other outrs to catch up, then re-check again
+            if sys.blockoutr then killTimer(sys.blockoutr); sys.blockoutr = nil end
+            sys.blockoutr = tempTimer(sys.wait + svo.syncdelay(), function() sys.blockoutr = nil
+              svo.debugf("sys.blockoutr expired") svo.make_gnomes_work()
+              end)
+            svo.debugf("sys.blockoutr setup: ", debug.traceback())
+          end
+        end,
+  
+        ontimeout = function()
+          rift.checkprecache()
+        end,
+  
+        onstart = function()
+          for herb, _ in pairs(rift.precache) do
+            if rift.precache[herb] ~= 0 and rift.riftcontents[herb] ~= 0 and (rift.invcontents[herb] &lt; rift.precache[herb]) then
+              send(string.format("outr %s%s", (affs.addiction and "" or (rift.precache[herb] - rift.invcontents[herb].." ")), herb), conf.commandecho)
+              if sys.sync then return end
+            end
+          end
+        end
+      }
+    },
+    prone = {
+      misc = {
+        isadvisable = function()
+          return (affs.prone and (not affs.paralysis or svo.doingaction'paralysis')
+            and (svo.haveskillset('weaponmastery') and (sk.didfootingattack or (bals.balance and bals.equilibrium and bals.leftarm and bals.rightarm)) or (bals.balance and bals.equilibrium and bals.leftarm and bals.rightarm))
+            and not svo.doingaction('prone') and not affs.sleep
+            and not affs.impale
+            and not affs.transfixed
+            and not affs.webbed and not affs.bound and not affs.roped
+            and not affs.crippledleftleg and not affs.crippledrightleg
+            and not affs.mangledleftleg and not affs.mangledrightleg
+            and not affs.mutilatedleftleg and not affs.mutilatedrightleg) or false
+        end,
+  
+        oncompleted = function() svo.rmaff('prone') end,
+  
+        onstart = function()
+  if svo.haveskillset('weaponmastery') then
+          if sk.didfootingattack and conf.recoverfooting then
+            send("recover footing", conf.commandecho)
+            if affs.blackout then send("recover footing", conf.commandecho) end
+          else
+            send('stand', conf.commandecho)
+            if affs.blackout then send('stand', conf.commandecho) end
+          end
+  else
+          send('stand', conf.commandecho)
+          if affs.blackout then send('stand', conf.commandecho) end
+  end
+        end
+      },
+      aff = {
+        oncompleted = function()
+          if not affs.prone then svo.addaffdict(svo.dict.prone) end
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('prone') end
+      },
+      onremoved = function() svo.donext() end,
+      onadded = function()
+        if affs.prone and affs.seriousconcussion then
+          sk.warn 'pulpable'
+        end
       end
     },
-    gone = {
-      oncompleted = function() defences.lost('speed') end
-    }
-  },
-  curingspeed = {
-    waitingfor = {
-      customwait = 7,
-
-      oncompleted = function() defences.got('speed') end,
-
-      ontimeout = function()
-        if defc.speed then return end
-
-        if (sys.deffing and defdefup[defs.mode].speed) or (conf.keepup and defkeepup[defs.mode].speed) then
-          svo.echof("Warning - speed didn't come up in 7s, checking 'def'.")
-          me.manualdefcheck = true
+    disrupt = {
+      gamename = 'disrupted',
+      misc = {
+        isadvisable = function()
+          return (affs.disrupt and not svo.doingaction('disrupt')
+            and not affs.confusion and not affs.sleep) or false
+        end,
+  
+        oncompleted = function() svo.rmaff('disrupt') end,
+  
+        oncured = function() svo.rmaff('disrupt') end,
+  
+        action = 'concentrate',
+        onstart = function() send('concentrate', conf.commandecho) end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.disrupt)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('disrupt') end
+      }
+    },
+    lightpipes = {
+      physical = {
+        balanceless_act = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          return ((not pipes.valerian.arty and not pipes.valerian.lit and pipes.valerian.puffs &gt; 0 and not (pipes.valerian.id == 0)
+            or (not pipes.elm.arty and not pipes.elm.lit and pipes.elm.puffs &gt; 0 and not (pipes.elm.id == 0))
+            or (not pipes.skullcap.arty and not pipes.skullcap.lit and pipes.skullcap.puffs &gt; 0 and not (pipes.skullcap.id == 0))
+            or (not pipes.elm.arty2 and not pipes.elm.lit2 and pipes.elm.puffs2 &gt; 0 and not (pipes.elm.id2 == 0))
+            or (not pipes.valerian.arty2 and not pipes.valerian.lit2 and pipes.valerian.puffs2 &gt; 0 and not (pipes.valerian.id2 == 0))
+            or (not pipes.skullcap.arty2 and not pipes.skullcap.lit2 and pipes.skullcap.puffs2 &gt; 0 and not (pipes.skullcap.id2 == 0))
+            )
+          and (conf.relight or sk.forcelight_valerian or sk.forcelight_skullcap or sk.forcelight_elm)
+          and not (conf.serverside or svo.doingaction('lightskullcap') or svo.doingaction('lightelm') or svo.doingaction('lightvalerian') or svo.doingaction('lightpipes'))) or false
+        end,
+  
+        oncompleted = function()
+          pipes.valerian.lit = true
+          pipes.valerian.lit2 = true
+          sk.forcelight_valerian = false
+          pipes.elm.lit = true
+          pipes.elm.lit2 = true
+          sk.forcelight_elm = false
+          pipes.skullcap.lit = true
+          pipes.skullcap.lit2 = true
+          sk.forcelight_skullcap = false
+  
+          svo.lastlit('valerian')
+        end,
+  
+        actions = {"light pipes"},
+        onstart = function()
+          if conf.gagrelight then
+            send("light pipes", false)
+          else
+            send("light pipes", conf.commandecho) end
+        end
+      }
+    },
+    fillskullcap = {
+      physical = {
+        balanceless_act = true,
+        herb = 'skullcap',
+        uncurable = true,
+        fillingid = 0,
+  
+        mainpipeout = function()
+          return (pipes.skullcap.puffs &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.skullcap.id == 0)
+        end,
+  
+        secondarypipeout = function()
+          return (pipes.skullcap.puffs2 &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.skullcap.id2 == 0)
+        end,
+  
+        isadvisable = function()
+          return ((svo.dict.fillskullcap.physical.mainpipeout() or svo.dict.fillskullcap.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance() and not (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed) and not conf.serverside) or false
+        end,
+  
+        oncompleted = function()
+          if svo.dict.fillskullcap.fillingid == pipes.skullcap.id then
+            pipes.skullcap.puffs = pipes.skullcap.maxpuffs or 10
+            pipes.skullcap.lit = false
+            rift.invcontents.skullcap = rift.invcontents.skullcap - 1
+            if rift.invcontents.skullcap &lt; 0 then rift.invcontents.skullcap = 0 end
+          else
+            pipes.skullcap.puffs2 = pipes.skullcap.maxpuffs2 or 10
+            pipes.skullcap.lit2 = false
+            rift.invcontents.skullcap = rift.invcontents.skullcap - 1
+            if rift.invcontents.skullcap &lt; 0 then rift.invcontents.skullcap = 0 end
+          end
+        end,
+  
+        onstart = function()
+          if svo.dict.fillskullcap.physical.mainpipeout() then
+            svo.fillpipe('skullcap', pipes.skullcap.id)
+            svo.dict.fillskullcap.fillingid = pipes.skullcap.id
+          else
+            svo.fillpipe('skullcap', pipes.skullcap.id2)
+            svo.dict.fillskullcap.fillingid = pipes.skullcap.id2
+          end
+        end
+      }
+    },
+    fillelm = {
+      physical = {
+        balanceless_act = true,
+        herb = 'elm',
+        uncurable = true,
+        fillingid = 0,
+  
+        mainpipeout = function()
+          return (pipes.elm.puffs &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.elm.id == 0)
+        end,
+  
+        secondarypipeout = function()
+          return (pipes.elm.puffs2 &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.elm.id2 == 0)
+        end,
+  
+        isadvisable = function()
+          return ((svo.dict.fillelm.physical.mainpipeout() or svo.dict.fillelm.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance()  and not (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed) and not conf.serverside) or false
+        end,
+  
+        oncompleted = function()
+          if svo.dict.fillelm.fillingid == pipes.elm.id then
+            pipes.elm.puffs = pipes.elm.maxpuffs or 10
+            pipes.elm.lit = false
+            rift.invcontents.elm = rift.invcontents.elm - 1
+            if rift.invcontents.elm &lt; 0 then rift.invcontents.elm = 0 end
+          else
+            pipes.elm.puffs2 = pipes.elm.maxpuffs2 or 10
+            pipes.elm.lit2 = false
+            rift.invcontents.elm = rift.invcontents.elm - 1
+            if rift.invcontents.elm &lt; 0 then rift.invcontents.elm = 0 end
+          end
+        end,
+  
+        onstart = function()
+          if svo.dict.fillelm.physical.mainpipeout() then
+            svo.fillpipe('elm', pipes.elm.id)
+            svo.dict.fillelm.fillingid = pipes.elm.id
+          else
+            svo.fillpipe('elm', pipes.elm.id2)
+            svo.dict.fillelm.fillingid = pipes.elm.id2
+          end
+        end
+      }
+    },
+    fillvalerian = {
+      physical = {
+        balanceless_act = true,
+        herb = 'valerian',
+        uncurable = true,
+        fillingid = 0,
+  
+        mainpipeout = function()
+          return (pipes.valerian.puffs &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.valerian.id == 0)
+        end,
+  
+        secondarypipeout = function()
+          return (pipes.valerian.puffs2 &lt;= ((sys.sync or defc.selfishness) and 0 or conf.refillat)) and not (pipes.valerian.id2 == 0)
+        end,
+  
+        isadvisable = function()
+          if ((svo.dict.fillvalerian.physical.mainpipeout() or svo.dict.fillvalerian.physical.secondarypipeout()) and not svo.doingaction('fillskullcap') and not svo.doingaction('fillelm') and not svo.doingaction('fillvalerian') and not svo.will_take_balance() and not conf.serverside) then
+  
+            if (affs.crippledleftarm or affs.mangledleftarm or affs.mutilatedleftarm or affs.crippledrightarm or affs.mangledrightarm or affs.mutilatedrightarm or affs.paralysis or affs.transfixed) then
+              sk.warn 'emptyvalerianpipenorefill'
+              return false
+            else
+              return true
+            end
+          end
+        end,
+  
+        oncompleted = function()
+          if svo.dict.fillvalerian.fillingid == pipes.valerian.id then
+            pipes.valerian.puffs = pipes.valerian.maxpuffs or 10
+            pipes.valerian.lit = false
+            rift.invcontents.valerian = rift.invcontents.valerian - 1
+            if rift.invcontents.valerian &lt; 0 then rift.invcontents.valerian = 0 end
+          else
+            pipes.valerian.puffs2 = pipes.valerian.maxpuffs2 or 10
+            pipes.valerian.lit2 = false
+            rift.invcontents.valerian = rift.invcontents.valerian - 1
+            if rift.invcontents.valerian &lt; 0 then rift.invcontents.valerian = 0 end
+          end
+        end,
+  
+        onstart = function()
+          if svo.dict.fillvalerian.physical.mainpipeout() then
+            svo.fillpipe('valerian', pipes.valerian.id)
+            svo.dict.fillvalerian.fillingid = pipes.valerian.id
+          else
+            svo.fillpipe('valerian', pipes.valerian.id2)
+            svo.dict.fillvalerian.fillingid = pipes.valerian.id2
+          end
+        end
+      }
+    },
+    rewield = {
+      rewieldables = false,
+      physical = {
+        balanceless_act = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          return (conf.autorewield and svo.dict.rewield.rewieldables and not svo.doingaction'rewield' and not affs.impale and not affs.webbed and not affs.transfixed and not affs.roped and not affs.transfixed and sys.canoutr and not affs.mutilatedleftarm and not affs.mutilatedrightarm and not affs.mangledrightarm and not affs.mangledleftarm and not affs.crippledrightarm and not affs.crippledleftarm) or false
+        end,
+  
+        oncompleted = function (id)
+          if not svo.dict.rewield.rewieldables then return end
+  
+          for count, item in ipairs(svo.dict.rewield.rewieldables) do
+            if item.id == id then
+              table.remove(svo.dict.rewield.rewieldables, count)
+              break
+            end
+          end
+  
+          if #svo.dict.rewield.rewieldables == 0 then
+            svo.dict.rewield.rewieldables = false
+          end
+        end,
+  
+        failed = function()
+          svo.dict.rewield.rewieldables = false
+        end,
+  
+        clear = function()
+          svo.dict.rewield.rewieldables = false
+        end,
+  
+        onstart = function()
+          for _, t in pairs(svo.dict.rewield.rewieldables) do
+            send("wield "..t.id, conf.commandecho)
+            if sys.sync then return end
+          end
+        end
+      }
+    },
+    blackout = {
+      waitingfor = {
+        customwait = 60,
+  
+        onstart = function() end,
+  
+        oncompleted = function() svo.rmaff('blackout') end,
+  
+        ontimeout = function() svo.rmaff('blackout') end
+      },
+      aff = {
+        oncompleted = function()
+          if affs.blackout then return end
+  
+          svo.addaffdict(svo.dict.blackout)
+  
+          tempTimer(4.5, function() if affs.blackout then svo.addaffdict(svo.dict.disrupt) svo.make_gnomes_work() end end)
+  
+          -- prevent leprosy in blackout
+          if svo.enabledskills.necromancy then
+            svo.echof("Fighting a Necromancer - going to assume crippled limbs every now and then.")
+            tempTimer(3, function() if affs.blackout then svo.addaffdict(svo.dict.unknowncrippledlimb) svo.make_gnomes_work() end end)
+            tempTimer(5, function() if affs.blackout then svo.addaffdict(svo.dict.unknowncrippledlimb) svo.make_gnomes_work() end end)
+          end
+  
+          if svo.enabledskills.curses then
+            svo.echof("Fighting a Shaman - going to check for asthma/anorexia.")
+            tempTimer(3, function() if affs.blackout then svo.affsp.anorexia = true; svo.affsp.asthma = true; svo.make_gnomes_work() end end)
+            tempTimer(5, function() if affs.blackout then svo.affsp.anorexia = true; svo.affsp.asthma = true; svo.make_gnomes_work() end end)
+          end
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('blackout') end,
+      },
+      onremoved = function()
+        svo.check_generics()
+        if sk.sylvan_eclipse then
+          sys.manualdiag = true
+        end
+  
+        if not affs.recklessness then
+          svo.killaction(svo.dict.nomana.waitingfor)
+        end
+  
+        if svo.dict.blackout.check_lust then
+          svo.echof("Checking allies for potential lust...")
+          send('allies', conf.commandecho)
+          svo.dict.blackout.check_lust = nil
+        end
+  
+        tempTimer(0.5, function()
+          if not bals.equilibrium and not conf.serverside then svo.addaffdict(svo.dict.disrupt) end
+  
+          if stats.currenthealth == 0 and conf.assumestats ~= 0 then
+            svo.reset.affs()
+            svo.reset.general()
+            svo.reset.defs()
+            conf.paused = true
+            echo"\n"svo.echof("We died.")
+            raiseEvent("svo config changed", 'paused')
+          end
+        end)
+  
+        -- if we came out with full health and mana out of blackout, assume we've got recklessness meanwhile. don't do it in serverside curing though, because that doesn't assume the same
+        if (not svo.dict.blackout.addedon or svo.dict.blackout.addedon ~= os.time()) and stats.currenthealth == stats.maxhealth and stats.currentmana == stats.maxmana then
+          svo.addaffdict(svo.dict.recklessness)
+          svo.echof("suspicious full stats out of blackout - going to assume reckless.")
+          if conf.serverside then
+            svo.sendcuring("predict recklessness")
+          end
         end
       end,
-
-      onstart = function() end
-    }
-  },
-  sileris = {
-    gamename = 'fangbarrier',
-    applying = "",
-    misc = {
-      def = true,
-
-      isadvisable = function()
-        return (not defc.sileris and ((sys.deffing and defdefup[defs.mode].sileris) or (conf.keepup and defkeepup[defs.mode].sileris)) and not svo.doingaction('waitingforsileris') and not svo.doingaction('sileris') and not affs.paralysis and not affs.slickness and not me.manualdefcheck) or false
-      end,
-
-      oncompleted = function (def)
-        if def and not defc.sileris then defences.got('sileris')
-        else svo.doaction(svo.dict.waitingforsileris.waitingfor) end
-      end,
-
-      slick = function()
-        svo.addaffdict(svo.dict.slickness)
-      end,
-
-      ontimeout = function()
-        if not affs.blackout then return end
-
-        svo.dict.sileris.blocked = true
-        tempTimer(3, function() svo.dict.sileris.blocked = false; svo.make_gnomes_work() end)
-      end,
-
-      -- special case for 'missing herb' trig
-      eatcure = {'sileris', 'quicksilver'},
-      applycure = {'sileris', 'quicksilver'},
-      actions = {"apply sileris", "apply quicksilver"},
-      onstart = function()
-        local use = 'sileris'
-
-        if conf.curemethod and conf.curemethod ~= 'conconly' and (
-
-          conf.curemethod == 'transonly' or
-
-          (conf.curemethod == 'preferconc' and
-            -- we don't have in inventory, but do have alchemy in inventory, use alchemy
-             (not (rift.invcontents.sileris &gt; 0) and (rift.invcontents.quicksilver &gt; 0)) or
-              -- or if we don't have the conc cure in rift either, use alchemy
-             (not (rift.riftcontents.sileris &gt; 0))) or
-
-          (conf.curemethod == 'prefertrans' and
-            (rift.invcontents.quicksilver &gt; 0
-              or (not (rift.invcontents.sileris &gt; 0) and (rift.riftcontents.quicksilver &gt; 0)))) or
-
-          -- prefercustom, and we either prefer alchy and have it, or prefer conc and don't have it
-          (conf.curemethod == 'prefercustom' and (
-            (me.curelist[use] == use and rift.riftcontents[use] &lt;= 0)
-              or
-            (me.curelist[use] == 'quicksilver' and rift.riftcontents['quicksilver'] &gt; 0)
-          ))
-
-          ) then
-            use = 'quicksilver'
-        end
-
-        sys.last_used['sileris_misc'] = use
-
-        svo.dict.sileris.applying = use
-        if rift.invcontents[use] &gt; 0 then
-          send("outr "..use, conf.commandecho)
-          send("apply "..use, conf.commandecho)
-        else
-          send("outr "..use, conf.commandecho)
-          send("apply "..use, conf.commandecho)
-        end
-      end,
-
-      empty = function()
-        svo.dict.sileris.misc.oncompleted()
+      onadded = function()
+        svo.check_generics()
+        svo.dict.blackout.addedon = os.time()
       end
     },
-    gone = {
-      oncompleted = function (line_spotted_on)
-        if not conf.aillusion or not line_spotted_on or (line_spotted_on+1 == getLastLineNumber('main')) then
-          defences.lost('sileris')
+    unknownany = {
+      count = 0,
+      reckhp = false, reckmana = false,
+      waitingfor = {
+        customwait = 999,
+  
+        onstart = function() end,
+  
+        empty = function() end
+      },
+      aff = {
+        oncompleted = function (number)
+  
+          if ((svo.dict.unknownany.reckhp and stats.currenthealth == stats.maxhealth) or
+            (svo.dict.unknownany.reckmana and stats.currentmana == stats.maxmana)) then
+              svo.addaffdict(svo.dict.recklessness)
+  
+              if conf.serverside then
+                svo.sendcuring("predict recklessness")
+              end
+  
+              if number and number &gt; 1 then
+                -- take one off because one affliction is recklessness
+                codepaste.addunknownany(number-1)
+              end
+          else
+            codepaste.addunknownany(number)
+          end
+  
+          svo.dict.unknownany.reckhp = false; svo.dict.unknownany.reckmana = false
+        end,
+  
+        wrack = function()
+          -- if 3, then it was not hidden, ignore - affliction triggers will watch the aff
+          if svo.paragraph_length &gt;= 3 then return end
+  
+          if ((svo.dict.unknownany.reckhp and stats.currenthealth == stats.maxhealth) or
+            (svo.dict.unknownany.reckmana and stats.currentmana == stats.maxmana)) then
+              svo.addaffdict(svo.dict.recklessness)
+  
+              if conf.serverside then
+                svo.sendcuring("predict recklessness")
+              end
+          else
+            codepaste.addunknownany()
+          end
+  
+          svo.dict.unknownany.reckhp = false; svo.dict.unknownany.reckmana = false
         end
-      end,
-
-      camusbite = function (oldhp)
-        if not conf.aillusion or (not affs.recklessness and stats.currenthealth &lt; oldhp) then
-          defences.lost('sileris')
-        end
-      end,
-
-      sumacbite = function (oldhp)
-        if not conf.aillusion or (not affs.recklessness and stats.currenthealth &lt; oldhp) then
-          defences.lost('sileris')
-        end
-      end,
-    }
-  },
-  waitingforsileris = {
-    waitingfor = {
-      customwait = 8,
-
-      oncompleted = function() defences.got('sileris') end,
-
-      ontimeout = function()
-        if defc.sileris then return end
-
-        if (sys.deffing and defdefup[defs.mode].sileris) or (conf.keepup and defkeepup[defs.mode].sileris) then
-          svo.echof("Warning - sileris isn't back yet, we might've been tricked. Going to see if we get bitten.")
-          local oldsileris = defc.sileris
-          defc.sileris = 'unsure'
-          if oldsileris ~= defc.sileris then raiseEvent("svo got def", 'sileris') end
-        end
-      end,
-
-      onstart = function() end
-    }
-  },
-  deathsight = {
-    herb = {
-      def = true,
-
-      isadvisable = function()
-        return (not defc.deathsight and (not conf.deathsight or not svo.can_usemana()) and ((sys.deffing and defdefup[defs.mode].deathsight) or (conf.keepup and defkeepup[defs.mode].deathsight)) and not svo.doingaction('deathsight')) or false
-      end,
-
-      oncompleted = function() defences.got('deathsight') end,
-
-      eatcure = {'skullcap', 'azurite'},
-      onstart = function() svo.eat(svo.dict.deathsight.herb) end,
-
-      empty = function() defences.got('deathsight') end
-    },
-    physical = {
-      balanceless_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.deathsight and conf.deathsight and svo.can_usemana() and not svo.doingaction('deathsight') and ((sys.deffing and defdefup[defs.mode].deathsight) or (conf.keepup and defkeepup[defs.mode].deathsight)) and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function() defences.got('deathsight') end,
-
-      action = 'deathsight',
-      onstart = function() send('deathsight', conf.commandecho) end
-    },
-  },
-  thirdeye = {
-    herb = {
-      def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].thirdeye and not defc.thirdeye) or (conf.keepup and defkeepup[defs.mode].thirdeye and not defc.thirdeye)) and not svo.doingaction('thirdeye') and not (conf.thirdeye and svo.can_usemana())) or false
-      end,
-
-      oncompleted = function() defences.got('thirdeye') end,
-
-      eatcure = {'echinacea', 'dolomite'},
-      onstart = function() svo.eat(svo.dict.thirdeye.herb) end,
-
-      empty = function() defences.got('thirdeye') end
-    },
-    misc = {
-      def = true,
-
-      isadvisable = function()
-        return (conf.thirdeye and svo.can_usemana() and not svo.doingaction('thirdeye') and ((sys.deffing and defdefup[defs.mode].thirdeye and not defc.thirdeye) or (conf.keepup and defkeepup[defs.mode].thirdeye and not defc.thirdeye))) or false
-      end,
-
-      -- by default, oncompleted means a clot went through okay
-      oncompleted = function() defences.got('thirdeye') end,
-
-      action = 'thirdeye',
-      onstart = function() send('thirdeye', conf.commandecho) end
-    },
-  },
-  insomnia = {
-    herb = {
-      def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].insomnia and not defc.insomnia) or (conf.keepup and defkeepup[defs.mode].insomnia and not defc.insomnia)) and not svo.doingaction('insomnia') and not (conf.insomnia and svo.can_usemana()) and not affs.hypersomnia) or false
-      end,
-
-      oncompleted = function() defences.got('insomnia') end,
-
-      eatcure = {'cohosh', 'gypsum'},
-      onstart = function() svo.eat(svo.dict.insomnia.herb) end,
-
-      empty = function() defences.got('insomnia') end,
-
-      hypersomnia = function()
-        svo.addaffdict(svo.dict.hypersomnia)
-      end
-    },
-    misc = {
-      def = true,
-
-      isadvisable = function()
-        return (conf.insomnia and svo.can_usemana() and not svo.doingaction('insomnia') and ((sys.deffing and defdefup[defs.mode].insomnia and not defc.insomnia) or (conf.keepup and defkeepup[defs.mode].insomnia and not defc.insomnia)) and not affs.hypersomnia) or false
-      end,
-
-      oncompleted = function() defences.got('insomnia') end,
-
-      hypersomnia = function()
-        svo.addaffdict(svo.dict.hypersomnia)
-      end,
-
-      action = 'insomnia',
-      onstart = function() send('insomnia', conf.commandecho) end
-    },
-    -- small cheat for insomnia being on diagnose
-    aff = {
-      oncompleted = function() defences.got('insomnia') end
-    },
-    gone = {
-      oncompleted = function(aff)
-        defences.lost('insomnia')
-
-        if aff and aff == 'unknownany' then
-          svo.dict.unknownany.count = svo.dict.unknownany.count - 1
-          if svo.dict.unknownany.count &lt;= 0 then
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('unknownany')
+          svo.dict.unknownany.count = 0
+        end,
+  
+        -- to be used when you lost one unknown (for example, you saw a symptom for something else)
+        lost_level = function()
+          if not affs.unknownany then return end
+          affs.unknownany.p.count = affs.unknownany.p.count - 1
+          if affs.unknownany.p.count &lt;= 0 then
             svo.rmaff('unknownany')
             svo.dict.unknownany.count = 0
           else
             svo.updateaffcount(svo.dict.unknownany)
           end
-        elseif aff and aff == 'unknownmental' then
-          svo.dict.unknownmental.count = svo.dict.unknownmental.count - 1
-          if svo.dict.unknownmental.count &lt;= 0 then
+        end
+      }
+    },
+    unknownmental = {
+      count = 0,
+      reckhp = false, reckmana = false,
+      focus = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (affs.unknownmental) or false
+        end,
+  
+        oncompleted = function()
+          -- special: gets called on each focus mind cure, but we most of
+          -- the time don't have an unknown aff
+          if not affs.unknownmental then return end
+          affs.unknownmental.p.count = affs.unknownmental.p.count - 1
+          if affs.unknownmental.p.count &lt;= 0 then
+            svo.rmaff('unknownmental')
+            svo.dict.unknownmental.count = 0
+          else
+            svo.updateaffcount(svo.dict.unknownmental)
+          end
+  
+          svo.lostbal_focus()
+        end,
+  
+        onstart = function() send('focus mind', conf.commandecho) end,
+  
+        empty = function()
+          svo.lostbal_focus()
+  
+          svo.rmaff('unknownmental')
+        end
+      },
+      aff = {
+        oncompleted = function (number)
+          if ((svo.dict.unknownmental.reckhp and stats.currenthealth == stats.maxhealth) or
+            (svo.dict.unknownmental.reckmana and stats.currentmana == stats.maxmana)) then
+              svo.addaffdict(svo.dict.recklessness)
+  
+              if conf.serverside then
+                svo.sendcuring("predict recklessness")
+              end
+  
+              if number and number &gt; 1 then
+                local count = svo.dict.unknownany.count
+                svo.addaffdict(svo.dict.unknownany)
+                -- take one off because one affliction is recklessness
+                affs.unknownany.p.count = (count or 0) + (number - 1)
+                svo.updateaffcount(svo.dict.unknownany)
+              end
+          else
+            local count = svo.dict.unknownmental.count
+            svo.addaffdict(svo.dict.unknownmental)
+  
+            svo.dict.unknownmental.count = (count or 0) + (number or 1)
+            svo.updateaffcount(svo.dict.unknownmental)
+          end
+  
+          svo.dict.unknownmental.reckhp = false; svo.dict.unknownmental.reckmana = false
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('unknownmental')
+          svo.dict.unknownmental.count = 0
+        end,
+  
+        -- to be used when you lost one focusable (for example, you saw a symptom for something else)
+        lost_level = function()
+          if not affs.unknownmental then return end
+          affs.unknownmental.p.count = affs.unknownmental.p.count - 1
+          if affs.unknownmental.p.count &lt;= 0 then
             svo.rmaff('unknownmental')
             svo.dict.unknownmental.count = 0
           else
             svo.updateaffcount(svo.dict.unknownmental)
           end
         end
-      end,
-
-      relaxed = function (line_spotted_on)
-        if not conf.aillusion or not line_spotted_on or (line_spotted_on+1 == getLastLineNumber('main')) then
-          defences.lost('insomnia')
-        end
-      end,
-    }
-  },
-  myrrh = {
-    gamename = 'scholasticism',
-    herb = {
-      def = true,
-      undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].myrrh and not defc.myrrh) or (conf.keepup and defkeepup[defs.mode].myrrh and not defc.myrrh))) or false
-      end,
-
-      oncompleted = function() defences.got('myrrh') end,
-
-      noeffect = function()
-        svo.dict.myrrh.herb.oncompleted ()
-      end,
-
-      eatcure = {'myrrh', 'bisemutum'},
-      onstart = function() svo.eat(svo.dict.myrrh.herb) end,
-
-      empty = function() defences.got('myrrh') end
+      }
     },
-  },
-  kola = {
-    herb = {
-      def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].kola and not defc.kola) or (conf.keepup and defkeepup[defs.mode].kola and not defc.kola))) or false
-      end,
-
-      oncompleted = function() defences.got('kola') end,
-
-      noeffect = function()
-        svo.dict.kola.herb.oncompleted ()
-      end,
-
-      eatcure = {'kola', 'quartz'},
-      onstart = function() svo.eat(svo.dict.kola.herb) end,
-
-      empty = function() defences.got('kola') end
-    },
-    gone = {
-      oncompleted = function()
-        if not conf.aillusion or not svo.pflags.k then
-          defences.lost('kola')
-        end
-      end
-    }
-  },
-  mass = {
-    gamename = 'density',
-    salve = {
-      def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].mass and not defc.mass) or (conf.keepup and defkeepup[defs.mode].mass and not defc.mass))) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        defences.got('mass')
-      end,
-
-      -- sometimes a salve cure can get misgiagnosed on a death (from a previous apply)
-      noeffect = function() end,
-      empty = function() end,
-
-      applycure = {'mass', 'density'},
-      actions = {"apply mass to body", "apply mass", "apply density to body", "apply density"},
-      onstart = function()
-        svo.apply(svo.dict.mass.salve, " to body")
-      end,
-    },
-  },
-  caloric = {
-    salve = {
-      def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].caloric and not defc.caloric) or (conf.keepup and defkeepup[defs.mode].caloric and not defc.caloric))) or false
-      end,
-
-      oncompleted = function()
-        svo.lostbal_salve()
-        defences.got('caloric')
-      end,
-
-      noeffect = function() svo.lostbal_salve() end,
-
-      -- called from shivering or frozen cure
-      gotcaloricdef = function (hypothermia)
-        if not hypothermia then svo.rmaff({'frozen', 'shivering'}) end
-        svo.dict.caloric.salve.oncompleted ()
-      end,
-
-      applycure = {'caloric', 'exothermic'},
-      actions = {"apply caloric to body", "apply caloric", "apply exothermic to body", "apply exothermic"},
-      onstart = function()
-        svo.apply(svo.dict.caloric.salve, " to body")
-      end,
-    },
-    gone = {
-      oncompleted = function(aff)
-        defences.lost('caloric')
-
-        if aff and aff == 'unknownany' then
-          svo.dict.unknownany.count = svo.dict.unknownany.count - 1
-          if svo.dict.unknownany.count &lt;= 0 then
-            svo.rmaff('unknownany')
-            svo.dict.unknownany.count = 0
-          end
-        elseif aff and aff == 'unknownmental' then
-          svo.dict.unknownmental.count = svo.dict.unknownmental.count - 1
-          if svo.dict.unknownmental.count &lt;= 0 then
-            svo.rmaff('unknownmental')
-            svo.dict.unknownmental.count = 0
-          end
-        end
-      end
-    }
-  },
-  blind = {
-    gamename = 'blindness',
-    onservereignore = function()			
-      -- no blind skill: ignore serverside if it's not to be deffed up atm
-      -- with blind skill: ignore serverside can use skill, or if it's not to be deffed up atm
-      return not 
-        ((not svo.haveskillset('shindo') or (conf.shindoblind and not defc.dragonform)) or
-        (not svo.haveskillset('kaido') or (conf.kaidoblind and not defc.dragonform)) or
-        not ((sys.deffing and defdefup[defs.mode].blind) or (conf.keepup and defkeepup[defs.mode].blind)))
-    end,
-    herb = {
-      def = true,
-
-      isadvisable = function()
-        return (not affs.scalded and
-          (not svo.haveskillset('shindo') or (defc.dragonform or (not conf.shindoblind))) and
-          (not svo.haveskillset('kaido') or (defc.dragonform or (not conf.kaidoblind))) and
-          ((sys.deffing and defdefup[defs.mode].blind and not defc.blind) or (conf.keepup and defkeepup[defs.mode].blind and not defc.blind)) and
-          not svo.doingaction'waitingonblind') or false
-      end,
-
-      oncompleted = function()
-        defences.got('blind')
-        svo.lostbal_herb()
-      end,
-
-      noeffect = function()
-        svo.dict.blind.herb.oncompleted()
-      end,
-
-      eatcure = {'bayberry', 'arsenic'},
-      onstart = function() svo.eat(svo.dict.blind.herb) end,
-
-      empty = function()
-        defences.got('blind')
-        svo.lostbal_herb()
-      end
-    },
-    gone = {
-      oncompleted = function()
-        if not conf.aillusion or not svo.pflags.b then
-          defences.lost('blind')
-        end
-      end
-    }
-  },
-  waitingonblind = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function() defences.got('blind') end,
-
-      onstart = function() end
-    }
-  },
-  deaf = {
-    gamename = 'deafness',
-    onservereignore = function()
-      -- no deaf skill: ignore serverside if it's not to be deffed up atm
-      -- with deaf skill: ignore serverside can use skill, or if it's not to be deffed up atm
-      return not((not svo.haveskillset('shindo') or (conf.shindodeaf and not defc.dragonform)) or
-        (not svo.haveskillset('kaido') or (conf.kaidodeaf and not defc.dragonform)) or
-        not ((sys.deffing and defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf)))
-    end,
-    herb = {
-      def = true,
-
-      isadvisable = function()
-        return (not defc.deaf and
-          (not svo.haveskillset('shindo') or (defc.dragonform or not conf.shindodeaf)) and
-          (not svo.haveskillset('kaido') or (defc.dragonform or not conf.kaidodeaf)) and
-         ((sys.deffing and defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf)) and not svo.doingaction('waitingondeaf')) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.waitingondeaf.waitingfor)
-        svo.lostbal_herb()
-      end,
-
-      eatcure = {'hawthorn', 'calamine'},
-      onstart = function() svo.eat(svo.dict.deaf.herb) end,
-
-      empty = function()
-        svo.dict.deaf.herb.oncompleted()
-      end
-    },
-    gone = {
-      oncompleted = function()
-        if not conf.aillusion or not svo.pflags.d then
-          defences.lost('deaf')
-        end
-      end
-    }
-  },
-  waitingondeaf = {
-    waitingfor = {
-      customwait = 6,
-
-      oncompleted = function() defences.got('deaf') end,
-
-      onstart = function() end
-    }
-  },
-
-
--- balance-related defences
-  lyre = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.lyre and ((sys.deffing and defdefup[defs.mode].lyre) or (conf.keepup and defkeepup[defs.mode].lyre)) and not svo.will_take_balance() and not conf.lyre_step and not svo.doingaction('lyre') and not affs.prone) or false
-      end,
-
-      oncompleted = function()
-        defences.got('lyre')
-
-        if conf.lyre and not conf.paused then conf.paused = true; raiseEvent("svo config changed", 'paused') end
-      end,
-
-      ontimeout = function()
-        if conf.paused and not defc.lyre then
-          svo.echof("Lyre strum didn't happen - unpausing.")
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          svo.make_gnomes_work()
-        end
-      end,
-
-      onkill = function()
-        if conf.paused and not defc.lyre then
-          svo.echof("Lyre strum cancelled - unpausing.")
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-        end
-      end,
-
-      action = "strum lyre",
-      onstart = function()
-        sys.sendonceonly = true
-        -- small fix to make 'lyc' work and be in-order (as well as use batching)
-        local send = send
-        -- record in systemscommands, so it doesn't get killed later on in the controller and loop
-        if conf.batch then send = function(what, ...) svo.sendc(what, ...) sk.systemscommands[what] = true end end
-
-        if not conf.lyrecmd then
-          send("strum lyre", conf.commandecho)
-        else
-          send(tostring(conf.lyrecmd), conf.commandecho)
-        end
-        sys.sendonceonly = false
-
-        if conf.lyre and not conf.paused then conf.paused = true; raiseEvent("svo config changed", 'paused') end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('lyre')
-
-        -- as a special case for handling the following scenario:
-        --[[(focus)
-          Your prismatic barrier dissolves into nothing.
-          You focus your mind intently on curing your mental maladies.
-          Food is no longer repulsive to you. (7.548s)
-          H: 3294 (50%), M: 4911 (89%) 28725e, 10294w 89.3% ex|cdk- 19:24:04.719(sip health|eat bayberry|outr bayberry|eat
-          irid|outr irid)(+324h, 5.0%, -291m, 5.3%)
-          You begin to weave a melody of magical, heart-rending beauty and a beautiful barrier of prismatic light surrounds you.
-          (p) H: 3294 (50%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:04.897
-          Your prismatic barrier dissolves into nothing.
-          You take a drink from a purple heartwood vial.
-          The elixir heals and soothes you.
-          H: 4767 (73%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:05.247(+1473h, 22.7%)
-          You eat some bayberry bark.
-          Your eyes dim as you lose your sight.
-        ]]
-        -- we want to kill lyre going up when it goes down and you're off balance, because you won't get it up off-bal
-
-        -- but don't kill it if it is in lifevision - meaning we're going to get it:
-        --[[
-          (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
-          Your prismatic barrier dissolves into nothing.
-          You strum a Lasallian lyre, and a prismatic barrier forms around you.
-          (svo): Lyre strum cancelled - unpausing.
-          (x) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}
-          You have recovered equilibrium. (3.887s)
-          (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
-          Your prismatic barrier dissolves into nothing.
-          You strum a Lasallian lyre, and a prismatic barrier forms around you.
-          (svo): Lyre strum cancelled - unpausing.
-        ]]
-
-        if not (bals.balance and bals.equilibrium) and svo.actions.lyre_physical and not svo.lifevision.l.lyre_physical then svo.killaction(svo.dict.lyre.physical) end
-
-        -- unpause should we lose the lyre def for some reason - but not while we're doing lyc
-        -- since we'll lose the lyre def and it'll come up right away
-        if conf.lyre and conf.paused and not svo.actions.lyre_physical then conf.paused = false; raiseEvent("svo config changed", 'paused') end
-      end,
-    }
-  },
-  breath = {
-    gamename = 'heldbreath',
-    physical = {
-      balanceless_act = true, def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].breath and not defc.breath) or (conf.keepup and defkeepup[defs.mode].breath and not defc.breath)) and not svo.doingaction('breath') and not codepaste.balanceful_defs_codepaste() and not affs.aeon and not affs.asthma) or false
-      end,
-
-      oncompleted = function() defences.got('breath') end,
-
-      action = "hold breath",
-      onstart = function()
-        if conf.gagbreath and not sys.sync then
-          send("hold breath", false)
-        else
-          send("hold breath", conf.commandecho) end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('breath') end,
-    }
-  },
-  dragonform = {
-    physical = {
-      unpauselater = false,
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].dragonform and not defc.dragonform) or (conf.keepup and defkeepup[defs.mode].dragonform and not defc.dragonform)) and not svo.doingaction('waitingfordragonform') and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.waitingfordragonform.waitingfor)
-      end,
-
-      alreadyhave = function()
-        svo.dict.waitingfordragonform.waitingfor.oncompleted()
-      end,
-
-      actions = {'dragonform', "dragonform red", "dragonform black", "dragonform silver", "dragonform gold", "dragonform blue", "dragonform green"},
-      onstart = function()
-      -- user commands catching needs this check
-        if not (bals.balance and bals.equilibrium) then return end
-
-        if defc.flame and svo.haveskillset('metamorphosis') then
-          send("relax flame", conf.commandecho)
-        end
-        send('dragonform', conf.commandecho)
-
-        if not conf.paused then
-          svo.dict.dragonform.physical.unpauselater = true
-          conf.paused = true; raiseEvent("svo config changed", 'paused')
-          echo"\n" svo.echof("Temporarily pausing for dragonform.")
-        end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('dragonform')
-        svo.dict.dragonbreath.gone.oncompleted()
-        svo.dict.dragonarmour.gone.oncompleted()
-        signals.dragonform:emit()
-      end,
-    }
-  },
-  waitingfordragonform = {
-    waitingfor = {
-      customwait = 20,
-
-      oncompleted = function()
-        defences.got('dragonform')
-        svo.dict.riding.gone.oncompleted()
-
-        -- strip class defences that don't stay through dragon
-        for def, deft in svo.defs_data:iter() do
-          local skillset = deft.type
-          if skillset ~= 'general' and skillset ~= 'enchantment' and skillset ~= 'dragoncraft' and not deft.staysindragon and defc[def] then
-            defences.lost(def)
-          end
-        end
-
-        -- lifevision, via artefact, has to be removed as well
-        if defc.lifevision and not svo.haveskillset('necromancy') then
-          defences.lost('lifevision')
-        end
-
-        signals.dragonform:emit()
-
-        if conf.paused and svo.dict.dragonform.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-
-          echo"\n"
-          if math.random(1, 20) == 1 then
-            svo.echof("ROOOAR!")
-          else
-            svo.echof("Obtained dragonform, unpausing.")
-          end
-        end
-        svo.dict.dragonform.physical.unpauselater = false
-      end,
-
-      cancelled = function()
-        signals.dragonform:emit()
-        if conf.paused and svo.dict.dragonform.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          echo"\n" svo.echof("Unpausing.")
-        end
-        svo.dict.dragonform.physical.unpauselater = false
-      end,
-
-      ontimeout = function()
-        svo.dict.waitingfordragonform.waitingfor.cancelled()
-      end,
-
-      onstart = function() end
-    }
-  },
-  dragonbreath = {
-    physical = {
-      balanceless_act = true, def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].dragonbreath and not defc.dragonbreath) or (conf.keepup and defkeepup[defs.mode].dragonbreath and not defc.dragonbreath)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction('dragonbreath') and not svo.doingaction('waitingfordragonbreath') and defc.dragonform and not svo.dict.dragonbreath.blocked and not affs.paralysis and not affs.prone) or false
-      end,
-
-      oncompleted = function (def)
-        if def then defences.got('dragonbreath')
-        else svo.doaction(svo.dict.waitingfordragonbreath.waitingfor) end
-      end,
-
-      ontimeout = function()
-        if not affs.blackout then return end
-
-        svo.dict.dragonbreath.blocked = true
-        tempTimer(3, function() svo.dict.dragonbreath.blocked = false; svo.make_gnomes_work() end)
-      end,
-
-      alreadygot = function() defences.got('dragonbreath') end,
-			
-      actions = {'summon acid', 'summon psi', 'summon ice', 'summon venom', 'summon dragonfire', 'summon lightning'},
-
-      onstart = function()
-        send("summon "..(conf.dragonbreath and conf.dragonbreath or 'unknown'), conf.commandecho)
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('dragonbreath') end
-    }
-  },
-  waitingfordragonbreath = {
-    waitingfor = {
-      customwait = 2,
-
-      onstart = function() end,
-
-      oncompleted = function() defences.got('dragonbreath') end
-    }
-  },
-  dragonarmour = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].dragonarmour and not defc.dragonarmour) or (conf.keepup and defkeepup[defs.mode].dragonarmour and not defc.dragonarmour)) and not codepaste.balanceful_defs_codepaste() and defc.dragonform) or false
-      end,
-
-      oncompleted = function() defences.got('dragonarmour') end,
-
-      action = "dragonarmour on",
-      onstart = function() send('dragonarmour on', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function() defences.lost('dragonarmour') end
-    }
-  },
-  selfishness = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (
-          ((sys.deffing and defdefup[defs.mode].selfishness and not defc.selfishness)
-            or (not sys.deffing and conf.keepup and ((defkeepup[defs.mode].selfishness and not defc.selfishness) or (not defkeepup[defs.mode].selfishness and defc.selfishness))))
-          and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function() defences.got('selfishness') end,
-
-      onstart = function()
-        if (sys.deffing and defdefup[defs.mode].selfishness and not defc.selfishness) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].selfishness and not defc.selfishness) then
-          send('selfishness', conf.commandecho)
-        else
-          send('generosity', conf.commandecho)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('selfishness')
-
-        -- if we've done sl off, _gone gets added, so _physical gets readded by action clear - kill physical here for that not to happen
-        if svo.actions.selfishness_physical then
-          svo.killaction(svo.dict.selfishness.physical)
-        end
-      end,
-    }
-  },
-  riding = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (
-          ((sys.deffing and defdefup[defs.mode].riding and not defc.riding)
-            or (not sys.deffing and conf.keepup and ((defkeepup[defs.mode].riding and not defc.riding) or (not defkeepup[defs.mode].riding and defc.riding))))
-          and not codepaste.balanceful_defs_codepaste() and not defc.dragonform and not affs.hamstring and (not affs.prone or svo.doingaction'prone') and not affs.crippledleftarm and not affs.crippledrightarm and not affs.mangledleftarm and not affs.mangledrightarm and not affs.mutilatedleftarm and not affs.mutilatedrightarm and not affs.unknowncrippledleg and not affs.parestolegs and not svo.doingaction'riding' and not affs.pinshot and not affs.paralysis
-          and not string.find(svo.me.class, "Elemental")) or false
-      end,
-
-      oncompleted = function()
-        if (not sys.deffing and conf.keepup and not defkeepup[defs.mode].riding and (defc.riding == true or defc.riding == nil)) then
-          svo.dict.riding.gone.oncompleted()
-        else
-          defences.got('riding')
-        end
-
-        if bals.balance and not conf.freevault then
-          svo.config.set('freevault', 'yep', true)
-        elseif not bals.balance and conf.freevault then
-          svo.config.set('freevault', 'nope', true)
-        end
-      end,
-
-      alreadyon = function() defences.got('riding') end,
-
-      dragonform = function()
-        defences.got('dragonform')
-        signals.dragonform:emit()
-      end,
-
-      hastring = function()
-        svo.dict.hamstring.aff.oncompleted()
-      end,
-
-      dismount = function()
-        defences.lost('riding')
-        svo.dict.block.gone.oncompleted()
-      end,
-
-      onstart = function()
-        if (sys.deffing and defdefup[defs.mode].riding and not defc.riding) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].riding and not defc.riding) then
-          send(string.format("%s %s", tostring(conf.ridingskill), tostring(conf.ridingsteed)), conf.commandecho)
-        else
-          send('dismount', conf.commandecho)
-          if sys.sync or tostring(conf.ridingsteed) == 'giraffe' then return end
-          if conf.steedfollow then send(string.format("order %s follow me", tostring(conf.ridingsteed), conf.commandecho)) end
-        end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('riding')
-        svo.dict.block.gone.oncompleted()
-      end,
-    }
-  },
-  meditate = {
-    physical = {
-      balanceless_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].meditate and not defc.meditate) or (conf.keepup and defkeepup[defs.mode].meditate and not defc.meditate)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'meditate' and (stats.currentwillpower &lt; stats.maxwillpower or stats.currentmana &lt; stats.maxmana)) or false
-      end,
-
-      oncompleted = function() defences.got('meditate') end,
-
-      actions = {'med', 'meditate'},
-      onstart = function() send('meditate', conf.commandecho) end
-    }
-  },
-
-  mindseye = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.mindseye and ((sys.deffing and defdefup[defs.mode].mindseye) or (conf.keepup and defkeepup[defs.mode].mindseye)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
-      end,
-
-      oncompleted = function()
-        defences.got('mindseye')
-
-        -- check if we need to re-classify deaf
-        if (defc.deaf or affs.deafaff) and (defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf) or defc.mindseye then
-          defences.got('deaf')
-          svo.rmaff('deafaff')
-        elseif (defc.deaf or affs.deafaff) then
-          defences.lost('deaf')
-          svo.addaffdict(svo.dict.deafaff)
-        end
-
-        -- check if we need to re-classify blind
-        if (defc.blind or affs.blindaff) and (defdefup[defs.mode].blind) or (conf.keepup and defkeepup[defs.mode].blind) and (svo.me.class == 'Apostate' or defc.mindseye) then
-          defences.got('blind')
-          svo.rmaff('blindaff')
-        elseif (defc.blind or affs.blindaff) then
-          defences.lost('blind')
-          svo.addaffdict(svo.dict.blindaff)
-        end
-      end,
-
-      action = "touch mindseye",
-      onstart = function() send('touch mindseye', conf.commandecho) end
-    }
-  },
-  metawake = {
-    physical = {
-      balanceless_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.metawake and ((sys.deffing and defdefup[defs.mode].metawake) or (conf.keepup and defkeepup[defs.mode].metawake)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not svo.doingaction'metawake' and not affs.lullaby) or false
-      end,
-
-      oncompleted = function() defences.got('metawake') end,
-
-      action = "metawake on",
-      onstart = function() send('metawake on', conf.commandecho) end
-    }
-  },
-  cloak = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.cloak and ((sys.deffing and defdefup[defs.mode].cloak) or (conf.keepup and defkeepup[defs.mode].cloak)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
-      end,
-
-      oncompleted = function() defences.got('cloak') end,
-
-      action = "touch cloak",
-      onstart = function() send('touch cloak', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        if not conf.aillusion or not svo.pflags.c then
-          defences.lost('cloak')
-        end
-      end
-    }
-  },
-
-  nightsight = {
-    physical = {
-      balanceless_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.nightsight and
-          ((sys.deffing and defdefup[defs.mode].nightsight) or (conf.keepup and defkeepup[defs.mode].nightsight)) and
-          not codepaste.balanceful_defs_codepaste() and
-          sys.canoutr and
-          not affs.prone and
-          not svo.doingaction'nightsight'
-          and (not svo.haveskillset('metamorphosis') or ((not affs.cantmorph and not svo.doingaction'waitingformorph' and sk.morphsforskill.nightsight) or defc.dragonform))) or false
-      end,
-
-      oncompleted = function() defences.got('nightsight') end,
-
-      action = "nightsight on",
-      onstart = function()
-if not svo.haveskillset('metamorphosis') then
-        send("nightsight on", conf.commandecho)
-else
-        if not defc.dragonform and (not conf.transmorph and sk.inamorph() and not sk.inamorphfor'nightsight') then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        elseif not defc.dragonform and not sk.inamorphfor'nightsight' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph "..sk.morphsforskill.nightsight[1], conf.commandecho)
-          if not conf.truemorph then svo.doaction(svo.dict.waitingformorph.waitingfor) end
-        elseif defc.dragonform or sk.inamorphfor'nightsight' then
-          send("nightsight on", conf.commandecho)
-        end
-end
-      end
-    },
-  },
-  shield = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].shield and not defc.shield) or (conf.keepup and defkeepup[defs.mode].shield and not defc.shield)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not (affs.mangledleftarm and affs.mangledlrightarm) and not affs.prone) or false
-      end,
-
-      oncompleted = function()
-        defences.got('shield')
-        if defkeepup[defs.mode].shield and conf.oldts then
-          defs.keepup('shield', false)
-        end
-      end,
-
-      actions = {"touch shield", "angel aura"},
-      onstart = function()
-if svo.haveskillset('spirituality') then
-        if defc.dragonform or not defc.summon or stats.currentwillpower &lt;= 10 then
-          send("touch shield", conf.commandecho)
-        else
-          send("angel aura", conf.commandecho)
-        end
-else
-        send("touch shield", conf.commandecho)
-end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('shield') end
-    }
-  },
-  sstosvoa = {
-    addiction = 'addiction',
-    aeon = 'aeon',
-    agoraphobia = 'agoraphobia',
-    airfisted = 'galed',
-    amnesia = 'amnesia',
-    anorexia = 'anorexia',
-    asthma = 'asthma',
-    blackout = 'blackout',
-    blindness = false,
-    bound = 'bound',
-    brokenleftarm = 'crippledleftarm',
-    brokenleftleg = 'crippledleftleg',
-    brokenrightarm = 'crippledrightarm',
-    brokenrightleg = 'crippledrightleg',
-    bruisedribs = false,
-    burning = 'ablaze',
-    cadmuscurse = 'cadmus',
-    calcifiedskull = 'calcifiedskull',
-    calcifiedtorso = 'calcifiedtorso',
-    claustrophobia = 'claustrophobia',
-    clumsiness = 'clumsiness',
-    concussion = 'seriousconcussion',
-    conflagration = false,
-    confusion = 'confusion',
-    corruption = 'corrupted',
-    crackedribs = 'crackedribs',
-    crushedthroat = 'crushedthroat',
-    daeggerimpale = false,
-    damagedhead = 'mildconcussion',
-    damagedleftarm = 'mangledleftarm',
-    damagedleftleg = 'mangledleftleg',
-    damagedrightarm = 'mangledrightarm',
-    damagedrightleg = 'mangledrightleg',
-    darkshade = 'darkshade',
-    dazed = false,
-    dazzled = false,
-    deadening = 'deadening',
-    deafness = false,
-    deepsleep = 'sleep',
-    degenerate = 'degenerate',
-    dehydrated = 'dehydrated',
-    dementia = 'dementia',
-    demonstain = 'stain',
-    depression = 'depression',
-    deteriorate = 'deteriorate',
-    disloyalty = 'disloyalty',
-    disrupted = 'disrupt',
-    dissonance = 'dissonance',
-    dizziness = 'dizziness',
-    enlightenment = false,
-    enmesh = false,
-    ensorcelled = 'ensorcelled',
-    entangled = 'roped',
-    entropy = false,
-    epilepsy = 'epilepsy',
-    fear = 'fear',
-    flamefisted = 'burning',
-    flushings = 'flushings',
-    frozen = 'frozen',
-    generosity = 'generosity',
-    guilt = 'guilt',
-    haemophilia = 'haemophilia',
-    hallucinations = 'hallucinations',
-    hamstrung = 'hamstring',
-    hatred = 'hatred',
-    healthleech = 'healthleech',
-    heartseed = 'heartseed',
-    hecatecurse = 'hecate',
-    hellsight = 'hellsight',
-    hindered = false,
-    homunculusmercury = false,
-    horror = 'horror',
-    hypersomnia = 'hypersomnia',
-    hypochondria = 'hypochondria',
-    hypothermia = 'hypothermia',
-    icefisted = 'icing',
-    impaled = 'impale',
-    impatience = 'impatience',
-    indifference = 'indifference',
-    inquisition = 'inquisition',
-    insomnia = false,
-    internalbleeding = false,
-    isolation = false,
-    itching = 'itching',
-    justice = 'justice',
-    kaisurge = false,
-    laceratedthroat = 'laceratedthroat',
-    lapsingconsciousness = false,
-    latched = 'latched',
-    lethargy = 'lethargy',
-    loneliness = 'loneliness',
-    lovers = 'inlove',
-    manaleech = 'manaleech',
-    mangledhead = 'seriousconcussion',
-    mangledleftarm = 'mutilatedleftarm',
-    mangledleftleg = 'mutilatedleftleg',
-    mangledrightarm = 'mutilatedrightarm',
-    mangledrightleg = 'mutilatedrightleg',
-    masochism = 'masochism',
-    mildtrauma = 'mildtrauma',
-    mindclamp = false,
-    mycalium = 'mycalium',
-    nausea = 'illness',
-    numbedleftarm = 'numbedleftarm',
-    numbedrightarm = 'numbedrightarm',
-    pacified = 'pacifism',
-    palpatarfeed = 'palpatar',
-    paralysis = 'paralysis',
-    paranoia = 'paranoia',
-    parasite = 'parasite',
-    peace = 'peace',
-    penitence = false,
-    petrified = false,
-    phlogisticated = 'phlogistication',
-    pinshot = 'pinshot',
-    prone = 'prone',
-    pressure = 'pressure',
-    pyramides = 'pyramides',
-    rebbies = 'rebbies',
-    recklessness = 'recklessness',
-    retribution = 'retribution',
-    revealed = false,
-    sandfever = 'sandfever',
-    scalded = 'scalded',
-    scrambledbrains = false,
-    scytherus = 'relapsing',
-    selarnia = 'selarnia',
-    sensitivity = 'sensitivity',
-    serioustrauma = 'serioustrauma',
-    shadowmadness = 'shadowmadness',
-    shivering = 'shivering',
-    shyness = 'shyness',
-    silver = false,
-    skullfractures = 'skullfractures',
-    slashedthroat = 'slashedthroat',
-    sleeping = 'sleep',
-    slickness = 'slickness',
-    slimeobscure = 'ninkharsag',
-    spiritburn = 'spiritburn',
-    stupidity = 'stupidity',
-    stuttering = 'stuttering',
-    temperedcholeric = 'cholerichumour',
-    temperedmelancholic = 'melancholichumour',
-    temperedphlegmatic = 'phlegmatichumour',
-    temperedsanguine = 'sanguinehumour',
-    tenderskin = 'tenderskin',
-    timeflux = 'timeflux',
-    timeloop = 'timeloop',
-    tension = 'tension',
-    torntendons = 'torntendons',
-    transfixation = 'transfixed',
-    trueblind = false,
-    unconsciousness = 'unconsciousness',
-    unweavingbody = 'unweavingbody',
-    unweavingmind = 'unweavingmind',
-    unweavingspirit = 'unweavingspirit',
-    vertigo = 'vertigo',
-    vinewreathed = false,
-    vitiated = false,
-    vitrified = 'vitrification',
-    voidfisted = 'voided',
-    voyria = 'voyria',
-    weakenedmind = 'rixil',
-    weariness = 'weakness',
-    webbed = 'webbed',
-    whisperingmadness = 'madness',
-    wristfractures = 'wristfractures'
-  },
-  sstosvod = {
-    acrobatics = 'acrobatics',
-    accursedresolve = 'accursedresolve',
-    affinity = 'affinity',
-    aiming = false,
-    airpocket = 'waterbubble',
-    alertness = 'alertness',
-    antiforce = 'gaiartha',
-    arctar = 'arctar',
-    aria = 'aria',
-    arrowcatching = 'arrowcatch',
-    astralform = 'astralform',
-    astronomy = 'empower',
-    balancing = 'balancing',
-    barkskin = 'barkskin',
-    basking = 'bask',
-    bedevilaura = 'bedevil',
-    belltattoo = 'bell',
-    blackwind = false,
-    blademastery = 'mastery',
-    blessingofthegods = false,
-    blindness = 'blind',
-    blocking = 'block',
-    bloodquell = 'ukhia',
-    bloodshield = false,
-    blur = 'blur',
-    boartattoo = false,
-    bodyaugment = 'mainaas',
-    bodyblock = 'bodyblock',
-    boostedregeneration = 'boosting',
-    brains = 'brains',
-    bulk = 'bulk',
-    chameleon = 'chameleon',
-    chargeshield = 'chargeshield',
-    circulate = 'circulate',
-    clinging = 'clinging',
-    cloak = 'cloak',
-    coldresist = 'coldresist',
-    consciousness = 'consciousness',
-    constitution = 'constitution',
-    croonmirror = false,
-    curseward = 'curseward',
-    dawnhand = 'dawnhand',
-    deafness = 'deaf',
-    deathaura = 'deathaura',
-    deathsight = 'deathsight',
-    deflect = 'deflect',
-    deliverance = false,
-    demonarmour = 'armour',
-    demonfury = false,
-    density = 'mass',
-    devilmark = 'devilmark',
-    devour = 'devour',
-    diamondskin = 'diamondskin',
-    disassociate = false,
-    distortedaura = 'distortedaura',
-    disperse = 'disperse',
-    dodging = 'dodging',
-    dragonarmour = 'dragonarmour',
-    dragonbreath = 'dragonbreath',
-    drunkensailor = 'drunkensailor',
-    durability = 'tsuura',
-    earthshield = 'earthblessing',
-    eavesdropping = 'eavesdrop',
-    electricresist = 'electricresist',
-    elusiveness = 'elusiveness',
-    enduranceblessing = 'enduranceblessing',
-    enhancedform = false,
-    evadeblock = 'evadeblock',
-    evasion = false,
-    extispicy = 'extispicy',
-    eyes = 'eyes',
-    fangbarrier = 'sileris',
-    fervour = 'fervour',
-    firefly = false,
-    fireresist = 'fireresist',
-    firstaid = 'firstaid',
-    flailingstaff = 'flail',
-    fleetness = 'fleetness',
-    frenzied = false,
-    frostshield = 'frostblessing',
-    fury = false,
-    ghost = 'ghost',
-    golgothagrace = 'golgotha',
-    gripping = 'grip',
-    groundwatch = 'groundwatch',
-    harmony = 'harmony',
-    haste = false,
-    heads = 'heads',
-    heartsfury = 'heartsfury',
-    heldbreath = 'breath',
-    heresy = 'heresy',
-    hiding = 'hiding',
-    hypersense = 'hypersense',
-    hypersight = 'hypersight',
-    immunity = 'immunity',
-    insomnia = 'insomnia',
-    inspiration = 'inspiration',
-    insuflate = false,
-    insulation = false,
-    ironform = false,
-    ironwill = 'qamad',
-    joints = 'joints',
-    kaiboost = 'kaiboost',
-    kaitrance = 'trance',
-    kola = 'kola',
-    lament = false,
-    lay = 'lay',
-    leechlogograph = 'traceleech',
-    levitating = 'levitation',
-    lifegiver = false,
-    lifesteal = false,
-    lifevision = 'lifevision',
-    lipreading = 'lipread',
-    magicresist = 'magicresist',
-    megalithtattoo = false,
-    mercury = 'mercury',
-    metawake = 'metawake',
-    mindcloak = 'mindcloak',
-    mindnet = 'mindnet',
-    mindseye = 'mindseye',
-    mindtelesense = 'mindtelesense',
-    moontattoo = false,
-    morph = false,
-    mouths = 'mouths',
-    mosstattoo = false,
-    nightsight = 'nightsight',
-    numbness = 'numb',
-    oxtattoo = false,
-    pacing = 'pacing',
-    panacea = 'panacea',
-    phased = 'phase',
-    pinchblock = 'pinchblock',
-    poisonresist = 'venom',
-    preachblessing = false,
-    precision = 'trusad',
-    prismatic = 'lyre',
-    projectiles = 'projectiles',
-    promosurcoat = false,
-    putrefaction = 'putrefaction',
-    rebounding = 'rebounding',
-    reflections = 'reflection',
-    reflexes = false,
-    regeneration = 'regeneration',
-    resistance = 'resistance',
-    retaliation = 'retaliationstrike',
-    retribution = 'retributionvow',
-    satiation = 'satiation',
-    scales = 'scales',
-    scholasticism = 'myrrh',
-    scouting = 'scout',
-    secondsight = 'secondsight',
-    selfishness = 'selfishness',
-    shadowveil = 'shadowveil',
-    shield = 'shield',
-    shieldlogograph = 'traceshield',
-    shikudoform = false,
-    shinbinding = 'bind',
-    shinclarity = 'clarity',
-    shinrejoinder = false,
-    shintrance = 'shintrance',
-    shipwarning = 'shipwarning',
-    skywatch = 'skywatch',
-    slippery = 'slipperiness',
-    softfocusing = 'softfocus',
-    songbird = 'songbird',
-    soulcage = 'soulcage',
-    speed = 'speed',
-    spinning = 'spinning',
-    spinningstaff = false,
-    spiritbonded = 'bonding',
-    spiritwalk = false,
-    splitmind = 'splitmind',
-    standingfirm = 'sturdiness',
-    starburst = 'starburst',
-    stealth = 'stealth',
-    stonefist = 'stonefist',
-    stoneskin = 'stoneskin',
-    sulphur = 'sulphur',
-    swiftcurse = 'swiftcurse',
-    tekurastance = false,
-    telesense = 'telesense',
-    temperance = 'frost',
-    tentacles = 'tentacles',
-    thermalshield = 'thermalblessing',
-    thirdeye = 'thirdeye',
-    tin = 'tin',
-    tongues = 'tongues',
-    toughness = 'toughness',
-    treewatch = 'treewatch',
-    truestare = 'truestare',
-    tumors = 'tumors',
-    tune = 'tune',
-    twoartsstance = false,
-    unbowed = 'unbowed',
-    unnamablepresence = 'unnamablepresence',
-    vengeance = 'vengeance',
-    venomsacks = 'venomsacks',
-    vigilance = 'vigilance',
-    vigour = 'vigour',
-    viridian = 'viridian',
-    vitality = 'vitality',
-    ward = false,
-    waterwalking = 'waterwalk',
-    weakvigour = false,
-    weathering = 'weathering',
-    weaving = 'weaving',
-    wildgrowth = 'wildgrowth',
-    willpowerblessing = 'willpowerblessing',
-    xporb = false,
-  },
-  svotossa = {},
-  svotossd = {}
-} -- end of dict
-
-if svo.haveskillset('subterfuge') then
-  svo.dict.sstosvod.shroud = 'cloaking'
-else
-  svo.dict.sstosvod.shroud = 'shroud'
-end
-
-if svo.haveskillset('weaponmastery') then
-  svo.dict.prone.misc.actions = {'stand', "recover footing"}
-else
-  svo.dict.prone.misc.action = 'stand'
-end
-
--- undeffable since serverside can't morph to get a specific defence up
-if svo.haveskillset('metamorphosis') then
-  svo.dict.nightsight.physical.undeffable = true
-end
-
-if svo.haveskillset('shindo') then
-  svo.dict.deaf.misc = {
-    def = true,
-
-    isadvisable = function()
-      return (not defc.deaf and conf.shindodeaf and not defc.dragonform and ((sys.deffing and defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf)) and not svo.doingaction('waitingondeaf')) or false
-    end,
-
-    oncompleted = function()
-      svo.doaction(svo.dict.waitingondeaf.waitingfor)
-    end,
-
-    action = 'deaf',
-    onstart = function()
-      send('deaf', conf.commandecho)
-    end
-  }
-end
-if svo.haveskillset('kaido') then
-  svo.dict.deaf.misc = {
-    def = true,
-
-    isadvisable = function()
-      return (not defc.deaf and conf.kaidodeaf and not defc.dragonform and ((sys.deffing and defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf)) and not svo.doingaction('waitingondeaf')) or false
-    end,
-
-    oncompleted = function()
-      svo.doaction(svo.dict.waitingondeaf.waitingfor)
-    end,
-
-    action = 'deaf',
-    onstart = function()
-      send('deaf', conf.commandecho)
-    end
-  }
-end
-if svo.haveskillset('shindo') then
-  svo.dict.blind.misc = {
-      def = true,
-
-      isadvisable = function()
-        return (conf.shindoblind and not defc.dragonform and ((sys.deffing and defdefup[defs.mode].blind and not defc.blind) or (conf.keepup and defkeepup[defs.mode].blind and not defc.blind)) and not svo.doingaction'waitingonblind') or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.waitingonblind.waitingfor)
-      end,
-
-      action = 'blind',
-      onstart = function() send('blind', conf.commandecho) end
-    }
-end
-if svo.haveskillset('kaido') then
-  svo.dict.blind.misc = {
-      def = true,
-
-      isadvisable = function()
-        return (conf.kaidoblind and not defc.dragonform and ((sys.deffing and defdefup[defs.mode].blind and not defc.blind) or (conf.keepup and defkeepup[defs.mode].blind and not defc.blind)) and not svo.doingaction'waitingonblind') or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.waitingonblind.waitingfor)
-      end,
-
-      action = 'blind',
-      onstart = function() send('blind', conf.commandecho) end
-    }
-end
-
-
--- skillset-specific defences
-if svo.haveskillset('necromancy') then
-  svo.dict.lifevision = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.lifevision and ((sys.deffing and defdefup[defs.mode].lifevision) or (conf.keepup and defkeepup[defs.mode].lifevision)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.prone and stats.currentmana &gt;= 600) or false
-      end,
-
-      oncompleted = function() defences.got('lifevision') end,
-
-      action = 'lifevision',
-      onstart = function() send('lifevision', conf.commandecho) end
-    }
-  }
-end
-
-
-if svo.haveskillset('zeal') then
-  svo.dict.frostblessing = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.frostblessing and ((sys.deffing and defdefup[defs.mode].frostblessing) or (conf.keepup and defkeepup[defs.mode].frostblessing)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and bals.prayer == true and stats.currentmana &gt;= 750) or false
-      end,
-
-      oncompleted = function() 
-        if conf.benediction then 
-          defences.got('frostblessing') defences.got('thermalblessing') defences.got('earthblessing') defences.got('willpowerblessing') defences.got('enduranceblessing') svo.lostbal_prayer()
-        else 
-          defences.got('frostblessing') svo.lostbal_prayer() 
-        end
-      end,
-
-      action = "recite void me",
-
-      onstart = function() 
-        if conf.benediction then 
-          send('recite benediction me', conf.commandecho)
-        else 
-          send('recite void me', conf.commandecho) 
-        end
-      end
-    }
-  }
-  svo.dict.willpowerblessing = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.willpowerblessing and ((sys.deffing and defdefup[defs.mode].willpowerblessing) or (conf.keepup and defkeepup[defs.mode].willpowerblessing)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and bals.prayer == true and stats.currentmana &gt;= 750) or false
-      end,
-
-      oncompleted = function() 
-        if conf.benediction then 
-          defences.got('frostblessing') defences.got('thermalblessing') defences.got('earthblessing') defences.got('willpowerblessing') defences.got('enduranceblessing') svo.lostbal_prayer()
-        else 
-          defences.got('willpowerblessing') svo.lostbal_prayer() 
-        end
-      end,
-
-      action = "recite will me",
-
-      onstart = function() 
-        if conf.benediction then 
-          send('recite benediction me', conf.commandecho)
-        else 
-          send('recite will me', conf.commandecho) 
-        end 
-      end
-    }
-  }
-  svo.dict.thermalblessing = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.thermalblessing and ((sys.deffing and defdefup[defs.mode].thermalblessing) or (conf.keepup and defkeepup[defs.mode].thermalblessing)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and bals.prayer == true and stats.currentmana &gt;= 750) or false
-      end,
-
-      oncompleted = function() 
-        if conf.benediction then 
-          defences.got('frostblessing') defences.got('thermalblessing') defences.got('earthblessing') defences.got('willpowerblessing') defences.got('enduranceblessing') svo.lostbal_prayer()
-        else 
-          defences.got('thermalblessing') svo.lostbal_prayer() 
-        end
-      end,
-
-      action = "recite fire me",
-
-      onstart = function() 
-        if conf.benediction then 
-          send('recite benediction me', conf.commandecho)
-        else 
-          send('recite fire me', conf.commandecho) 
-        end
-      end
-    }
-  }
-  svo.dict.earthblessing = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.earthblessing and ((sys.deffing and defdefup[defs.mode].earthblessing) or (conf.keepup and defkeepup[defs.mode].earthblessing)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and bals.prayer == true and stats.currentmana &gt;= 750) or false
-      end,
-
-      oncompleted = function() 
-        if conf.benediction then 
-          defences.got('frostblessing') defences.got('thermalblessing') defences.got('earthblessing') defences.got('willpowerblessing') defences.got('enduranceblessing') svo.lostbal_prayer()
-        else 
-          defences.got('earthblessing') svo.lostbal_prayer() 
-        end
-      end,
-
-      action = "recite protection me",
-
-      onstart = function() 
-        if conf.benediction then 
-          send('recite benediction me', conf.commandecho)
-        else 
-          send('recite protection me', conf.commandecho) 
-        end
-      end
-    }
-  }
-  svo.dict.enduranceblessing = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.enduranceblessing and ((sys.deffing and defdefup[defs.mode].enduranceblessing) or (conf.keepup and defkeepup[defs.mode].enduranceblessing)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and bals.prayer == true and stats.currentmana &gt;= 750) or false
-      end,
-
-      oncompleted = function() 
-        if conf.benediction then 
-          defences.got('frostblessing') defences.got('thermalblessing') defences.got('earthblessing') defences.got('willpowerblessing') defences.got('enduranceblessing') svo.lostbal_prayer()
-        else 
-          defences.got('enduranceblessing') svo.lostbal_prayer() 
-        end
-      end,
-
-      action = "recite endurance me",
-      onstart = function() 
-        if conf.benediction then 
-          send('recite benediction me', conf.commandecho)
-        else 
-          send('recite endurance me', conf.commandecho) 
-        end
-      end
-    }
-  }
-end
-
-if svo.haveskillset('spirituality') then
-  svo.dict.mace = {
-    physical = {
-      unpauselater = false,
-      balanceful_act = true, -- it is balanceless, but this causes it to be bundled with a balanceful action - not desired
-      def = true,
-      undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].mace and not defc.mace) or (conf.keepup and defkeepup[defs.mode].mace and not defc.mace)) and not svo.doingaction('waitingformace') and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.waitingformace.waitingfor)
-      end,
-
-      alreadyhave = function()
-        svo.dict.waitingformace.waitingfor.oncompleted()
-        send("wield mace", conf.commandecho)
-      end,
-
-      action = "summon mace",
-      onstart = function()
-      -- user commands catching needs this check
-        if not (bals.balance and bals.equilibrium) then return end
-
-        send("summon mace", conf.commandecho)
-
-        if not conf.paused then
-          svo.dict.mace.physical.unpauselater = true
-          conf.paused = true; raiseEvent("svo config changed", 'paused')
-          echo"\n" svo.echof("Temporarily pausing to summon the mace.")
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('mace') end,
-    }
-  }
-  svo.dict.waitingformace = {
-    waitingfor = {
-      customwait = 3,
-
-      oncompleted = function()
-        defences.got('mace')
-
-        if conf.paused and svo.dict.mace.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-
-          svo.echof("Obtained mace, unpausing.")
-        end
-        svo.dict.mace.physical.unpauselater = false
-      end,
-
-      cancelled = function()
-        if conf.paused and svo.dict.mace.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          svo.echof("Oops, summoning interrupted. Unpausing.")
-        end
-        svo.dict.mace.physical.unpauselater = false
-      end,
-
-      ontimeout = function()
-        if conf.paused and svo.dict.mace.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          svo.echof("Hm... doesn't seem the mace summon is happening. Going to try again.")
-        end
-        svo.dict.mace.physical.unpauselater = false
-      end,
-
-      onstart = function() end
-    }
-  }
-  svo.dict.sacrifice = {
-    description = "tracks whenever you've sent the angel sacrifice command - so an illusion on angel sacrifice won't trick the system into clearing all affs",
-    physical = {
-      balanceless_act = true,
-      uncurable = true,
-
-      isadvisable = function()
-        return false
-      end,
-
-      oncompleted = function() end,
-
-      action = "angel sacrifice",
-      onstart = function() send('angel sacrifice', conf.commandecho) end
-    }
-  }
-  svo.dict.summon = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.summon and ((sys.deffing and defdefup[defs.mode].summon) or (conf.keepup and defkeepup[defs.mode].summon)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
-      end,
-
-      oncompleted = function() defences.got('summon') end,
-
-      action = "angel summon",
-      onstart = function() send('angel summon', conf.commandecho) end
-    }
-  }
-  svo.dict.empathy = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.empathy and ((sys.deffing and defdefup[defs.mode].empathy) or (conf.keepup and defkeepup[defs.mode].empathy)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and defc.summon) or false
-      end,
-
-      oncompleted = function() defences.got('empathy') end,
-
-      action = "angel empathy on",
-      onstart = function() send('angel empathy on', conf.commandecho) end
-    }
-  }
-  svo.dict.watch = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.watch and ((sys.deffing and defdefup[defs.mode].watch) or (conf.keepup and defkeepup[defs.mode].watch)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and defc.summon) or false
-      end,
-
-      oncompleted = function() defences.got('watch') end,
-
-      action = "angel watch on",
-      onstart = function() send('angel watch on', conf.commandecho) end
-    }
-  }
-  svo.dict.care = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.care and ((sys.deffing and defdefup[defs.mode].care) or (conf.keepup and defkeepup[defs.mode].care)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and defc.summon) or false
-      end,
-
-      oncompleted = function() defences.got('care') end,
-
-      action = "angel care on",
-      onstart = function() send('angel care on', conf.commandecho) end
-    }
-  }
-end
-
-if svo.haveskillset('shindo') then
-  svo.dict.phoenix = {
-    description = "tracks whenever you've sent the shindo phoenix command - so an illusion on shindo phoenix won't trick the system into clearing all affs",
-    physical = {
-      balanceful_act = true,
-      uncurable = true,
-
-      isadvisable = function()
-        return false
-      end,
-
-      oncompleted = function() end,
-
-      action = "shin phoenix",
-      onstart = function() send('shin phoenix', conf.commandecho) end
-    }
-  }
-end
-
-if svo.haveskillset('twoarts') then
-  svo.dict.doya = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].doya and not defc.doya) or (conf.keepup and defkeepup[defs.mode].doya and not defc.doya)) and not defc.thyr and not defc.mir and not defc.arash and not defc.sanya and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        for _, stance in ipairs{'doya', 'thyr', 'mir', 'arash', 'sanya'} do
-          defences.lost(stance)
-        end
-
-        defences.got('doya')
-      end,
-
-      action = 'doya',
-      onstart = function() send('doya', conf.commandecho) end
-    },
-  }
-  svo.dict.thyr = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].thyr and not defc.thyr) or (conf.keepup and defkeepup[defs.mode].thyr)) and not defc.doya and not defc.thyr and not defc.mir and not defc.arash and not defc.sanya and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        for _, stance in ipairs{'doya', 'thyr', 'mir', 'arash', 'sanya'} do
-          defences.lost(stance)
-        end
-
-        defences.got('thyr')
-      end,
-
-      action = 'thyr',
-      onstart = function() send('thyr', conf.commandecho) end
-    },
-  }
-  svo.dict.mir = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].mir and not defc.mir) or (conf.keepup and defkeepup[defs.mode].mir)) and not defc.doya and not defc.thyr and not defc.mir and not defc.arash and not defc.sanya and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        for _, stance in ipairs{'doya', 'thyr', 'mir', 'arash', 'sanya'} do
-          defences.lost(stance)
-        end
-
-        defences.got('mir')
-      end,
-
-      action = 'mir',
-      onstart = function() send('mir', conf.commandecho) end
-    },
-  }
-  svo.dict.arash = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].arash and not defc.arash) or (conf.keepup and defkeepup[defs.mode].arash)) and not defc.doya and not defc.thyr and not defc.mir and not defc.arash and not defc.sanya and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        for _, stance in ipairs{'doya', 'thyr', 'mir', 'arash', 'sanya'} do
-          defences.lost(stance)
-        end
-
-        defences.got('arash')
-      end,
-
-      action = 'arash',
-      onstart = function() send('arash', conf.commandecho) end
-    },
-  }
-  svo.dict.sanya = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].sanya and not defc.sanya) or (conf.keepup and defkeepup[defs.mode].sanya)) and not defc.doya and not defc.thyr and not defc.mir and not defc.arash and not defc.sanya and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        for _, stance in ipairs{'doya', 'thyr', 'mir', 'arash', 'sanya'} do
-          defences.lost(stance)
-        end
-
-        defences.got('sanya')
-      end,
-
-      action = 'sanya',
-      onstart = function() send('sanya', conf.commandecho) end
-    },
-  }
-end
-
-if svo.haveskillset('metamorphosis') then
-  svo.dict.affinity = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
-
-      isadvisable = function()
-        return (not defc.affinity and ((sys.deffing and defdefup[defs.mode].affinity) or (conf.keepup and defkeepup[defs.mode].affinity)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not svo.doingaction('waitingformorph') and not affs.prone) or false
-      end,
-
-      oncompleted = function() defences.got('affinity') end,
-
-      action = "embrace spirit",
-      onstart = function()
-        if sk.inamorph() then
-          send("embrace spirit", conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-
-          if sk.skillmorphs.wyvern then
-            send("morph wyvern", conf.commandecho)
-          else
-            send("morph "..sk.morphsforskill.nightsight[1], conf.commandecho)
-          end
-          if  not conf.truemorph then
-            svo.doaction(svo.dict.waitingformorph.waitingfor)
-          end
-        end
-      end
-    }
-  }
-  svo.dict.fitness = {
-    physical = {
-      balanceful_act = true,
-      undeffable = true, -- mark as undeffable since serverside can't morph
-
-      isadvisable = function()
-        if not (not affs.weakness and not defc.dragonform and bals.fitness and not codepaste.balanceful_defs_codepaste() and (defc.wyvern or defc.wolf or defc.hyena or defc.jaguar or defc.cheetah or defc.elephant or defc.hydra) and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.fitness) then
-          return false
-        end
-
-        for name, func in pairs(svo.fitness) do
-          if not me.disabledfitnessfunc[name] then
-            local s,m = pcall(func[1])
-            if s and m then return true end
-          end
-        end
-      end,
-
-      oncompleted = function()
-        svo.rmaff('asthma')
-        svo.lostbal_fitness()
-      end,
-
-      curedasthma = function() svo.rmaff('asthma') end,
-
-      weakness = function()
-        svo.addaffdict(svo.dict.weakness)
-      end,
-
-      allgood = function() svo.rmaff('asthma') end,
-
-      actions = {'fitness'},
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'fitness' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        elseif not sk.inamorphfor'fitness' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph "..sk.morphsforskill.fitness[1], conf.commandecho)
-          if  not conf.truemorph then
-            svo.doaction(svo.dict.waitingformorph.waitingfor)
-          end
-        elseif sk.inamorphfor'fitness' then
-          send('fitness', conf.commandecho)
-        end
-      end
-    },
-  }
-  svo.dict.elusiveness = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
-
-      isadvisable = function()
-        return (not defc.elusiveness and ((sys.deffing and defdefup[defs.mode].elusiveness) or (conf.keepup and defkeepup[defs.mode].elusiveness)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.elusiveness) or false
-      end,
-
-      oncompleted = function() defences.got('elusiveness') end,
-
-      action = "elusiveness on",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'elusiveness' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        elseif not sk.inamorphfor'elusiveness' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph "..sk.morphsforskill.elusiveness[1], conf.commandecho)
-          if  not conf.truemorph then
-            svo.doaction(svo.dict.waitingformorph.waitingfor)
-          end
-        elseif sk.inamorphfor'elusiveness' then
-          send("elusiveness on", conf.commandecho)
-        end
-      end
-    },
-  }
-  svo.dict.temperance = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
-
-      isadvisable = function()
-        return (not defc.temperance and ((sys.deffing and defdefup[defs.mode].temperance) or (conf.keepup and defkeepup[defs.mode].temperance)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.temperance) or false
-      end,
-
-      oncompleted = function()
-        defences.got('temperance')
-        defences.got('frost')
-      end,
-
-      action = 'temperance',
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'temperance' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        elseif not sk.inamorphfor'temperance' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph "..sk.morphsforskill.temperance[1], conf.commandecho)
-          if  not conf.truemorph then
-            svo.doaction(svo.dict.waitingformorph.waitingfor)
-          end
-        elseif sk.inamorphfor'temperance' then
-          send('temperance', conf.commandecho)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('frost') end
-    }
-  }
-  svo.dict.bonding = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
-
-      isadvisable = function()
-        return (not defc.bonding and ((sys.deffing and defdefup[defs.mode].bonding) or (conf.keepup and defkeepup[defs.mode].bonding)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.inamorph()) or false
-      end,
-
-      oncompleted = function()
-        defences.got('bonding')
-      end,
-
-      action = 'bond spirit',
-
-      onstart = function() 
-				if sk.inamorph() then
-					send('bond spirit', conf.commandecho)
-				else
-          if defc.flame then send("relax flame", conf.commandecho) end
-
-          if sk.skillmorphs.wyvern then
-            send("morph wyvern", conf.commandecho)
-          else
-            send("morph "..sk.morphsforskill.nightsight[1], conf.commandecho)
-          end
-          if  not conf.truemorph then
-            svo.doaction(svo.dict.waitingformorph.waitingfor)
-          end
-        end
-			end,
-
-   		gone = {
-      	oncompleted = function() defences.lost('bonding') end
-    	}
-		}
-  }
-  svo.dict.stealth = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
-
-      isadvisable = function()
-        return (not defc.stealth and ((sys.deffing and defdefup[defs.mode].stealth) or (conf.keepup and defkeepup[defs.mode].stealth)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.stealth) or false
-      end,
-
-      oncompleted = function() defences.got('stealth') end,
-
-      action = "stealth on",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'stealth' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        elseif not sk.inamorphfor'stealth' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph "..sk.morphsforskill.stealth[1], conf.commandecho)
-          if  not conf.truemorph then
-            svo.doaction(svo.dict.waitingformorph.waitingfor)
-          end
-        elseif sk.inamorphfor'stealth' then
-          send("stealth on", conf.commandecho)
-        end
-      end
-    },
-  }
-  svo.dict.resistance = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
-
-      isadvisable = function()
-        return (not defc.resistance and ((sys.deffing and defdefup[defs.mode].resistance) or (conf.keepup and defkeepup[defs.mode].resistance)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.resistance) or false
-      end,
-
-      oncompleted = function() defences.got('resistance') end,
-
-      action = 'resistance',
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'resistance' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        elseif not sk.inamorphfor'resistance' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph "..sk.morphsforskill.resistance[1], conf.commandecho)
-          if  not conf.truemorph then
-            svo.doaction(svo.dict.waitingformorph.waitingfor)
-          end
-        elseif sk.inamorphfor'resistance' then
-          send('resistance', conf.commandecho)
-        end
-      end
-    },
-  }
-  svo.dict.rest = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
-
-      isadvisable = function()
-        return (not defc.rest and ((sys.deffing and defdefup[defs.mode].rest) or (conf.keepup and defkeepup[defs.mode].rest)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.rest) or false
-      end,
-
-      oncompleted = function() defences.got('rest') end,
-
-      action = 'rest',
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'rest' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        elseif not sk.inamorphfor'rest' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph "..sk.morphsforskill.rest[1], conf.commandecho)
-          if  not conf.truemorph then
-            svo.doaction(svo.dict.waitingformorph.waitingfor)
-          end
-        elseif sk.inamorphfor'rest' then
-          send('rest', conf.commandecho)
-        end
-      end
-    },
-  }
-  svo.dict.vitality = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
-
-      isadvisable = function()
-        if (not defc.vitality and ((sys.deffing and defdefup[defs.mode].vitality) or (conf.keepup and defkeepup[defs.mode].vitality)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.vitality and not svo.doingaction'cantvitality') then
-
-         if (stats.currenthealth &gt;= stats.maxhealth and stats.currentmana &gt;= stats.maxmana)
-          then
-            return true
-          elseif not sk.gettingfullstats then
-            svo.fullstats(true)
-            svo.echof("Getting fullstats for vitality now...")
-          end
-        end
-      end,
-
-      oncompleted = function() defences.got('vitality') end,
-
-      action = 'vitality',
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'vitality' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        elseif not sk.inamorphfor'vitality' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph "..sk.morphsforskill.vitality[1], conf.commandecho)
-          if  not conf.truemorph then
-            svo.doaction(svo.dict.waitingformorph.waitingfor)
-          end
-        elseif sk.inamorphfor'vitality' then
-          send('vitality', conf.commandecho)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('vitality')
-        if not svo.actions.cantvitality_waitingfor then svo.doaction(svo.dict.cantvitality.waitingfor) end
-      end
-    }
-  }
-  svo.dict.flame = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
-
-      isadvisable = function()
-        return (not defc.flame and ((sys.deffing and defdefup[defs.mode].flame) or (conf.keepup and defkeepup[defs.mode].flame)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.flame) or false
-      end,
-
-      oncompleted = function() defences.got('flame') end,
-
-      actions = {"summon flame", "summon fire", "ignite"},
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'flame' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        elseif not sk.inamorphfor'flame' then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph "..sk.morphsforskill.flame[1], conf.commandecho)
-          if  not conf.truemorph then
-            svo.doaction(svo.dict.waitingformorph.waitingfor)
-          end
-        elseif sk.inamorphfor'flame' then
-          send("summon flame", conf.commandecho)
-        end
-      end
-    },
-  }
-  svo.dict.waitingformorph = {
-	unpauselater = false,
-	waitingfor = {
-		customwait = 4,
-		
-		oncompleted = function()
-			if conf.paused and svo.dict.waitingformorph.unpauselater then
-				conf.paused = false; raiseEvent("svo config changed", 'paused')
-				echo"\n"
-				svo.echof("Obtained morph, unpausing.")         
-			end
-			svo.dict.waitingformorph.unpauselater = false
-		end,
-		
-		cancelled = function()
-			if conf.paused and svo.dict.waitingformorph.unpauselater then
-				conf.paused = false; raiseEvent("svo config changed", 'paused')
-				echo"\n" svo.echof("Unpausing.")
-			end
-			svo.dict.waitingformorph.unpauselater = false
-		
-		end,
-		
-		ontimeout = function()
-		 svo.dict.waitingformorph.waitingfor.cancelled()
-		end,
-		
-		onstart = function()
-			if not conf.truemorph then
-				if not conf.paused then
-					svo.dict.waitingformorph.unpauselater = true
-					conf.paused = true; raiseEvent("svo config changed", 'paused')
-					echo"\n" svo.echof("Temporarily pausing for morphing.")
-				end
-			else
-				svo.dict.waitingformorph.oncompleted()
-			end
-		end,
-	}
-  }
-  svo.dict.squirrel = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.squirrel and ((sys.deffing and defdefup[defs.mode].squirrel) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].squirrel)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('squirrel')
-      end,
-
-      action = "morph squirrel",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph squirrel", conf.commandecho)
-        end 
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('squirrel') end,
-    }
-  }
-  svo.dict.wildcat = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.wildcat and ((sys.deffing and defdefup[defs.mode].wildcat) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].wildcat)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('wildcat')
-      end,
-
-      action = "morph wildcat",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph wildcat", conf.commandecho)
-        end 
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('wildcat') end,
-    }
-  }
-  svo.dict.wolf = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.wolf and ((sys.deffing and defdefup[defs.mode].wolf) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].wolf)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('wolf')
-      end,
-
-      action = "morph wolf",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph wolf", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('wolf') end,
-    }
-  }
-  svo.dict.turtle = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.turtle and ((sys.deffing and defdefup[defs.mode].turtle) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].turtle)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('turtle')
-      end,
-
-      action = "morph turtle",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph turtle", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('turtle') end,
-    }
-  }
-  svo.dict.jackdaw = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.jackdaw and ((sys.deffing and defdefup[defs.mode].jackdaw) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].jackdaw)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('jackdaw')
-      end,
-
-      action = "morph jackdaw",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph jackdaw", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('jackdaw') end,
-    }
-  }
-  svo.dict.cheetah = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.cheetah and ((sys.deffing and defdefup[defs.mode].cheetah) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].cheetah)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('cheetah')
-      end,
-
-      action = "morph cheetah",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph cheetah", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('cheetah') end,
-    }
-  }
-  svo.dict.owl = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      
-      isadvisable = function()
-        return (not defc.owl and ((sys.deffing and defdefup[defs.mode].owl) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].owl)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('owl')
-      end,
-
-      action = "morph owl",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph owl", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('owl') end,
-    }
-  }
-  svo.dict.hyena = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.hyena and ((sys.deffing and defdefup[defs.mode].hyena) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].hyena)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-          sk.clearmorphs()
-          defences.got('hyena')
-      end,
-
-      action = "morph hyena",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph hyena", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-		
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('hyena') end,
-    }
-  }
-  svo.dict.condor = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.condor and ((sys.deffing and defdefup[defs.mode].condor) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].condor)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('condor')
-      end,
-
-      action = "morph condor",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph condor", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('condor') end,
-    }
-  }
-  svo.dict.gopher = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.gopher and ((sys.deffing and defdefup[defs.mode].gopher) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].gopher)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('gopher')
-      end,
-
-      action = "morph gopher",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph gopher", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('gopher') end,
-    }
-  }
-  svo.dict.sloth = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.sloth and ((sys.deffing and defdefup[defs.mode].sloth) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].sloth)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('sloth')
-      end,
-
-      action = "morph sloth",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph sloth", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('sloth') end,
-    }
-  }
-  svo.dict.bear = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.bear and ((sys.deffing and defdefup[defs.mode].bear) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].bear)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('bear')
-      end,
-
-      action = "morph bear",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph bear", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('bear') end,
-    }
-  }
-  svo.dict.nightingale = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.nightingale and ((sys.deffing and defdefup[defs.mode].nightingale) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].nightingale)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('nightingale')
-      end,
-
-      action = "morph nightingale",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph nightingale", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('nightingale') end,
-    }
-  }
-  svo.dict.elephant = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.elephant and ((sys.deffing and defdefup[defs.mode].elephant) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].elephant)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('elephant')
-      end,
-
-      action = "morph elephant",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph elephant", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('elephant') end,
-    }
-  }
-  svo.dict.wolverine = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.wolverine and ((sys.deffing and defdefup[defs.mode].wolverine) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].wolverine)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('wolverine')
-      end,
-
-      action = "morph wolverine",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph wolverine", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('wolverine') end,
-    }
-  }
-  svo.dict.eagle = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.eagle and ((sys.deffing and defdefup[defs.mode].eagle) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].eagle)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('eagle')
-      end,
-
-      action = "morph eagle",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph eagle", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('eagle') end,
-    }
-  }
-  svo.dict.gorilla = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.gorilla and ((sys.deffing and defdefup[defs.mode].gorilla) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].gorilla)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('gorilla')
-      end,
-
-      action = "morph gorilla",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph gorilla", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('gorilla') end,
-    }
-  }
-  svo.dict.icewyrm = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.icewyrm and ((sys.deffing and defdefup[defs.mode].icewyrm) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].icewyrm)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('icewyrm')
-      end,
-
-      action = "morph icewyrm",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph icewyrm", conf.commandecho)
-        end
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('icewyrm') end,
-    }
-  }
-end
-
-if svo.haveskillset('swashbuckling') then
-  svo.dict.drunkensailor = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return ((sys.deffing and defdefup[defs.mode].drunkensailor and not defc.drunkensailor) or (conf.keepup and defkeepup[defs.mode].drunkensailor and not defc.drunkensailor) and not defc.heartsfury and not svo.doingaction'drunkensailor' and not affs.paralysis) or false
-      end,
-
-      oncompleted = function() defences.got('drunkensailor') end,
-
-      action = 'drunkensailor',
-      onstart = function() send('drunkensailor', conf.commandecho) end
-    },
-  }
-  svo.dict.heartsfury = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return ((sys.deffing and defdefup[defs.mode].heartsfury and not defc.heartsfury) or (conf.keepup and defkeepup[defs.mode].heartsfury and not defc.heartsfury) and not defc.drunkensailor and not svo.doingaction'heartsfury' and not affs.paralysis) or false
-      end,
-
-      oncompleted = function() defences.got('heartsfury') end,
-
-      action = 'heartsfury',
-      onstart = function() send('heartsfury', conf.commandecho) end
-    },
-  }
-end
-
-if svo.haveskillset('voicecraft') then
-  svo.dict.lay = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].lay and not defc.lay) or (conf.keepup and defkeepup[defs.mode].lay and not defc.lay)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'lay' and bals.voice) or false
-      end,
-
-      oncompleted = function()
-        defences.got('lay')
-        svo.lostbal_voice()
-      end,
-
-      action = "sing lay",
-      onstart = function() send('sing lay', conf.commandecho) end
-    },
-  }
-  svo.dict.tune = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].tune and not defc.tune) or (conf.keepup and defkeepup[defs.mode].tune and not defc.tune)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'tune' and bals.voice) or false
-      end,
-
-      oncompleted = function()
-        defences.got('tune')
-        svo.lostbal_voice()
-      end,
-
-      action = "sing tune",
-      onstart = function() send('sing tune', conf.commandecho) end
-    },
-  }
-  svo.dict.aria = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].aria and not defc.aria) or (conf.keepup and defkeepup[defs.mode].aria and not defc.aria)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'aria' and bals.voice) or false
-      end,
-
-      oncompleted = function()
-        defences.got('aria')
-        svo.lostbal_voice()
-      end,
-      applycure = {'epidermal'},
-      action = 'sing aria at me',
-      onstart = function()
-        if defc.deaf or affs.deafaff then svo.apply(svo.dict.aria.salve, ' to ears', conf.commandecho) end
-        send('sing aria at me', conf.commandecho)   
-      end
-    },
-  }
-end
-
-if svo.haveskillset('occultism') then
-  svo.dict.astralform = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.astralform and ((sys.deffing and defdefup[defs.mode].astralform) or (conf.keepup and defkeepup[defs.mode].astralform)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
-      end,
-
-      oncompleted = function()
-        defences.got('astralform')
-        defences.lost('riding')
-      end,
-
-      action = 'astralform',
-      onstart = function() send('astralform', conf.commandecho) end
-    }
-  }
-end
-
-if svo.haveskillset('elementalism') or svo.haveskillset('weatherweaving') then
-  svo.dict.simultaneity = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-       return (not defc.simultaneity and ((sys.deffing and defdefup[defs.mode].simultaneity) or (conf.keepup and defkeepup[defs.mode].simultaneity)) and not codepaste.balanceful_defs_codepaste() and stats.currentmana &gt;= 1000) or false
-      end,
-
-      oncompleted = function() defences.got('simultaneity') end,
-
-      action = 'simultaneity',
-      onstart = function() send('simultaneity', conf.commandecho) end
-    }
-  }
-  svo.dict.air = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-       return (not defc.air and ((sys.deffing and defdefup[defs.mode].air) or (conf.keepup and defkeepup[defs.mode].air)) and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        defences.got('air')
-        if defc.air and defc.earth and defc.water and not defc.spirit
-        and (svo.haveskillset('weatherweaving') or defc.fire) then
-          defences.got('simultaneity')
-        end
-      end,
-
-      action = "channel air",
-      onstart = function() send('channel air', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('air')
-        defences.lost('simultaneity')
-      end
-    }
-  }
-  svo.dict.water = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-       return (not defc.water and ((sys.deffing and defdefup[defs.mode].water) or (conf.keepup and defkeepup[defs.mode].water)) and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        defences.got('water')
-        if defc.air and defc.earth and defc.water and not defc.spirit
-        and (svo.haveskillset('weatherweaving') or defc.fire) then
-          defences.got('simultaneity')
-        end
-      end,
-
-      action = "channel water",
-      onstart = function() send('channel water', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('water')
-        defences.lost('simultaneity')
-      end
-    }
-  }
-  svo.dict.earth = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-       return (not defc.earth and ((sys.deffing and defdefup[defs.mode].earth) or (conf.keepup and defkeepup[defs.mode].earth)) and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        defences.got('earth')
-        if defc.air and defc.earth and defc.water and not defc.spirit
-        and (svo.haveskillset('weatherweaving') or defc.fire) then
-          defences.got('simultaneity')
-        end
-      end,
-
-      action = "channel earth",
-      onstart = function() send('channel earth', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('earth')
-        defences.lost('simultaneity')
-      end
-    }
-  }
-if not svo.haveskillset('weatherweaving') then
-  svo.dict.fire = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-       return (not defc.fire and ((sys.deffing and defdefup[defs.mode].fire) or (conf.keepup and defkeepup[defs.mode].fire)) and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function()
-        defences.got('fire')
-        if defc.air and defc.fire and defc.earth and defc.water and not defc.spirit then
-          defences.got('simultaneity')
-        end
-      end,
-
-      action = "channel fire",
-      onstart = function() send('channel fire', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('fire')
-        defences.lost('simultaneity')
-      end
-    }
-  }
-end
-  svo.dict.bindall = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((((sys.deffing and defdefup[defs.mode].bindall and not defc.bindall) or (conf.keepup and defkeepup[defs.mode].bindall and not defc.bindall))) or (conf.keepup and defkeepup[defs.mode].bindall and not defc.bindall)) and not codepaste.balanceful_defs_codepaste() and stats.currentmana &gt;= 750 and defc.air and defc.earth and defc.water and not defc.spirit
-        and (svo.haveskillset('weatherweaving') or defc.fire)) or false
-      end,
-
-      oncompleted = function() defences.got('bindall') end,
-
-      action = "bind all",
-      onstart = function() send('bind all', conf.commandecho) end
-    }
-  }
-  svo.dict.boundair = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((((sys.deffing and defdefup[defs.mode].boundair and not defc.boundair) or (conf.keepup and defkeepup[defs.mode].boundair and not defc.boundair))) or (conf.keepup and defkeepup[defs.mode].boundair and not defc.boundair)) and not codepaste.balanceful_defs_codepaste() and defc.air) or false
-      end,
-
-      oncompleted = function()
-        defences.got('boundair')
-        if defc.boundair and defc.boundearth and defc.boundwater and not defc.boundspirit and (svo.haveskillset('weatherweaving') or defc.boundfire) then
-          defences.got('bindall')
-        end
-      end,
-
-      action = "bind air",
-      onstart = function() send('bind air', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('boundair')
-        defences.lost('bindall')
-      end
-    }
-  }
-  svo.dict.boundwater = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((((sys.deffing and defdefup[defs.mode].boundwater and not defc.boundwater) or (conf.keepup and defkeepup[defs.mode].boundwater and not defc.boundwater))) or (conf.keepup and defkeepup[defs.mode].boundwater and not defc.boundwater)) and not codepaste.balanceful_defs_codepaste() and defc.water) or false
-      end,
-
-      oncompleted = function()
-        defences.got('boundwater')
-        if defc.boundair and defc.boundearth and defc.boundwater and not defc.boundspirit and (svo.haveskillset('weatherweaving') or defc.boundfire) then
-          defences.got('bindall')
-        end
-      end,
-
-      action = "bind water",
-      onstart = function() send('bind water', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('boundwater')
-        defences.lost('bindall')
-      end
-    }
-  }
-  if not svo.haveskillset('weatherweaving') then
-    svo.dict.boundfire = {
-      physical = {
-        balanceful_act = true, def = true, undeffable = true,
-
+    unknowncrippledlimb = {
+      count = 0,
+      salve = {
+        uncurable = true,
+  
         isadvisable = function()
-          return (((((sys.deffing and defdefup[defs.mode].boundfire and not defc.boundfire) or (conf.keepup and defkeepup[defs.mode].boundfire and not defc.boundfire))) or (conf.keepup and defkeepup[defs.mode].boundfire and not defc.boundfire)) and not codepaste.balanceful_defs_codepaste() and defc.fire) or false
+          return (affs.unknowncrippledlimb and not (affs.mutilatedrightarm or affs.mutilatedleftarm or affs.mangledleftarm or affs.mangledrightarm or affs.parestoarms) and not (affs.mutilatedrightleg or affs.mutilatedleftleg or affs.mangledleftleg or affs.mangledrightleg or affs.parestolegs)) or false
         end,
-
+  
         oncompleted = function()
-          defences.got('boundfire')
-          if defc.boundair and defc.boundfire and defc.boundearth and defc.boundwater and not defc.boundspirit then
-            defences.got('bindall')
-          end
+          svo.lostbal_salve()
+          svo.rmaff('unknowncrippledlimb')
         end,
-
-        action = "bind fire",
+  
+        applycure = {'mending', 'renewal'},
+        actions = {"apply mending", "apply renewal"},
         onstart = function()
-          send("bind fire", conf.commandecho)
+          svo.apply(svo.dict.unknowncrippledlimb.salve)
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.apply_mending()
+        end,
+  
+        fizzled = function()
+          svo.lostbal_salve()
+          -- if it fizzled, then it means we've got a resto break on arms or legs
+          -- applying resto without targetting a limb doesn't work, so try mending on both, see what happens
+          svo.rmaff('unknowncrippledlimb')
+          svo.addaffdict(svo.dict.unknowncrippledarm)
+          svo.addaffdict(svo.dict.unknowncrippledleg)
+          tempTimer(0, function() svo.show_info("some limb broken?", "It would seem an arm or a leg of yours is broken (the salve fizzled), not just crippled - going to work out which is it and fix it") end)
+        end,
+      },
+      aff = {
+        oncompleted = function (amount)
+          svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count + (amount or 1)
+          if svo.dict.unknowncrippledlimb.count &gt; 4 then svo.dict.unknowncrippledlimb.count = 4 end
+          svo.addaffdict(svo.dict.unknowncrippledlimb)
+          svo.updateaffcount(svo.dict.unknowncrippledlimb)
         end
       },
       gone = {
         oncompleted = function()
-          defences.lost('boundfire')
-          defences.lost('bindall')
+          svo.dict.unknowncrippledlimb.count = 0
+          svo.rmaff('unknowncrippledlimb')
+        end,
+      },
+      onremoved = function()
+        if svo.dict.unknowncrippledlimb.count &lt;= 0 then return end
+  
+        svo.dict.unknowncrippledlimb.count = svo.dict.unknowncrippledlimb.count - 1
+        if svo.dict.unknowncrippledlimb.count &lt;= 0 then return end
+        svo.addaffdict(svo.dict.unknowncrippledlimb)
+        svo.updateaffcount(svo.dict.unknowncrippledlimb)
+      end,
+    },
+    unknowncrippledarm = {
+      count = 0,
+      salve = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (affs.unknowncrippledarm and not (affs.mutilatedrightarm or affs.mutilatedleftarm or affs.mangledleftarm or affs.mangledrightarm or affs.parestoarms)) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('unknowncrippledarm')
+        end,
+  
+        actions = {"apply mending to arms", "apply mending", "apply renewal to arms", "apply renewal"},
+        applycure = {'mending', 'renewal'},
+        onstart = function()
+          svo.apply(svo.dict.unknowncrippledarm.salve, " to arms")
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.noeffect_mending_arms()
+        end,
+  
+        fizzled = function (limb)
+          svo.lostbal_salve()
+          if limb and svo.dict['mangled'..limb] then svo.addaffdict(svo.dict['mangled'..limb]) end
+        end,
+      },
+      aff = {
+        oncompleted = function (amount)
+          svo.dict.unknowncrippledarm.count = svo.dict.unknowncrippledarm.count + (amount or 1)
+          if svo.dict.unknowncrippledarm.count &gt; 2 then svo.dict.unknowncrippledarm.count = 2 end
+          svo.addaffdict(svo.dict.unknowncrippledarm)
+          svo.updateaffcount(svo.dict.unknowncrippledarm)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.dict.unknowncrippledarm.count = 0
+          svo.rmaff('unknowncrippledarm')
+        end,
+      },
+      onremoved = function()
+        if svo.dict.unknowncrippledarm.count &lt;= 0 then return end
+  
+        svo.dict.unknowncrippledarm.count = svo.dict.unknowncrippledarm.count - 1
+        if svo.dict.unknowncrippledarm.count &lt;= 0 then return end
+        svo.addaffdict(svo.dict.unknowncrippledarm)
+        svo.updateaffcount(svo.dict.unknowncrippledarm)
+      end,
+    },
+    unknowncrippledleg = {
+      count = 0,
+      salve = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (affs.unknowncrippledleg and not (affs.mutilatedrightleg or affs.mutilatedleftleg or affs.mangledleftleg or affs.mangledrightleg or affs.parestolegs)) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          svo.rmaff('unknowncrippledleg')
+        end,
+  
+        actions = {"apply mending to legs", "apply mending", "apply renewal to legs", "apply renewal"},
+        applycure = {'mending', 'renewal'},
+        onstart = function()
+          svo.apply(svo.dict.unknowncrippledleg.salve, " to legs")
+        end,
+  
+        noeffect = function()
+          svo.lostbal_salve()
+          empty.noeffect_mending_legs()
+        end,
+  
+        fizzled = function (limb)
+          svo.lostbal_salve()
+          if limb and svo.dict['mangled'..limb] then svo.addaffdict(svo.dict['mangled'..limb]) end
+        end,
+      },
+      aff = {
+        oncompleted = function (amount)
+          svo.dict.unknowncrippledleg.count = svo.dict.unknowncrippledleg.count + (amount or 1)
+          if svo.dict.unknowncrippledleg.count &gt; 2 then svo.dict.unknowncrippledleg.count = 2 end
+          svo.addaffdict(svo.dict.unknowncrippledleg)
+          svo.updateaffcount(svo.dict.unknowncrippledleg)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.dict.unknowncrippledleg.count = 0
+          svo.rmaff('unknowncrippledleg')
+        end,
+      },
+      onremoved = function()
+        if svo.dict.unknowncrippledleg.count &lt;= 0 then return end
+  
+        svo.dict.unknowncrippledleg.count = svo.dict.unknowncrippledleg.count - 1
+        if svo.dict.unknowncrippledleg.count &lt;= 0 then return end
+        svo.addaffdict(svo.dict.unknowncrippledleg)
+        svo.updateaffcount(svo.dict.unknowncrippledleg)
+      end,
+    },
+    unknowncure = {
+      count = 0,
+      waitingfor = {
+        customwait = 999,
+  
+        onstart = function() end,
+  
+        empty = function() end
+      },
+      aff = {
+        oncompleted = function (number)
+          local count = svo.dict.unknowncure.count
+          svo.addaffdict(svo.dict.unknowncure)
+  
+          svo.dict.unknowncure.count = (count or 0) + (number or 1)
+          svo.updateaffcount(svo.dict.unknowncure)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('unknowncure')
+          svo.dict.unknowncure.count = 0
+        end
+      }
+    },
+  
+  
+  -- writhes
+    bound = {
+      misc = {
+        dontbatch = true,
+  
+        isadvisable = function()
+          return (affs.bound and codepaste.writhe()) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.curingbound.waitingfor)
+        end,
+  
+        action = 'writhe',
+        onstart = function() send('writhe', conf.commandecho) end,
+  
+        helpless = function()
+          empty.writhe()
+        end,
+  
+        impale = function()
+          svo.doaction(svo.dict.curingimpale.waitingfor)
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.bound)
+          signals.canoutr:emit()
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('bound') end,
+      },
+      onremoved = function() signals.canoutr:emit() end
+    },
+    curingbound = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function() svo.rmaff('bound') end,
+  
+        onstart = function() end
+      }
+    },
+    webbed = {
+      misc = {
+        dontbatch = true,
+  
+        isadvisable = function()
+          return (affs.webbed and codepaste.writhe() and not (bals.balance and bals.rightarm and bals.leftarm and svo.dict.dragonflex.misc.isadvisable()) and (not svo.haveskillset('voicecraft') or (not conf.dwinnu or not svo.dict.dwinnu.misc.isadvisable()))) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.curingwebbed.waitingfor)
+        end,
+  
+        action = 'writhe',
+        onstart = function()
+          if math.random(1, 30) == 1 then
+            send("writhe wiggle wiggle", conf.commandecho)
+          else
+            send('writhe', conf.commandecho)
+          end
+        end,
+  
+        helpless = function()
+          empty.writhe()
+        end,
+  
+        impale = function()
+          svo.doaction(svo.dict.curingimpale.waitingfor)
+        end
+      },
+      aff = {
+        oncompleted = function()
+          affs.webbed = nil
+          svo.addaffdict(svo.dict.webbed)
+          signals.canoutr:emit()
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('webbed') end,
+      },
+      onremoved = function() signals.canoutr:emit() svo.donext() end
+    },
+    curingwebbed = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function() svo.rmaff('webbed') end,
+  
+        onstart = function() end
+      }
+    },
+    roped = {
+      misc = {
+        dontbatch = true,
+  
+        isadvisable = function()
+          return (affs.roped and codepaste.writhe() and not (bals.balance and bals.rightarm and bals.leftarm and svo.dict.dragonflex.misc.isadvisable()) and (not svo.haveskillset('voicecraft') or (not conf.dwinnu or not svo.dict.dwinnu.misc.isadvisable()))) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.curingroped.waitingfor)
+        end,
+  
+        action = 'writhe',
+        onstart = function() send('writhe', conf.commandecho) end,
+  
+        helpless = function()
+          empty.writhe()
+        end,
+  
+        impale = function()
+          svo.doaction(svo.dict.curingimpale.waitingfor)
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.roped)
+          signals.canoutr:emit()
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('roped') end,
+      },
+      onremoved = function() signals.canoutr:emit() svo.donext() end
+    },
+    curingroped = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function() svo.rmaff('roped') end,
+  
+        onstart = function() end
+      }
+    },
+    hoisted = {
+      misc = {
+        dontbatch = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          return (affs.hoisted and codepaste.writhe() and bals.balance and bals.rightarm and bals.leftarm) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.curinghoisted.waitingfor)
+        end,
+  
+        action = 'writhe',
+        onstart = function() send('writhe', conf.commandecho) end,
+  
+        helpless = function()
+          empty.writhe()
+        end,
+  
+        impale = function()
+          svo.doaction(svo.dict.curingimpale.waitingfor)
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.hoisted)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('hoisted') end,
+      }
+    },
+    curinghoisted = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function() svo.rmaff('hoisted') end,
+  
+        onstart = function() end
+      }
+    },
+    transfixed = {
+      gamename = 'transfixation',
+      misc = {
+        dontbatch = true,
+  
+        isadvisable = function()
+          return (affs.transfixed and codepaste.writhe()) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.curingtransfixed.waitingfor)
+        end,
+  
+        action = 'writhe',
+        onstart = function() send('writhe', conf.commandecho) end,
+  
+        helpless = function()
+          empty.writhe()
+        end,
+  
+        impale = function()
+          svo.doaction(svo.dict.curingimpale.waitingfor)
+        end
+      },
+      aff = {
+        oncompleted = function()
+          if not conf.aillusion or ((not affs.blindaff and not defc.blind) or svo.lifevision.l.blindaff_aff or svo.lifevision.l.blind_herb or svo.lifevision.l.blind_misc) then
+            svo.affsp.transfixed = nil
+            svo.addaffdict(svo.dict.transfixed)
+          end
+  
+          signals.canoutr:emit()
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('transfixed') end,
+      },
+      onremoved = function() signals.canoutr:emit() svo.donext() end
+    },
+    curingtransfixed = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function() svo.rmaff('transfixed') end,
+  
+        onstart = function() end
+      }
+    },
+    impale = {
+      gamename = 'impaled',
+      misc = {
+        dontbatch = true,
+  
+  
+        isadvisable = function()
+          return (affs.impale and not svo.doingaction('curingimpale') and not svo.doingaction('impale') and bals.balance and bals.rightarm and bals.leftarm) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.curingimpale.waitingfor)
+        end,
+  
+        action = 'writhe',
+        onstart = function() send('writhe', conf.commandecho) end,
+  
+        helpless = function()
+          empty.writhe()
+        end,
+  
+        dragged = function() svo.rmaff('impale') end,
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.impale)
+          signals.canoutr:emit()
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('impale') end,
+      },
+      onremoved = function() signals.canoutr:emit() end
+    },
+    curingimpale = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function() svo.rmaff('impale') end,
+  
+        withdrew = function() svo.rmaff('impale') end,
+  
+        dragged = function() svo.rmaff('impale') end,
+  
+        onstart = function() end
+      }
+    },
+    dragonflex = {
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (conf.dragonflex and ((affs.webbed and not svo.ignore.webbed) or (affs.roped and not svo.ignore.roped)) and codepaste.writhe() and not affs.paralysis and defc.dragonform and bals.balance and not svo.doingaction'impale') or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff{'webbed', 'roped'}
+        end,
+  
+        action = 'dragonflex',
+        onstart = function() send('dragonflex', conf.commandecho) end
+      },
+    },
+  
+    -- anti-illusion checks, grouped by symptom similarity
+    checkslows = {
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (next(svo.affsp) and (svo.affsp.retardation or svo.affsp.aeon or svo.affsp.truename)) or false
+        end,
+  
+        oncompleted = function() end,
+  
+        sluggish = function()
+          if svo.affsp.retardation then
+            svo.affsp.retardation = nil
+            svo.addaffdict(svo.dict.retardation)
+            signals.newroom:unblock(sk.check_retardation)
+          elseif svo.affsp.aeon then
+            svo.affsp.aeon = nil
+  
+            svo.addaffdict(svo.dict.aeon)
+            defences.lost('speed')
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          elseif svo.affsp.truename then
+            svo.affsp.truename = nil
+  
+            svo.addaffdict(svo.dict.aeon)
+            defences.lost('speed')
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          end
+  
+          sk.checkaeony()
+          signals.changecuring:emit()
+          codepaste.badaeon()
+        end,
+  
+        onclear = function()
+          if svo.affsp.retardation then
+            svo.affsp.retardation = nil
+          elseif svo.affsp.aeon then
+            svo.affsp.aeon = nil
+          elseif svo.affsp.truename then
+            svo.affsp.truename = nil
+          end
+        end,
+  
+        onstart = function()
+          send('say', false)
+        end
+      },
+      aff = {
+        notagameaff = true,
+        oncompleted = function (which)
+        if svo.paragraph_length &gt; 2 or svo.ignore.checkslows then
+            if which == 'truename' then which = 'aeon' end
+  
+            svo.addaffdict(svo.dict[which])
+            svo.killaction(svo.dict.checkslows.misc)
+  
+            if which == 'aeon' then defences.lost('speed') end
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+  
+            sk.checkaeony()
+            signals.changecuring:emit()
+            codepaste.badaeon()
+  
+            if which == 'retardation' then
+              signals.newroom:unblock(sk.check_retardation)
+            end
+          else
+            svo.affsp[which] = true
+          end
+        end,
+  
+        truename = function()
+          svo.affsp.truename = true
+        end,
+      },
+    },
+  
+    checkanorexia = {
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (svo.affsp.anorexia) or false
+        end,
+  
+        oncompleted = function() end,
+  
+        blehfood = function()
+          svo.addaffdict(svo.dict.anorexia)
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          svo.affsp.anorexia = nil
+        end,
+  
+        onclear = function()
+          svo.affsp.anorexia = nil
+        end,
+  
+        onstart = function()
+          send("eat something", false)
+        end
+      },
+      aff = {
+        notagameaff = true,
+        oncompleted = function()
+          if svo.paragraph_length &gt; 2 then
+            svo.addaffdict(svo.dict.anorexia)
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+            svo.killaction(svo.dict.checkanorexia.misc)
+          else
+            svo.affsp.anorexia = true
+          end
+        end
+      },
+    },
+  
+    checkparalysis = {
+      description = "anti-illusion check for paralysis",
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return false -- hardcoded to be off, as there's no known solution currently that works
+          --return (svo.affsp.paralysis and not affs.sleep and (not conf.waitparalysisai or (bals.balance and bals.equilibrium)) and not affs.roped) or false
+        end,
+  
+        oncompleted = function() end,
+  
+        paralysed = function()
+          svo.addaffdict(svo.dict.paralysis)
+  
+          if svo.dict.relapsing.saw_with_checkable == 'paralysis' then
+            svo.dict.relapsing.saw_with_checkable = nil
+            svo.addaffdict(svo.dict.relapsing)
+          end
+  
+          if type(svo.affsp.paralysis) == 'string' then
+            svo.addaffdict(svo.dict[svo.affsp.paralysis])
+          end
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+  
+          svo.affsp.paralysis = nil
+        end,
+  
+        onclear = function()
+          svo.affsp.paralysis = nil
+        end,
+  
+        onstart = function()
+          send("fling paralysis", false)
+        end
+      },
+      aff = {
+        notagameaff = true,
+        oncompleted = function (withaff) -- ie, 'darkshade' - add the additional aff if we have paralysis
+          -- disabled, as fling no longer works and illusions are not so prevalent
+          if true then
+          -- if svo.paragraph_length &gt; 2 or (not (bals.balance and bals.equilibrium) and not conf.waitparalysisai) then -- if it's not an illusion for sure, or if we have waitparalysisai off and don't have both balance/eq, accept it as paralysis right now
+            svo.addaffdict(svo.dict.paralysis)
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+            svo.killaction(svo.dict.checkparalysis.misc)
+            if withaff then svo.addaffdict(svo.dict[withaff]) end
+          -- else -- else, it gets added to be checked later if we have waitparalysisai on and don't have balance or eq
+          --   svo.affsp.paralysis = withaff or true
+          end
+        end
+      },
+    },
+  
+    checkimpatience = {
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (svo.affsp.impatience and not affs.sleep and bals.focus and conf.focus) or false
+        end,
+  
+        oncompleted = function() end,
+  
+        impatient = function()
+          if not affs.impatience then
+            svo.addaffdict(svo.dict.impatience)
+            svo.echof("Looks like the impatience is real.")
+          end
+  
+          svo.affsp.impatience = nil
+        end,
+  
+        -- if serverside cures impatience before we can even validate it, cancel it
+        oncancel = function()
+          svo.affsp.impatience = nil
+          svo.killaction(svo.dict.checkimpatience.misc)
+        end,
+  
+        onclear = function()
+          if svo.affsp.impatience then
+            svo.lostbal_focus()
+            if svo.affsp.impatience ~= 'quiet' then
+              svo.echof("The impatience earlier was actually an illusion, ignoring it.")
+            end
+            svo.affsp.impatience = nil
+          end
+        end,
+  
+        onstart = function()
+          send('focus', false)
+        end
+      },
+      aff = {
+        notagameaff = true,
+        oncompleted = function (option)
+          if svo.paragraph_length &gt; 2 then
+            svo.addaffdict(svo.dict.impatience)
+            svo.killaction(svo.dict.checkimpatience.misc)
+          else
+            svo.affsp.impatience = option and option or true
+          end
+        end
+      },
+    },
+  
+    checkasthma = {
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (svo.affsp.asthma and conf.breath and bals.balance and bals.equilibrium) or false
+        end,
+  
+        oncompleted = function() end,
+  
+        weakbreath = function()
+          svo.addaffdict(svo.dict.asthma)
+          local r = svo.findbybal('smoke')
+          if r then
+            svo.killaction(svo.dict[r.action_name].smoke)
+          end
+  
+          if svo.dict.relapsing.saw_with_checkable == 'asthma' then
+            svo.dict.relapsing.saw_with_checkable = nil
+            svo.addaffdict(svo.dict.relapsing)
+          end
+  
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          svo.affsp.asthma = nil
+          codepaste.badaeon()
+        end,
+  
+        onclear = function()
+          svo.affsp.asthma = nil
+        end,
+  
+        onstart = function() send('hold breath', conf.commandecho) end
+      },
+      smoke = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (svo.affsp.asthma and not svo.dict.checkasthma.misc.isadvisable() and codepaste.smoke_valerian_pipe()) or false
+        end,
+  
+        oncompleted = function() svo.lostbal_smoke() end,
+  
+        badlungs = function()
+          svo.addaffdict(svo.dict.asthma)
+          local r = svo.findbybal('smoke')
+          if r then
+            svo.killaction(svo.dict[r.action_name].smoke)
+          end
+  
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+          svo.affsp.asthma = nil
+        end,
+  
+        -- mucous can hit when we aren't even afflicted, so it's moot. Have to wait for it to clear up
+        mucous = function() end,
+  
+        onclear = function()
+          svo.affsp.asthma = nil
+          svo.lostbal_smoke()
+        end,
+  
+        empty = function()
+          svo.affsp.asthma = nil
+          svo.lostbal_smoke()
+        end,
+  
+        smokecure = {'valerian', 'realgar'},
+        onstart = function()
+          send("smoke " .. pipes.valerian.id, conf.commandecho)
+        end
+      },
+      aff = {
+        notagameaff = true,
+        oncompleted = function (oldhp)
+        if svo.paragraph_length &gt; 2 or (oldhp and stats.currenthealth &lt; oldhp) or (svo.paragraph_length == 2 and svo.find_until_last_paragraph("aura of weapons rebounding disappears", 'substring')) then
+            svo.addaffdict(svo.dict.asthma)
+            local r = svo.findbybal('smoke')
+            if r then
+              svo.killaction(svo.dict[r.action_name].smoke)
+            end
+  
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+            svo.killaction(svo.dict.checkasthma.misc)
+  
+            -- if we were checking and we got a verified aff, kill verification
+            if svo.actions.checkasthma_smoke then
+              svo.killaction(svo.dict.checkasthma.smoke)
+            end
+          else
+            svo.affsp.asthma = true
+          end
+        end
+      },
+    },
+  
+    checkhypersomnia = {
+      description = "anti-illusion check for hypersomnia",
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (svo.affsp.hypersomnia and not affs.sleep) or false
+        end,
+  
+        oncompleted = function() end,
+  
+        hypersomnia = function()
+          svo.addaffdict(svo.dict.hypersomnia)
+  
+          svo.affsp.hypersomnia = nil
+        end,
+  
+        onclear = function()
+          svo.affsp.hypersomnia = nil
+        end,
+  
+        onstart = function() send('insomnia', conf.commandecho) end
+      },
+      aff = {
+        notagameaff = true,
+        oncompleted = function()
+          -- can't check hypersomnia with insomina up - it'll give the insomnia
+          -- def line
+          if svo.paragraph_length &gt; 2 or defc.insomnia then
+            svo.addaffdict(svo.dict.hypersomnia)
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+            svo.killaction(svo.dict.checkhypersomnia.misc)
+          else
+            svo.affsp.hypersomnia = true
+          end
+        end
+      },
+    },
+  
+    checkstun = {
+      templifevision = false, -- stores the lifevision actions that will be wiped until confirmed
+      tempactions = false, -- stores the actions queue items that will be wiped until confirmed
+      time = 0,
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (svo.affsp.stun) or false
+        end,
+  
+        oncompleted = function (data)
+          -- 'fromstun' is given to us if we just had started checking for stun with checkstun_misc, and stun wore off before we could finish - for this rare scenario, we complete checkstun
+          if data ~= 'fromstun' then svo.dict.stun.aff.oncompleted(svo.dict.checkstun.time) end
+          svo.dict.checkstun.time = 0
+          svo.affsp.stun = nil
+          tempTimer(0, function()
+            if not svo.dict.checkstun.templifevision then return end
+  
+            svo.lifevision.l = deepcopy(svo.dict.checkstun.templifevision)
+            svo.dict.checkstun.templifevision = nil
+  
+            if svo.lifevision.l.checkstun_aff then
+              svo.lifevision.l:set('checkstun_aff', nil)
+            end
+  
+            for k,v in svo.dict.checkstun.tempactions:iter() do
+              if svo.actions[k] then
+                svo.debugf("%s already exists, overwriting it", k)
+              else
+                svo.debugf("re-added %s", k)
+              end
+  
+              svo.actions[k] = v
+            end
+  
+            svo.dict.checkstun.tempactions = nil
+            svo.send_in_the_gnomes()
+          end)
+        end,
+  
+        onclear = function()
+          svo.affsp.stun = nil
+          svo.dict.checkstun.templifevision = nil
+          svo.dict.checkstun.tempactions = nil
+        end,
+  
+        onstart = function()
+          send("eat something", false)
+        end
+      },
+      aff = {
+        -- this is an affliction for svo's purposes, but not in the game. Although it would be best if the 'aff' balance was replaced with something else
+        notagameaff = true,
+        oncompleted = function (num)
+        if svo.paragraph_length &gt; 2 then
+            svo.dict.stun.aff.oncompleted()
+            svo.killaction(svo.dict.checkstun.misc)
+          elseif not affs.sleep and not conf.paused then -- let autodetection take care of after we wake up. otherwise, a well timed stun &amp; stun symptom on awake can trick us. if paused, let it through as well, because we don't want to kill affs
+            svo.affsp.stun = true
+            svo.dict.checkstun.time = num
+            svo.dict.checkstun.templifevision = deepcopy(svo.lifevision.l)
+            svo.dict.checkstun.tempactions = deepcopy(svo.actions)
+            sk.stopprocessing = true
+          end
+        end
+      },
+    },
+  
+    checkwrithes = {
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (next(svo.affsp) and ((svo.affsp.impale and not affs.transfixed and not affs.webbed and not affs.roped) or (svo.affsp.webbed and not affs.transfixed and not affs.roped) or svo.affsp.transfixed)) or false
+        end,
+  
+        oncompleted = function() end,
+  
+        webbily = function()
+          svo.affsp.webbed = nil
+          svo.addaffdict(svo.dict.webbed)
+          signals.canoutr:emit()
+        end,
+  
+        impaly = function()
+          svo.affsp.impale = nil
+          svo.addaffdict(svo.dict.impale)
+          signals.canoutr:emit()
+        end,
+  
+        transfixily = function()
+          svo.affsp.transfixed = nil
+          svo.addaffdict(svo.dict.transfixed)
+          signals.canoutr:emit()
+        end,
+  
+        onclear = function()
+          svo.affsp.impale = nil
+          svo.affsp.webbed = nil
+          svo.affsp.transfixed = nil
+        end,
+  
+        onstart = function()
+          send('outr', false)
+        end
+      },
+      aff = {
+        notagameaff = true,
+        oncompleted = function (which)
+          if svo.paragraph_length &gt; 2 then
+            svo.addaffdict(svo.dict[which])
+            svo.killaction(svo.dict.checkwrithes.misc)
+          else
+            svo.affsp[which] = true
+          end
+        end,
+  
+        impale = function (oldhp)
+          if (oldhp and stats.currenthealth &lt; oldhp) then
+            svo.addaffdict(svo.dict.impale)
+            signals.canoutr:emit()
+          else
+            svo.affsp.impale = true
+          end
+        end
+      }
+    },
+    amnesia = {
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (affs.amnesia) or false
+        end,
+  
+        oncompleted = function() end,
+  
+        onstart = function()
+          send("touch stuff", conf.commandecho)
+          svo.rmaff('amnesia')
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.amnesia)
+  
+          -- cancel what we were doing, do it again
+          if sys.sync then
+            local result
+            for balance,actions in pairs(svo.bals_in_use) do
+              if balance ~= 'waitingfor' and balance ~= 'gone' and balance ~= 'aff' and next(actions) then result = select(2, next(actions)) break end
+            end
+            if result then
+              svo.killaction(svo.dict[result.action_name][result.balance])
+            end
+  
+            svo.conf.send_bypass = true
+            send("touch stuff", conf.commandecho)
+            svo.conf.send_bypass = false
+          end
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('amnesia') end,
+      }
+    },
+  
+    -- uncurable
+    stun = {
+      waitingfor = {
+        customwait = 1,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        ontimeout = function()
+          svo.rmaff('stun')
+  
+          if svo.dict.checkstun.templifevision then
+            svo.debugf("stun timed out = restoring checkstun lifevisions")
+            svo.dict.checkstun.misc.oncompleted('fromstun')
+            svo.make_gnomes_work()
+          end
+  
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('stun')
+  
+          if svo.dict.checkstun.templifevision then
+            svo.debugf("stun finished = restoring checkstun lifevisions")
+            svo.dict.checkstun.misc.oncompleted('fromstun')
+          end
+        end
+      },
+      aff = {
+        oncompleted = function (num)
+          if affs.stun then return end
+  
+          svo.dict.stun.waitingfor.customwait = (num and num ~= 0) and num or 1
+          svo.addaffdict(svo.dict.stun)
+          svo.doaction(svo.dict.stun.waitingfor)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('stun')
+          svo.killaction(svo.dict.stun.waitingfor)
+        end,
+      },
+      onremoved = function() svo.donext() end
+    },
+    unconsciousness = {
+      waitingfor = {
+        customwait = 7,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        ontimeout = function()
+          svo.rmaff('unconsciousness')
+          svo.make_gnomes_work()
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('unconsciousness')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.unconsciousness)
+          if not svo.actions.unconsciousness_waitingfor then svo.doaction(svo.dict.unconsciousness.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('unconsciousness')
+          svo.killaction(svo.dict.unconsciousness.waitingfor)
+        end,
+      },
+      onremoved = function() svo.donext() end
+    },
+    swellskin = { -- eating any herb cures it
+      waitingfor = {
+        customwait = 999,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('swellskin')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.swellskin)
+          if not svo.actions.swellskin_waitingfor then svo.doaction(svo.dict.swellskin.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('swellskin')
+          svo.killaction(svo.dict.swellskin.waitingfor)
+        end,
+      }
+    },
+    pinshot = {
+      waitingfor = {
+        customwait = 20, -- lasts 18s
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        ontimeout = function()
+          svo.rmaff('pinshot')
+          svo.make_gnomes_work()
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('pinshot')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.pinshot)
+          if not svo.actions.pinshot_waitingfor then svo.doaction(svo.dict.pinshot.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('pinshot')
+          svo.killaction(svo.dict.pinshot.waitingfor)
+        end,
+      }
+    },
+    dehydrated = {
+      waitingfor = {
+        customwait = 45, -- lasts 45s
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        ontimeout = function()
+          svo.rmaff('dehydrated')
+          svo.make_gnomes_work()
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('dehydrated')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.dehydrated)
+          if not svo.actions.dehydrated_waitingfor then svo.doaction(svo.dict.dehydrated.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('dehydrated')
+          svo.killaction(svo.dict.dehydrated.waitingfor)
+        end,
+      }
+    },
+    timeflux = {
+      waitingfor = {
+        customwait = 50, -- lasts 50s
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        ontimeout = function()
+          svo.rmaff('timeflux')
+          svo.make_gnomes_work()
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('timeflux')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.timeflux)
+          if not svo.actions.timeflux_waitingfor then svo.doaction(svo.dict.timeflux.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('timeflux')
+          svo.killaction(svo.dict.timeflux.waitingfor)
+        end,
+      }
+    },
+    inquisition = {
+      waitingfor = {
+        customwait = 30, -- ??
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('inquisition')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.inquisition)
+          if not svo.actions.inquisition_waitingfor then svo.doaction(svo.dict.inquisition.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('inquisition')
+          svo.killaction(svo.dict.inquisition.waitingfor)
+        end,
+      }
+    },
+    lullaby = {
+      waitingfor = {
+        customwait = 45, -- takes 45s
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('lullaby')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.lullaby)
+          if not svo.actions.lullaby_waitingfor then svo.doaction(svo.dict.lullaby.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('lullaby')
+          svo.killaction(svo.dict.lullaby.waitingfor)
+        end,
+      }
+    },
+    corrupted = {
+      waitingfor = {
+        customwait = 999, -- time increases
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function() svo.rmaff('corrupted') end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.corrupted)
+          if not svo.actions.corrupted_waitingfor then svo.doaction(svo.dict.corrupted.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('corrupted')
+          svo.killaction(svo.dict.corrupted.waitingfor)
+        end,
+      }
+    },
+    mucous = {
+      waitingfor = {
+        customwait = 6,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function() svo.rmaff('mucous') end,
+  
+        ontimeout = function()
+          svo.rmaff('mucous')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.mucous)
+          if not svo.actions.mucous_waitingfor then svo.doaction(svo.dict.mucous.waitingfor) end
+  
+          local r = svo.findbybal('smoke')
+          if r then
+            svo.killaction(svo.dict[r.action_name].smoke)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('mucous')
+          svo.killaction(svo.dict.mucous.waitingfor)
+        end,
+      }
+    },
+    phlogistication = {
+      waitingfor = {
+        customwait = 999, -- time increases
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('phlogistication')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.phlogistication)
+          if not svo.actions.phlogistication_waitingfor then svo.doaction(svo.dict.phlogistication.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('phlogistication')
+          svo.killaction(svo.dict.phlogistication.waitingfor)
+        end,
+      }
+    },
+    vitrification = {
+      waitingfor = {
+        customwait = 999,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('vitrification')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.vitrification)
+          if not svo.actions.vitrification_waitingfor then svo.doaction(svo.dict.vitrification.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('vitrification')
+          svo.killaction(svo.dict.vitrification.waitingfor)
+        end,
+      }
+    },
+  
+    icing = {
+      waitingfor = {
+        customwait = 30, -- ??
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('icing')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.icing)
+          if not svo.actions.icing_waitingfor then svo.doaction(svo.dict.icing.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('icing')
+          svo.killaction(svo.dict.icing.waitingfor)
+        end,
+      }
+    },
+    burning = {
+      waitingfor = {
+        customwait = 30, -- ??
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('burning')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.burning)
+          if not svo.actions.burning_waitingfor then svo.doaction(svo.dict.burning.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('burning')
+          svo.killaction(svo.dict.burning.waitingfor)
+        end,
+      }
+    },
+    latched = {
+      waitingfor = {
+        customwait = 20, -- not sure how this is cured yet exactly
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('latched')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.latched)
+          codepaste.badaeon()
+          if not svo.actions.latched_waitingfor then svo.doaction(svo.dict.latched.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('latched')
+          svo.killaction(svo.dict.latched.waitingfor)
+        end,
+      }
+    },
+    voided = {
+      waitingfor = {
+        customwait = 20, -- lasts 20s tops, 15s in some stances. out-times multiple pommelstrikes
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('voided')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.voided)
+          codepaste.badaeon()
+          if not svo.actions.voided_waitingfor then svo.doaction(svo.dict.voided.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('voided')
+          svo.killaction(svo.dict.voided.waitingfor)
+        end,
+      }
+    },
+    hamstring = {
+  	  gamename = "hamstrung",
+      waitingfor = {
+        customwait = 10,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        ontimeout = function()
+          if affs.hamstring then
+            svo.rmaff('hamstring')
+            svo.echof("Hamstring should have worn off by now, removing it.")
+          end
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('hamstring')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.hamstring)
+          if not svo.actions.hamstring_waitingfor then svo.doaction(svo.dict.hamstring.waitingfor) end
+        end,
+  
+        renew = function()
+          svo.addaffdict(svo.dict.hamstring)
+  
+          -- hamstrings timer gets renewed on hit
+          if svo.actions.hamstring_waitingfor then
+            svo.killaction(svo.dict.hamstring.waitingfor)
+          end
+          svo.doaction(svo.dict.hamstring.waitingfor)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('hamstring')
+          svo.killaction(svo.dict.hamstring.waitingfor)
+        end,
+      }
+    },
+    galed = {
+      waitingfor = {
+        customwait = 10,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('galed')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.galed)
+          if not svo.actions.galed_waitingfor then svo.doaction(svo.dict.galed.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('galed')
+          svo.killaction(svo.dict.galed.waitingfor)
+        end,
+      }
+    },
+    rixil = {
+      -- will double the cooldown period of the next focus ability.
+      waitingfor = {
+        customwait = 999,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        ontimeout = function() end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('rixil')
+          svo.killaction(svo.dict.rixil.waitingfor)
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.rixil)
+          if svo.actions.rixil_waitingfor then svo.killaction(svo.dict.rixil.waitingfor) end
+          svo.doaction(svo.dict.rixil.waitingfor)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('rixil')
+          svo.killaction(svo.dict.rixil.waitingfor)
+        end,
+      }
+    },
+    hecate = {
+      waitingfor = {
+        customwait = 22, -- seems to last at least 18s per log
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        ontimeout = function()
+          svo.rmaff('hecate')
+          svo.killaction(svo.dict.hecate.waitingfor)
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('hecate')
+          svo.killaction(svo.dict.hecate.waitingfor)
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.hecate)
+          if svo.actions.hecate_waitingfor then svo.killaction(svo.dict.hecate.waitingfor) end
+          svo.doaction(svo.dict.hecate.waitingfor)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('hecate')
+          svo.killaction(svo.dict.hecate.waitingfor)
+        end,
+      }
+    },
+    palpatar = {
+      waitingfor = {
+        customwait = 999,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        ontimeout = function() end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('palpatar')
+          svo.killaction(svo.dict.palpatar.waitingfor)
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.palpatar)
+          if svo.actions.palpatar_waitingfor then svo.killaction(svo.dict.palpatar.waitingfor) end
+          svo.doaction(svo.dict.palpatar.waitingfor)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('palpatar')
+          svo.killaction(svo.dict.palpatar.waitingfor)
+        end,
+      }
+    },
+    -- extends tree balance by 10s now
+    ninkharsag = {
+      waitingfor = {
+        customwait = 60, -- it lasts a minute
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        ontimeout = function() svo.rmaff('ninkharsag') end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('ninkharsag')
+          svo.killaction(svo.dict.ninkharsag.waitingfor)
+        end,
+  
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.ninkharsag)
+          if svo.actions.ninkharsag_waitingfor then svo.killaction(svo.dict.ninkharsag.waitingfor) end
+          svo.doaction(svo.dict.ninkharsag.waitingfor)
+        end,
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('ninkharsag')
+          svo.killaction(svo.dict.ninkharsag.waitingfor)
+        end,
+  
+        -- anti-illusion-checked aff hiding. in 'gone' because 'aff' resets the timer with checkaction, waitingfor has some other effect
+        hiddencures = function (amount)
+          local curableaffs = svo.gettreeableaffs()
+  
+          -- if we saw more ninkharsag lines than affs we've got, we can remove the affs safely
+          if amount &gt;= #curableaffs then
+            svo.rmaff(curableaffs)
+          else
+            -- otherwise add an unknown aff - so we eventually diagnose to see what is our actual aff status like.
+            -- this does mess with the aff counts, but it is better than not diagnosing ever.
+            codepaste.addunknownany()
+          end
+        end
+      }
+    },
+    cadmus = {
+      -- focusing will give one of: lethargy, clumsiness, haemophilia, healthleech, sensitivity, darkshade
+      waitingfor = {
+        customwait = 999,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        ontimeout = function() end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('cadmus')
+          svo.killaction(svo.dict.cadmus.waitingfor)
+        end
+      },
+      aff = {
+        -- oldmaxhp is an argument
+        oncompleted = function (_)
+          svo.addaffdict(svo.dict.cadmus)
+          if svo.actions.cadmus_waitingfor then svo.killaction(svo.dict.cadmus.waitingfor) end
+          svo.doaction(svo.dict.cadmus.waitingfor)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('cadmus')
+          svo.killaction(svo.dict.cadmus.waitingfor)
+        end,
+      }
+    },
+    stain = {
+      waitingfor = {
+        customwait = 60*2+20, -- lasts 2min, but varies, so let's go with 140s
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        ontimeout = function()
+          svo.rmaff('stain')
+          svo.echof("Taking a guess, I think stain expired by now.")
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('stain')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function (oldmaxhp)
+          -- oldmaxhp doesn't come from diag, it is optional
+          if (not conf.aillusion) or (oldmaxhp and (stats.maxhealth &lt; oldmaxhp)) then
+            svo.addaffdict(svo.dict.stain)
+            signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+            codepaste.badaeon()
+            if svo.actions.stain_waitingfor then svo.killaction(svo.dict.stain.waitingfor) end
+            svo.doaction(svo.dict.stain.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('stain')
+          svo.killaction(svo.dict.stain.waitingfor)
+        end,
+      }
+    },
+    depression = {
+      herb = {
+        isadvisable = function()
+          return affs.depression or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('depression')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+        onstart = function() svo.eat(svo.dict.depression.herb) end,
+  
+        empty = function() empty.eat_goldenseal() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.depression)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('depression') end,
+      }
+    },
+    parasite = {
+      herb = {
+        isadvisable = function()
+          return affs.parasite or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('parasite')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'kelp', 'aurum'},
+        onstart = function() svo.eat(svo.dict.parasite.herb) end,
+  
+        empty = function() empty.eat_kelp() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.parasite)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('parasite') end,
+      }
+    },
+    retribution = {
+      herb = {
+        isadvisable = function()
+          return affs.retribution or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('retribution')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'bellwort', 'cuprum'},
+        onstart = function() svo.eat(svo.dict.retribution.herb) end,
+  
+        empty = function() empty.eat_bellwort() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.retribution)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('retribution') end,
+      }
+    },
+    shadowmadness = {
+      herb = {
+        isadvisable = function()
+          return affs.shadowmadness or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('shadowmadness')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+        onstart = function() svo.eat(svo.dict.shadowmadness.herb) end,
+  
+        empty = function() empty.eat_goldenseal() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.shadowmadness)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('shadowmadness') end,
+      }
+    },
+    timeloop = {
+      herb = {
+        isadvisable = function()
+          return affs.timeloop or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('timeloop')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'bellwort', 'cuprum'},
+        onstart = function() svo.eat(svo.dict.timeloop.herb) end,
+  
+        empty = function() empty.eat_bellwort() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.timeloop)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('timeloop') end,
+      }
+    },
+    degenerate = {
+      waitingfor = {
+        customwait = 0, -- seems to last 6 seconds per degenerate affliction when boosted, set below
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('degenerate')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          local timeout = 0
+          for _, aff in ipairs(empty.degenerateaffs) do
+            timeout = timeout + (affs[aff] and 7 or 0)
+          end
+          svo.dict.degenerate.waitingfor.customwait = timeout
+          svo.addaffdict(svo.dict.degenerate)
+          if not svo.actions.degenerate_waitingfor then svo.doaction(svo.dict.degenerate.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('degenerate')
+          svo.killaction(svo.dict.degenerate.waitingfor)
+        end,
+      }
+    },
+    deteriorate = {
+      waitingfor = {
+        customwait = 0, -- seems to last 6 seconds per deteriorate affliction when boosted, set below
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('deteriorate')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          local timeout = 0
+          for _, aff in ipairs(empty.deteriorateaffs) do
+            timeout = timeout + (affs[aff] and 7 or 0)
+          end
+          svo.dict.deteriorate.waitingfor.customwait = timeout
+          svo.addaffdict(svo.dict.deteriorate)
+          if not svo.actions.deteriorate_waitingfor then svo.doaction(svo.dict.deteriorate.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('deteriorate')
+          svo.killaction(svo.dict.deteriorate.waitingfor)
+        end,
+      }
+    },
+    hatred = {
+      waitingfor = {
+        customwait = 15,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('hatred')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.hatred)
+          if not svo.actions.hatred_waitingfor then svo.doaction(svo.dict.hatred.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('hatred')
+          svo.killaction(svo.dict.hatred.waitingfor)
+        end,
+      }
+    },
+    paradox = {
+      count = 0,
+      blocked_herb = "",
+      boosted = {
+        oncompleted = function()
+          svo.dict.paradox.count = 10
+          svo.updateaffcount(svo.dict.paradox)
+        end
+      },
+      weakened = {
+        oncompleted = function()
+          codepaste.remove_stackableaff('paradox', true)
+        end
+      },
+      aff = {
+        oncompleted = function (herb)
+          svo.dict.paradox.count = 5
+          svo.dict.paradox.blocked_herb = herb
+          svo.addaffdict(svo.dict.paradox)
+          svo.affl['paradox'].herb = herb
+          svo.updateaffcount(svo.dict.paradox)
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('paradox')
+          svo.dict.paradox.count = 0
+          svo.dict.paradox.blocked_herb = ""
+        end,
+      }
+    },
+    mindravaged = {
+      waitingfor = {
+        customwait = 30, -- Honestly not sure how long this lasts, but this seems about right; need someone to make sure
+  
+        isadvisable = function ()
+          return false
+        end,
+  
+        onstart = function () end,
+  
+        oncompleted = function ()
+          svo.rmaff("mindravaged")
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function ()
+          svo.addaffdict(svo.dict.mindravaged)
+          if not svo.actions.mindravaged_waitingfor then svo.doaction(svo.dict.mindravaged.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function ()
+          svo.rmaff("burning")
+          svo.killaction(svo.dict.mindravaged.waitingfor)
+        end,
+      }
+    },
+    unweavingbody = {
+      count = 0,
+      name = 'unweavingbody',
+      gamename = 'unweavingbody',
+      herb = {
+        aspriority = 0,
+        spriority = 0,
+  
+        isadvisable = function ()
+          return affs.unweavingbody or false
+        end,
+  
+        oncompleted = function ()
+          svo.rmaff("unweavingbody")
+          svo.dict.unweavingbody.count = 0
+          svo.lostbal_herb()
+        end,
+  
+        cured = function()
+          svo.lostbal_herb()
+          svo.rmaff("unweavingbody")
+          svo.dict.unweavingbody.count = 0
+        end,
+  
+        eatcure = {"ginseng", "ferrum"},
+        onstart = function ()
+          svo.eat(svo.dict.unweavingbody.herb)
+        end,
+  
+        empty = function()
+          svo.empty.eat_ginseng()
+        end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(dict.unweavingbody)
+          svo.updateaffcount(svo.dict.unweavingbody)
+        end
+      },
+      gone = {
+        oncompleted = function ()
+          svo.rmaff("unweavingbody")
+          svo.dict.unweavingbody.count = 0
+        end,
+  
+        general_cure = function(amount, dontkeep)
+          svo.rmaff("unweavingbody")
+          svo.dict.unweavingbody.count = 0
+        end,
+  
+        general_cured = function(amount)
+          svo.rmaff("unweavingbody")
+          svo.dict.unweavingbody.count = 0
+        end
+      }
+    },
+    unweavingmind = {
+      count = 0,
+      name = 'unweavingmind',
+      gamename = 'unweavingmind',
+      herb = {
+        aspriority = 0,
+        spriority = 0,
+  
+        isadvisable = function ()
+          return svo.affs.unweavingmind or false
+        end,
+  
+        oncompleted = function ()
+          svo.rmaff("unweavingmind")
+          svo.dict.unweavingmind.count = 0
+          svo.lostbal_herb()
+        end,
+  
+        cured = function()
+          svo.lostbal_herb()
+          svo.rmaff("unweavingmind")
+          svo.dict.unweavingmind.count = 0
+        end,
+  
+        eatcure = {"goldenseal", "plumbum"},
+        onstart = function ()
+          svo.eat(svo.dict.unweavingmind.herb)
+        end,
+  
+        empty = function()
+          svo.empty.eat_goldenseal()
+        end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.unweavingmind)
+          svo.updateaffcount(svo.dict.unweavingmind)
+        end
+      },
+      gone = {
+        oncompleted = function ()
+          svo.rmaff("unweavingmind")
+          svo.dict.unweavingmind.count = 0
+        end,
+  
+        general_cure = function(amount, dontkeep)
+          svo.rmaff("unweavingmind")
+          svo.dict.unweavingmind.count = 0
+        end,
+  
+        general_cured = function(amount)
+          svo.rmaff("unweavingmind")
+          svo.dict.unweavingmind.count = 0
+        end,
+      }
+    },
+    unweavingspirit = {
+      count = 0,
+      name = 'unweavingspirit',
+      gamename = 'unweavingspirit',
+      smoke = {
+        isadvisable = function()
+          return (svo.affs.unweavingspirit and codepaste.smoke_elm_pipe()) or false
+        end,
+  
+        oncompleted = function()
+          svo.updateaffcount(svo.dict.unweavingspirit)
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
+        end,
+  
+        cured = function()
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
+          svo.rmaff("unweavingspirit")
+          svo.dict.unweavingspirit.count = 0
+        end,
+  
+        smokecure = {'elm', 'cinnabar'},
+        onstart = function()
+          send("smoke " .. pipes.elm.id, conf.commandecho)
+        end,
+  
+        empty = function()
+          svo.empty.smoke_elm()
+          svo.lostbal_smoke()
+          sk.elm_smokepuff()
+        end
+      },
+      aff = {
+        oncompleted = function (number)
+          svo.addaffdict(svo.dict.unweavingspirit)
+          svo.updateaffcount(svo.dict.unweavingspirit)
+        end
+      },
+      gone = {
+        oncompleted = function ()
+          svo.rmaff("unweavingspirit")
+          svo.dict.unweavingspirit.count = 0
+        end,
+  
+        general_cure = function(amount, dontkeep)
+          svo.updateaffcount(svo.dict.unweavingspirit)
+        end,
+  
+        general_cured = function(amount)
+          svo.rmaff("unweavingspirit")
+          svo.dict.unweavingspirit.count = 0
+        end
+      }
+    },
+    retardation = {
+      waitingfor = {
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function() svo.rmaff('retardation') end
+      },
+      aff = {
+        oncompleted = function()
+          if not affs.retardation then
+            svo.addaffdict(svo.dict.retardation)
+            sk.checkaeony()
+            signals.changecuring:emit()
+            signals.newroom:unblock(sk.check_retardation)
+          end
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('retardation') end,
+      },
+      onremoved = function()
+        svo.affsp.retardation = nil
+        sk.checkaeony()
+        signals.changecuring:emit()
+        signals.newroom:block(sk.check_retardation)
+      end,
+      onadded = function()
+        signals.newroom:unblock(sk.check_retardation)
+      end
+    },
+    
+    
+    nomana = {
+      waitingfor = {
+        customwait = 30,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+        ontimeout = function()
+          echo"\n"svo.echof("Hm, maybe we have enough mana for mana skills now...")
+          svo.killaction(svo.dict.nomana.waitingfor)
+          svo.make_gnomes_work()
+        end
+      }
+    },
+    
+    mycalium = {
+      herb = {
+        isadvisable = function()
+          return affs.mycalium or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('mycalium')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+        onstart = function() svo.eat(svo.dict.mycalium.herb) end,
+  
+        empty = function() empty.eat_goldenseal() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.mycalium)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('mycalium') end,
+      }
+    },
+    
+    flushings = {
+      herb = {
+        isadvisable = function()
+          return affs.flushings or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('flushings')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'ginseng', 'ferrum'},
+        onstart = function() svo.eat(svo.dict.flushings.herb) end,
+  
+        empty = function() empty.eat_ginseng() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.flushings)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('flushings') end,
+      }
+    },
+  
+    rebbies = {
+      herb = {
+        isadvisable = function()
+          return affs.rebbies or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('rebbies')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'kelp', 'aurum'},
+        onstart = function() svo.eat(svo.dict.rebbies.herb) end,
+  
+        empty = function() empty.eat_kelp() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.rebbies)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('rebbies') end,
+      }
+    },
+    
+    sandfever = {
+      herb = {
+        isadvisable = function()
+          return affs.sandfever or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('sandfever')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'goldenseal', 'plumbum'},
+        onstart = function() svo.eat(svo.dict.sandfever.herb) end,
+  
+        empty = function() empty.eat_goldenseal() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.sandfever)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('sandfever') end,
+      }
+    },
+    
+    pyramides = {
+      herb = {
+        isadvisable = function()
+          return affs.pyramides or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('pyramides')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'bloodroot', 'magnesium'},
+        onstart = function() svo.eat(svo.dict.pyramides.herb) end,
+  
+        empty = function() empty.eat_bloodroot() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.pyramides)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('pyramides') end,
+      }
+    },
+  
+    ensorcelled = {
+      waitingfor = {
+        customwait = 20,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('ensorcelled')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.ensorcelled)
+          if not svo.actions.ensorcelled_waitingfor then svo.doaction(svo.dict.ensorcelled.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('ensorcelled')
+          svo.killaction(svo.dict.ensorcelled.waitingfor)
+        end,
+      }
+    },
+  
+    latency = {
+      waitingfor = {
+        customwait = 13,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+  
+        oncompleted = function()
+          svo.rmaff('latency')
+          svo.make_gnomes_work()
+        end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.latency)
+          if not svo.actions.latency_waitingfor then svo.doaction(svo.dict.latency.waitingfor) end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.rmaff('latency')
+          svo.killaction(svo.dict.latency.waitingfor)
+          svo.echof("Latency gone. Can sip immunity now")
+        end,
+      }
+    },
+  
+    indifference = {
+      herb = {
+        isadvisable = function()
+          return affs.indifference or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('indifference')
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'bellwort', 'cuprum'},
+        onstart = function() svo.eat(svo.dict.indifference.herb) end,
+  
+        empty = function() empty.eat_bellwort() end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.indifference)
+        end,
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('indifference') end,
+      }
+    },
+  
+    -- random actions that should be protected by AI
+    givewarning = {
+      happened = {
+        oncompleted = function (tbl)
+          if tbl and tbl.initialmsg then
+            echo"\n\n"
+            svo.echof("Careful: %s", tbl.initialmsg)
+            echo"\n"
+          end
+  
+          if tbl and tbl.prefixwarning then
+            local duration = tbl.duration or 4
+            local startin = tbl.startin or 0
+            cnrl.warning = tbl.prefixwarning or ""
+  
+            -- timer for starting
+            if not conf.warningtype then return end
+  
+            tempTimer(startin, function()
+  
+              if cnrl.warnids[tbl.prefixwarning] then killTrigger(cnrl.warnids[tbl.prefixwarning]) end
+  
+                cnrl.warnids[tbl.prefixwarning] = tempRegexTrigger('^', [[
+                  if ((svo.conf.warningtype == 'prompt' and isPrompt()) or svo.conf.warningtype == 'all' or svo.conf.warningtype == 'right') and getCurrentLine() ~= "" and not svo.gagline then
+                    svo.prefixwarning()
+                  end
+                ]])
+              end)
+  
+            -- timer for ending
+            tempTimer(startin+duration, function() killTrigger(cnrl.warnids[tbl.prefixwarning]) end)
+          end
+        end
+      }
+    },
+    stolebalance = {
+      happened = {
+        oncompleted = function (balance)
+          svo['lostbal_'..balance]()
+        end
+      }
+    },
+    gotbalance = {
+      happened = {
+        tempmap = {},
+        oncompleted = function()
+          for _, balance in ipairs(svo.dict.gotbalance.happened.tempmap) do
+            if not bals[balance] then
+              bals[balance] = true
+  
+              raiseEvent("svo got balance", balance)
+  
+              svo.endbalancewatch(balance)
+  
+              -- this concern should be separated into its own
+              if balance == 'tree' then
+                killTimer(sys.treetimer)
+              end
+            end
+          end
+          svo.dict.gotbalance.happened.tempmap = {}
+        end,
+  
+        oncancel = function()
+          svo.dict.gotbalance.happened.tempmap = {}
+        end
+      }
+    },
+    gothit = {
+      happened = {
+        tempmap = {},
+        oncompleted = function()
+          for name, class in pairs(svo.dict.gothit.happened.tempmap) do
+            if name == '?' then
+              raiseEvent("svo got hit by", class)
+            else
+              raiseEvent("svo got hit by", class, name)
+            end
+          end
+          svo.dict.gothit.happened.tempmap = {}
+        end,
+  
+        oncancel = function()
+          svo.dict.gothit.happened.tempmap = {}
+        end
+      }
+    },
+  
+  -- general defences
+    rebounding = {
+      blocked = false, -- we need to block off in blackout, because otherwise we waste sips
+      smoke = {
+        def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].rebounding and not defc.rebounding) or (conf.keepup and defkeepup[defs.mode].rebounding and not defc.rebounding)) and codepaste.smoke_skullcap_pipe() and not svo.doingaction('waitingonrebounding') and not svo.dict.rebounding.blocked) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.waitingonrebounding.waitingfor)
+          sk.skullcap_smokepuff()
+          svo.lostbal_smoke()
+        end,
+  
+        alreadygot = function()
+          defences.got('rebounding')
+          sk.skullcap_smokepuff()
+          svo.lostbal_smoke()
+        end,
+  
+        ontimeout = function()
+          if not affs.blackout then return end
+  
+          svo.dict.rebounding.blocked = true
+          tempTimer(3, function() svo.dict.rebounding.blocked = false; svo.make_gnomes_work() end)
+        end,
+  
+        smokecure = {'skullcap', 'malachite'},
+        onstart = function()
+          send("smoke " .. pipes.skullcap.id, conf.commandecho)
+        end,
+  
+        empty = function()
+          svo.dict.rebounding.smoke.oncompleted()
+        end
+      }
+    },
+    waitingonrebounding = {
+      waitingfor = {
+        customwait = 9,
+  
+        onstart = function() raiseEvent("svo rebounding start") end,
+  
+        oncompleted = function() defences.got('rebounding') end,
+  
+        deathtarot = function() -- nothing happens! It just doesn't come up :/
+        end,
+  
+        -- expend torso cancels rebounding coming up
+        expend = function()
+          if svo.actions.waitingonrebounding_waitingfor then
+            svo.killaction(svo.dict.waitingonrebounding.waitingfor)
+          end
+        end,
+      }
+    },
+    frost = {
+      purgative = {
+        def = true,
+        undeffable = true,
+  
+        isadvisable = function()
+          return ((sys.deffing and defdefup[defs.mode].frost and not defc.frost) or (conf.keepup and defkeepup[defs.mode].frost and not defc.frost)) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('frost')
+          if svo.haveskillset('metamorphosis') then
+            defences.got('temperance')
+          end
+        end,
+  
+        sipcure = {'frost', 'endothermia'},
+  
+        onstart = function()
+          svo.sip(svo.dict.frost.purgative)
+        end,
+  
+        empty = function() defences.got('frost') end,
+  
+        noeffect = function() defences.got('frost') end
+      },
+      gone = {
+        oncompleted = function()
+          if svo.haveskillset('metamorphosis') then
+            defences.lost('temperance')
+          end
+        end
+      }
+    },
+    venom = {
+      gamename = 'poisonresist',
+      purgative = {
+        def = true,
+  
+        isadvisable = function()
+          return ((sys.deffing and defdefup[defs.mode].venom and not defc.venom) or (conf.keepup and defkeepup[defs.mode].venom and not defc.venom)) or false
+        end,
+  
+        oncompleted = function() defences.got('venom') end,
+  
+        noeffect = function() defences.got('venom') end,
+  
+        sipcure = {'venom', 'toxin'},
+  
+        onstart = function()
+          svo.sip(svo.dict.venom.purgative)
+        end,
+  
+        empty = function() defences.got('venom') end
+      }
+    },
+    levitation = {
+      gamename = 'levitating',
+      purgative = {
+        def = true,
+  
+        isadvisable = function()
+          return ((sys.deffing and defdefup[defs.mode].levitation and not defc.levitation) or (conf.keepup and defkeepup[defs.mode].levitation and not defc.levitation)) or false
+        end,
+  
+        oncompleted = function() defences.got('levitation') end,
+  
+        noeffect = function() defences.got('levitation') end,
+  
+        sipcure = {'levitation', 'hovering'},
+  
+        onstart = function()
+          svo.sip(svo.dict.levitation.purgative)
+        end,
+  
+        empty = function() defences.got('levitation') end
+      }
+    },
+    speed = {
+      blocked = false, -- we need to block off in blackout, because otherwise we waste sips
+      purgative = {
+        def = true,
+  
+        isadvisable = function()
+          return (not defc.speed and ((sys.deffing and defdefup[defs.mode].speed) or (conf.keepup and defkeepup[defs.mode].speed)) and not svo.doingaction('curingspeed') and not svo.doingaction('speed') and not svo.dict.speed.blocked and not me.manualdefcheck) or false
+        end,
+  
+        oncompleted = function (def)
+          if def then defences.got('speed')
+          else
+            if affs.palpatar then
+              svo.dict.curingspeed.waitingfor.customwait = 10
+            else
+              svo.dict.curingspeed.waitingfor.customwait = 7
+            end
+  
+            svo.doaction(svo.dict.curingspeed.waitingfor)
+          end
+        end,
+  
+        ontimeout = function()
+          if not affs.blackout then return end
+  
+          svo.dict.speed.blocked = true
+          tempTimer(3, function() svo.dict.speed.blocked = false; svo.make_gnomes_work() end)
+        end,
+  
+        noeffect = function() defences.got('speed') end,
+  
+        sipcure = {'speed', 'haste'},
+  
+        onstart = function()
+          svo.sip(svo.dict.speed.purgative)
+        end,
+  
+        empty = function()
+          svo.dict.speed.purgative.oncompleted ()
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('speed') end
+      }
+    },
+    curingspeed = {
+      waitingfor = {
+        customwait = 7,
+  
+        oncompleted = function() defences.got('speed') end,
+  
+        ontimeout = function()
+          if defc.speed then return end
+  
+          if (sys.deffing and defdefup[defs.mode].speed) or (conf.keepup and defkeepup[defs.mode].speed) then
+            svo.echof("Warning - speed didn't come up in 7s, checking 'def'.")
+            me.manualdefcheck = true
+          end
+        end,
+  
+        onstart = function() end
+      }
+    },
+    sileris = {
+      gamename = 'fangbarrier',
+      applying = "",
+      misc = {
+        def = true,
+  
+        isadvisable = function()
+          return (not defc.sileris and ((sys.deffing and defdefup[defs.mode].sileris) or (conf.keepup and defkeepup[defs.mode].sileris)) and not svo.doingaction('waitingforsileris') and not svo.doingaction('sileris') and not affs.paralysis and not affs.slickness and not me.manualdefcheck) or false
+        end,
+  
+        oncompleted = function (def)
+          if def and not defc.sileris then defences.got('sileris')
+          else svo.doaction(svo.dict.waitingforsileris.waitingfor) end
+        end,
+  
+        slick = function()
+          svo.addaffdict(svo.dict.slickness)
+        end,
+  
+        ontimeout = function()
+          if not affs.blackout then return end
+  
+          svo.dict.sileris.blocked = true
+          tempTimer(3, function() svo.dict.sileris.blocked = false; svo.make_gnomes_work() end)
+        end,
+  
+        -- special case for 'missing herb' trig
+        eatcure = {'sileris', 'quicksilver'},
+        applycure = {'sileris', 'quicksilver'},
+        actions = {"apply sileris", "apply quicksilver"},
+        onstart = function()
+          local use = 'sileris'
+  
+          if conf.curemethod and conf.curemethod ~= 'conconly' and (
+  
+            conf.curemethod == 'transonly' or
+  
+            (conf.curemethod == 'preferconc' and
+              -- we don't have in inventory, but do have alchemy in inventory, use alchemy
+               (not (rift.invcontents.sileris &gt; 0) and (rift.invcontents.quicksilver &gt; 0)) or
+                -- or if we don't have the conc cure in rift either, use alchemy
+               (not (rift.riftcontents.sileris &gt; 0))) or
+  
+            (conf.curemethod == 'prefertrans' and
+              (rift.invcontents.quicksilver &gt; 0
+                or (not (rift.invcontents.sileris &gt; 0) and (rift.riftcontents.quicksilver &gt; 0)))) or
+  
+            -- prefercustom, and we either prefer alchy and have it, or prefer conc and don't have it
+            (conf.curemethod == 'prefercustom' and (
+              (me.curelist[use] == use and rift.riftcontents[use] &lt;= 0)
+                or
+              (me.curelist[use] == 'quicksilver' and rift.riftcontents['quicksilver'] &gt; 0)
+            ))
+  
+            ) then
+              use = 'quicksilver'
+          end
+  
+          sys.last_used['sileris_misc'] = use
+  
+          svo.dict.sileris.applying = use
+          if rift.invcontents[use] &gt; 0 then
+            send("outr "..use, conf.commandecho)
+            send("apply "..use, conf.commandecho)
+          else
+            send("outr "..use, conf.commandecho)
+            send("apply "..use, conf.commandecho)
+          end
+        end,
+  
+        empty = function()
+          svo.dict.sileris.misc.oncompleted()
+        end
+      },
+      gone = {
+        oncompleted = function (line_spotted_on)
+          if not conf.aillusion or not line_spotted_on or (line_spotted_on+1 == getLastLineNumber('main')) then
+            defences.lost('sileris')
+          end
+        end,
+  
+        camusbite = function (oldhp)
+          if not conf.aillusion or (not affs.recklessness and stats.currenthealth &lt; oldhp) then
+            defences.lost('sileris')
+          end
+        end,
+  
+        sumacbite = function (oldhp)
+          if not conf.aillusion or (not affs.recklessness and stats.currenthealth &lt; oldhp) then
+            defences.lost('sileris')
+          end
+        end,
+      }
+    },
+    waitingforsileris = {
+      waitingfor = {
+        customwait = 8,
+  
+        oncompleted = function() defences.got('sileris') end,
+  
+        ontimeout = function()
+          if defc.sileris then return end
+  
+          if (sys.deffing and defdefup[defs.mode].sileris) or (conf.keepup and defkeepup[defs.mode].sileris) then
+            svo.echof("Warning - sileris isn't back yet, we might've been tricked. Going to see if we get bitten.")
+            local oldsileris = defc.sileris
+            defc.sileris = 'unsure'
+            if oldsileris ~= defc.sileris then raiseEvent("svo got def", 'sileris') end
+          end
+        end,
+  
+        onstart = function() end
+      }
+    },
+    deathsight = {
+      herb = {
+        def = true,
+  
+        isadvisable = function()
+          return (not defc.deathsight and (not conf.deathsight or not svo.can_usemana()) and ((sys.deffing and defdefup[defs.mode].deathsight) or (conf.keepup and defkeepup[defs.mode].deathsight)) and not svo.doingaction('deathsight')) or false
+        end,
+  
+        oncompleted = function() defences.got('deathsight') end,
+  
+        eatcure = {'skullcap', 'azurite'},
+        onstart = function() svo.eat(svo.dict.deathsight.herb) end,
+  
+        empty = function() defences.got('deathsight') end
+      },
+      physical = {
+        balanceless_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.deathsight and conf.deathsight and svo.can_usemana() and not svo.doingaction('deathsight') and ((sys.deffing and defdefup[defs.mode].deathsight) or (conf.keepup and defkeepup[defs.mode].deathsight)) and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function() defences.got('deathsight') end,
+  
+        action = 'deathsight',
+        onstart = function() send('deathsight', conf.commandecho) end
+      },
+    },
+    thirdeye = {
+      herb = {
+        def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].thirdeye and not defc.thirdeye) or (conf.keepup and defkeepup[defs.mode].thirdeye and not defc.thirdeye)) and not svo.doingaction('thirdeye') and not (conf.thirdeye and svo.can_usemana())) or false
+        end,
+  
+        oncompleted = function() defences.got('thirdeye') end,
+  
+        eatcure = {'echinacea', 'dolomite'},
+        onstart = function() svo.eat(svo.dict.thirdeye.herb) end,
+  
+        empty = function() defences.got('thirdeye') end
+      },
+      misc = {
+        def = true,
+  
+        isadvisable = function()
+          return (conf.thirdeye and svo.can_usemana() and not svo.doingaction('thirdeye') and ((sys.deffing and defdefup[defs.mode].thirdeye and not defc.thirdeye) or (conf.keepup and defkeepup[defs.mode].thirdeye and not defc.thirdeye))) or false
+        end,
+  
+        -- by default, oncompleted means a clot went through okay
+        oncompleted = function() defences.got('thirdeye') end,
+  
+        action = 'thirdeye',
+        onstart = function() send('thirdeye', conf.commandecho) end
+      },
+    },
+    insomnia = {
+      herb = {
+        def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].insomnia and not defc.insomnia) or (conf.keepup and defkeepup[defs.mode].insomnia and not defc.insomnia)) and not svo.doingaction('insomnia') and not (conf.insomnia and svo.can_usemana()) and not affs.hypersomnia) or false
+        end,
+  
+        oncompleted = function() defences.got('insomnia') end,
+  
+        eatcure = {'cohosh', 'gypsum'},
+        onstart = function() svo.eat(svo.dict.insomnia.herb) end,
+  
+        empty = function() defences.got('insomnia') end,
+  
+        hypersomnia = function()
+          svo.addaffdict(svo.dict.hypersomnia)
+        end
+      },
+      misc = {
+        def = true,
+  
+        isadvisable = function()
+          return (conf.insomnia and svo.can_usemana() and not svo.doingaction('insomnia') and ((sys.deffing and defdefup[defs.mode].insomnia and not defc.insomnia) or (conf.keepup and defkeepup[defs.mode].insomnia and not defc.insomnia)) and not affs.hypersomnia) or false
+        end,
+  
+        oncompleted = function() defences.got('insomnia') end,
+  
+        hypersomnia = function()
+          svo.addaffdict(svo.dict.hypersomnia)
+        end,
+  
+        action = 'insomnia',
+        onstart = function() send('insomnia', conf.commandecho) end
+      },
+      -- small cheat for insomnia being on diagnose
+      aff = {
+        oncompleted = function() defences.got('insomnia') end
+      },
+      gone = {
+        oncompleted = function(aff)
+          defences.lost('insomnia')
+  
+          if aff and aff == 'unknownany' then
+            svo.dict.unknownany.count = svo.dict.unknownany.count - 1
+            if svo.dict.unknownany.count &lt;= 0 then
+              svo.rmaff('unknownany')
+              svo.dict.unknownany.count = 0
+            else
+              svo.updateaffcount(svo.dict.unknownany)
+            end
+          elseif aff and aff == 'unknownmental' then
+            svo.dict.unknownmental.count = svo.dict.unknownmental.count - 1
+            if svo.dict.unknownmental.count &lt;= 0 then
+              svo.rmaff('unknownmental')
+              svo.dict.unknownmental.count = 0
+            else
+              svo.updateaffcount(svo.dict.unknownmental)
+            end
+          end
+        end,
+  
+        relaxed = function (line_spotted_on)
+          if not conf.aillusion or not line_spotted_on or (line_spotted_on+1 == getLastLineNumber('main')) then
+            defences.lost('insomnia')
+          end
+        end,
+      }
+    },
+    myrrh = {
+      gamename = 'scholasticism',
+      herb = {
+        def = true,
+        undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].myrrh and not defc.myrrh) or (conf.keepup and defkeepup[defs.mode].myrrh and not defc.myrrh))) or false
+        end,
+  
+        oncompleted = function() defences.got('myrrh') end,
+  
+        noeffect = function()
+          svo.dict.myrrh.herb.oncompleted ()
+        end,
+  
+        eatcure = {'myrrh', 'bisemutum'},
+        onstart = function() svo.eat(svo.dict.myrrh.herb) end,
+  
+        empty = function() defences.got('myrrh') end
+      },
+    },
+    kola = {
+      herb = {
+        def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].kola and not defc.kola) or (conf.keepup and defkeepup[defs.mode].kola and not defc.kola))) or false
+        end,
+  
+        oncompleted = function() defences.got('kola') end,
+  
+        noeffect = function()
+          svo.dict.kola.herb.oncompleted ()
+        end,
+  
+        eatcure = {'kola', 'quartz'},
+        onstart = function() svo.eat(svo.dict.kola.herb) end,
+  
+        empty = function() defences.got('kola') end
+      },
+      gone = {
+        oncompleted = function()
+          if not conf.aillusion or not svo.pflags.k then
+            defences.lost('kola')
+          end
+        end
+      }
+    },
+    mass = {
+      gamename = 'density',
+      salve = {
+        def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].mass and not defc.mass) or (conf.keepup and defkeepup[defs.mode].mass and not defc.mass))) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          defences.got('mass')
+        end,
+  
+        -- sometimes a salve cure can get misgiagnosed on a death (from a previous apply)
+        noeffect = function() end,
+        empty = function() end,
+  
+        applycure = {'mass', 'density'},
+        actions = {"apply mass to body", "apply mass", "apply density to body", "apply density"},
+        onstart = function()
+          svo.apply(svo.dict.mass.salve, " to body")
+        end,
+      },
+    },
+    caloric = {
+      salve = {
+        def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].caloric and not defc.caloric) or (conf.keepup and defkeepup[defs.mode].caloric and not defc.caloric))) or false
+        end,
+  
+        oncompleted = function()
+          svo.lostbal_salve()
+          defences.got('caloric')
+        end,
+  
+        noeffect = function() svo.lostbal_salve() end,
+  
+        -- called from shivering or frozen cure
+        gotcaloricdef = function (hypothermia)
+          if not hypothermia then svo.rmaff({'frozen', 'shivering'}) end
+          svo.dict.caloric.salve.oncompleted ()
+        end,
+  
+        applycure = {'caloric', 'exothermic'},
+        actions = {"apply caloric to body", "apply caloric", "apply exothermic to body", "apply exothermic"},
+        onstart = function()
+          svo.apply(svo.dict.caloric.salve, " to body")
+        end,
+      },
+      gone = {
+        oncompleted = function(aff)
+          defences.lost('caloric')
+  
+          if aff and aff == 'unknownany' then
+            svo.dict.unknownany.count = svo.dict.unknownany.count - 1
+            if svo.dict.unknownany.count &lt;= 0 then
+              svo.rmaff('unknownany')
+              svo.dict.unknownany.count = 0
+            end
+          elseif aff and aff == 'unknownmental' then
+            svo.dict.unknownmental.count = svo.dict.unknownmental.count - 1
+            if svo.dict.unknownmental.count &lt;= 0 then
+              svo.rmaff('unknownmental')
+              svo.dict.unknownmental.count = 0
+            end
+          end
+        end
+      }
+    },
+    blind = {
+      gamename = 'blindness',
+      onservereignore = function()			
+        -- no blind skill: ignore serverside if it's not to be deffed up atm
+        -- with blind skill: ignore serverside can use skill, or if it's not to be deffed up atm
+        return not 
+          ((not svo.haveskillset('shindo') or (conf.shindoblind and not defc.dragonform)) or
+          (not svo.haveskillset('kaido') or (conf.kaidoblind and not defc.dragonform)) or
+          not ((sys.deffing and defdefup[defs.mode].blind) or (conf.keepup and defkeepup[defs.mode].blind)))
+      end,
+      herb = {
+        def = true,
+  
+        isadvisable = function()
+          return (not affs.scalded and
+            (not svo.haveskillset('shindo') or (defc.dragonform or (not conf.shindoblind))) and
+            (not svo.haveskillset('kaido') or (defc.dragonform or (not conf.kaidoblind))) and
+            ((sys.deffing and defdefup[defs.mode].blind and not defc.blind) or (conf.keepup and defkeepup[defs.mode].blind and not defc.blind)) and
+            not svo.doingaction'waitingonblind') or false
+        end,
+  
+        oncompleted = function()
+          defences.got('blind')
+          svo.lostbal_herb()
+        end,
+  
+        noeffect = function()
+          svo.dict.blind.herb.oncompleted()
+        end,
+  
+        eatcure = {'bayberry', 'arsenic'},
+        onstart = function() svo.eat(svo.dict.blind.herb) end,
+  
+        empty = function()
+          defences.got('blind')
+          svo.lostbal_herb()
+        end
+      },
+      gone = {
+        oncompleted = function()
+          if not conf.aillusion or not svo.pflags.b then
+            defences.lost('blind')
+          end
+        end
+      }
+    },
+    waitingonblind = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function() defences.got('blind') end,
+  
+        onstart = function() end
+      }
+    },
+    deaf = {
+      gamename = 'deafness',
+      onservereignore = function()
+        -- no deaf skill: ignore serverside if it's not to be deffed up atm
+        -- with deaf skill: ignore serverside can use skill, or if it's not to be deffed up atm
+        return not((not svo.haveskillset('shindo') or (conf.shindodeaf and not defc.dragonform)) or
+          (not svo.haveskillset('kaido') or (conf.kaidodeaf and not defc.dragonform)) or
+          not ((sys.deffing and defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf)))
+      end,
+      herb = {
+        def = true,
+  
+        isadvisable = function()
+          return (not defc.deaf and
+            (not svo.haveskillset('shindo') or (defc.dragonform or not conf.shindodeaf)) and
+            (not svo.haveskillset('kaido') or (defc.dragonform or not conf.kaidodeaf)) and
+           ((sys.deffing and defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf)) and not svo.doingaction('waitingondeaf')) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.waitingondeaf.waitingfor)
+          svo.lostbal_herb()
+        end,
+  
+        eatcure = {'hawthorn', 'calamine'},
+        onstart = function() svo.eat(svo.dict.deaf.herb) end,
+  
+        empty = function()
+          svo.dict.deaf.herb.oncompleted()
+        end
+      },
+      gone = {
+        oncompleted = function()
+          if not conf.aillusion or not svo.pflags.d then
+            defences.lost('deaf')
+          end
+        end
+      }
+    },
+    waitingondeaf = {
+      waitingfor = {
+        customwait = 6,
+  
+        oncompleted = function() defences.got('deaf') end,
+  
+        onstart = function() end
+      }
+    },
+  
+  
+  -- balance-related defences
+    lyre = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.lyre and ((sys.deffing and defdefup[defs.mode].lyre) or (conf.keepup and defkeepup[defs.mode].lyre)) and not svo.will_take_balance() and not conf.lyre_step and not svo.doingaction('lyre') and not affs.prone) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('lyre')
+  
+          if conf.lyre and not conf.paused then conf.paused = true; raiseEvent("svo config changed", 'paused') end
+        end,
+  
+        ontimeout = function()
+          if conf.paused and not defc.lyre then
+            svo.echof("Lyre strum didn't happen - unpausing.")
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            svo.make_gnomes_work()
+          end
+        end,
+  
+        onkill = function()
+          if conf.paused and not defc.lyre then
+            svo.echof("Lyre strum cancelled - unpausing.")
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+          end
+        end,
+  
+        action = "strum lyre",
+        onstart = function()
+          sys.sendonceonly = true
+          -- small fix to make 'lyc' work and be in-order (as well as use batching)
+          local send = send
+          -- record in systemscommands, so it doesn't get killed later on in the controller and loop
+          if conf.batch then send = function(what, ...) svo.sendc(what, ...) sk.systemscommands[what] = true end end
+  
+          if not conf.lyrecmd then
+            send("strum lyre", conf.commandecho)
+          else
+            send(tostring(conf.lyrecmd), conf.commandecho)
+          end
+          sys.sendonceonly = false
+  
+          if conf.lyre and not conf.paused then conf.paused = true; raiseEvent("svo config changed", 'paused') end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('lyre')
+  
+          -- as a special case for handling the following scenario:
+          --[[(focus)
+            Your prismatic barrier dissolves into nothing.
+            You focus your mind intently on curing your mental maladies.
+            Food is no longer repulsive to you. (7.548s)
+            H: 3294 (50%), M: 4911 (89%) 28725e, 10294w 89.3% ex|cdk- 19:24:04.719(sip health|eat bayberry|outr bayberry|eat
+            irid|outr irid)(+324h, 5.0%, -291m, 5.3%)
+            You begin to weave a melody of magical, heart-rending beauty and a beautiful barrier of prismatic light surrounds you.
+            (p) H: 3294 (50%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:04.897
+            Your prismatic barrier dissolves into nothing.
+            You take a drink from a purple heartwood vial.
+            The elixir heals and soothes you.
+            H: 4767 (73%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:05.247(+1473h, 22.7%)
+            You eat some bayberry bark.
+            Your eyes dim as you lose your sight.
+          ]]
+          -- we want to kill lyre going up when it goes down and you're off balance, because you won't get it up off-bal
+  
+          -- but don't kill it if it is in lifevision - meaning we're going to get it:
+          --[[
+            (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
+            Your prismatic barrier dissolves into nothing.
+            You strum a Lasallian lyre, and a prismatic barrier forms around you.
+            (svo): Lyre strum cancelled - unpausing.
+            (x) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}
+            You have recovered equilibrium. (3.887s)
+            (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
+            Your prismatic barrier dissolves into nothing.
+            You strum a Lasallian lyre, and a prismatic barrier forms around you.
+            (svo): Lyre strum cancelled - unpausing.
+          ]]
+  
+          if not (bals.balance and bals.equilibrium) and svo.actions.lyre_physical and not svo.lifevision.l.lyre_physical then svo.killaction(svo.dict.lyre.physical) end
+  
+          -- unpause should we lose the lyre def for some reason - but not while we're doing lyc
+          -- since we'll lose the lyre def and it'll come up right away
+          if conf.lyre and conf.paused and not svo.actions.lyre_physical then conf.paused = false; raiseEvent("svo config changed", 'paused') end
+        end,
+      }
+    },
+    breath = {
+      gamename = 'heldbreath',
+      physical = {
+        balanceless_act = true, def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].breath and not defc.breath) or (conf.keepup and defkeepup[defs.mode].breath and not defc.breath)) and not svo.doingaction('breath') and not codepaste.balanceful_defs_codepaste() and not affs.aeon and not affs.asthma) or false
+        end,
+  
+        oncompleted = function() defences.got('breath') end,
+  
+        action = "hold breath",
+        onstart = function()
+          if conf.gagbreath and not sys.sync then
+            send("hold breath", false)
+          else
+            send("hold breath", conf.commandecho) end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('breath') end,
+      }
+    },
+    dragonform = {
+      physical = {
+        unpauselater = false,
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].dragonform and not defc.dragonform) or (conf.keepup and defkeepup[defs.mode].dragonform and not defc.dragonform)) and not svo.doingaction('waitingfordragonform') and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.waitingfordragonform.waitingfor)
+        end,
+  
+        alreadyhave = function()
+          svo.dict.waitingfordragonform.waitingfor.oncompleted()
+        end,
+  
+        actions = {'dragonform', "dragonform red", "dragonform black", "dragonform silver", "dragonform gold", "dragonform blue", "dragonform green"},
+        onstart = function()
+        -- user commands catching needs this check
+          if not (bals.balance and bals.equilibrium) then return end
+  
+          if defc.flame and svo.haveskillset('metamorphosis') then
+            send("relax flame", conf.commandecho)
+          end
+          send('dragonform', conf.commandecho)
+  
+          if not conf.paused then
+            svo.dict.dragonform.physical.unpauselater = true
+            conf.paused = true; raiseEvent("svo config changed", 'paused')
+            echo"\n" svo.echof("Temporarily pausing for dragonform.")
+          end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('dragonform')
+          svo.dict.dragonbreath.gone.oncompleted()
+          svo.dict.dragonarmour.gone.oncompleted()
+          signals.dragonform:emit()
+        end,
+      }
+    },
+    waitingfordragonform = {
+      waitingfor = {
+        customwait = 20,
+  
+        oncompleted = function()
+          defences.got('dragonform')
+          svo.dict.riding.gone.oncompleted()
+  
+          -- strip class defences that don't stay through dragon
+          for def, deft in svo.defs_data:iter() do
+            local skillset = deft.type
+            if skillset ~= 'general' and skillset ~= 'enchantment' and skillset ~= 'dragoncraft' and not deft.staysindragon and defc[def] then
+              defences.lost(def)
+            end
+          end
+  
+          -- lifevision, via artefact, has to be removed as well
+          if defc.lifevision and not svo.haveskillset('necromancy') then
+            defences.lost('lifevision')
+          end
+  
+          signals.dragonform:emit()
+  
+          if conf.paused and svo.dict.dragonform.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+  
+            echo"\n"
+            if math.random(1, 20) == 1 then
+              svo.echof("ROOOAR!")
+            else
+              svo.echof("Obtained dragonform, unpausing.")
+            end
+          end
+          svo.dict.dragonform.physical.unpauselater = false
+        end,
+  
+        cancelled = function()
+          signals.dragonform:emit()
+          if conf.paused and svo.dict.dragonform.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            echo"\n" svo.echof("Unpausing.")
+          end
+          svo.dict.dragonform.physical.unpauselater = false
+        end,
+  
+        ontimeout = function()
+          svo.dict.waitingfordragonform.waitingfor.cancelled()
+        end,
+  
+        onstart = function() end
+      }
+    },
+    dragonbreath = {
+      physical = {
+        balanceless_act = true, def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].dragonbreath and not defc.dragonbreath) or (conf.keepup and defkeepup[defs.mode].dragonbreath and not defc.dragonbreath)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction('dragonbreath') and not svo.doingaction('waitingfordragonbreath') and defc.dragonform and not svo.dict.dragonbreath.blocked and not affs.paralysis and not affs.prone) or false
+        end,
+  
+        oncompleted = function (def)
+          if def then defences.got('dragonbreath')
+          else svo.doaction(svo.dict.waitingfordragonbreath.waitingfor) end
+        end,
+  
+        ontimeout = function()
+          if not affs.blackout then return end
+  
+          svo.dict.dragonbreath.blocked = true
+          tempTimer(3, function() svo.dict.dragonbreath.blocked = false; svo.make_gnomes_work() end)
+        end,
+  
+        alreadygot = function() defences.got('dragonbreath') end,
+  			
+        actions = {'summon acid', 'summon psi', 'summon ice', 'summon venom', 'summon dragonfire', 'summon lightning'},
+  
+        onstart = function()
+          send("summon "..(conf.dragonbreath and conf.dragonbreath or 'unknown'), conf.commandecho)
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('dragonbreath') end
+      }
+    },
+    waitingfordragonbreath = {
+      waitingfor = {
+        customwait = 2,
+  
+        onstart = function() end,
+  
+        oncompleted = function() defences.got('dragonbreath') end
+      }
+    },
+    dragonarmour = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].dragonarmour and not defc.dragonarmour) or (conf.keepup and defkeepup[defs.mode].dragonarmour and not defc.dragonarmour)) and not codepaste.balanceful_defs_codepaste() and defc.dragonform) or false
+        end,
+  
+        oncompleted = function() defences.got('dragonarmour') end,
+  
+        action = "dragonarmour on",
+        onstart = function() send('dragonarmour on', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function() defences.lost('dragonarmour') end
+      }
+    },
+    selfishness = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (
+            ((sys.deffing and defdefup[defs.mode].selfishness and not defc.selfishness)
+              or (not sys.deffing and conf.keepup and ((defkeepup[defs.mode].selfishness and not defc.selfishness) or (not defkeepup[defs.mode].selfishness and defc.selfishness))))
+            and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function() defences.got('selfishness') end,
+  
+        onstart = function()
+          if (sys.deffing and defdefup[defs.mode].selfishness and not defc.selfishness) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].selfishness and not defc.selfishness) then
+            send('selfishness', conf.commandecho)
+          else
+            send('generosity', conf.commandecho)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('selfishness')
+  
+          -- if we've done sl off, _gone gets added, so _physical gets readded by action clear - kill physical here for that not to happen
+          if svo.actions.selfishness_physical then
+            svo.killaction(svo.dict.selfishness.physical)
+          end
+        end,
+      }
+    },
+    riding = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (
+            ((sys.deffing and defdefup[defs.mode].riding and not defc.riding)
+              or (not sys.deffing and conf.keepup and ((defkeepup[defs.mode].riding and not defc.riding) or (not defkeepup[defs.mode].riding and defc.riding))))
+            and not codepaste.balanceful_defs_codepaste() and not defc.dragonform and not affs.hamstring and (not affs.prone or svo.doingaction'prone') and not affs.crippledleftarm and not affs.crippledrightarm and not affs.mangledleftarm and not affs.mangledrightarm and not affs.mutilatedleftarm and not affs.mutilatedrightarm and not affs.unknowncrippledleg and not affs.parestolegs and not svo.doingaction'riding' and not affs.pinshot and not affs.paralysis
+            and not string.find(svo.me.class, "Elemental")) or false
+        end,
+  
+        oncompleted = function()
+          if (not sys.deffing and conf.keepup and not defkeepup[defs.mode].riding and (defc.riding == true or defc.riding == nil)) then
+            svo.dict.riding.gone.oncompleted()
+          else
+            defences.got('riding')
+          end
+  
+          if bals.balance and not conf.freevault then
+            svo.config.set('freevault', 'yep', true)
+          elseif not bals.balance and conf.freevault then
+            svo.config.set('freevault', 'nope', true)
+          end
+        end,
+  
+        alreadyon = function() defences.got('riding') end,
+  
+        dragonform = function()
+          defences.got('dragonform')
+          signals.dragonform:emit()
+        end,
+  
+        hastring = function()
+          svo.dict.hamstring.aff.oncompleted()
+        end,
+  
+        dismount = function()
+          defences.lost('riding')
+          svo.dict.block.gone.oncompleted()
+        end,
+  
+        onstart = function()
+          if (sys.deffing and defdefup[defs.mode].riding and not defc.riding) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].riding and not defc.riding) then
+            send(string.format("%s %s", tostring(conf.ridingskill), tostring(conf.ridingsteed)), conf.commandecho)
+          else
+            send('dismount', conf.commandecho)
+            if sys.sync or tostring(conf.ridingsteed) == 'giraffe' then return end
+            if conf.steedfollow then send(string.format("order %s follow me", tostring(conf.ridingsteed), conf.commandecho)) end
+          end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('riding')
+          svo.dict.block.gone.oncompleted()
+        end,
+      }
+    },
+    meditate = {
+      physical = {
+        balanceless_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].meditate and not defc.meditate) or (conf.keepup and defkeepup[defs.mode].meditate and not defc.meditate)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'meditate' and (stats.currentwillpower &lt; stats.maxwillpower or stats.currentmana &lt; stats.maxmana)) or false
+        end,
+  
+        oncompleted = function() defences.got('meditate') end,
+  
+        actions = {'med', 'meditate'},
+        onstart = function() send('meditate', conf.commandecho) end
+      }
+    },
+  
+    mindseye = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.mindseye and ((sys.deffing and defdefup[defs.mode].mindseye) or (conf.keepup and defkeepup[defs.mode].mindseye)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('mindseye')
+  
+          -- check if we need to re-classify deaf
+          if (defc.deaf or affs.deafaff) and (defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf) or defc.mindseye then
+            defences.got('deaf')
+            svo.rmaff('deafaff')
+          elseif (defc.deaf or affs.deafaff) then
+            defences.lost('deaf')
+            svo.addaffdict(svo.dict.deafaff)
+          end
+  
+          -- check if we need to re-classify blind
+          if (defc.blind or affs.blindaff) and (defdefup[defs.mode].blind) or (conf.keepup and defkeepup[defs.mode].blind) and (svo.me.class == 'Apostate' or defc.mindseye) then
+            defences.got('blind')
+            svo.rmaff('blindaff')
+          elseif (defc.blind or affs.blindaff) then
+            defences.lost('blind')
+            svo.addaffdict(svo.dict.blindaff)
+          end
+        end,
+  
+        action = "touch mindseye",
+        onstart = function() send('touch mindseye', conf.commandecho) end
+      }
+    },
+    metawake = {
+      physical = {
+        balanceless_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.metawake and ((sys.deffing and defdefup[defs.mode].metawake) or (conf.keepup and defkeepup[defs.mode].metawake)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not svo.doingaction'metawake' and not affs.lullaby) or false
+        end,
+  
+        oncompleted = function() defences.got('metawake') end,
+  
+        action = "metawake on",
+        onstart = function() send('metawake on', conf.commandecho) end
+      }
+    },
+    cloak = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.cloak and ((sys.deffing and defdefup[defs.mode].cloak) or (conf.keepup and defkeepup[defs.mode].cloak)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
+        end,
+  
+        oncompleted = function() defences.got('cloak') end,
+  
+        action = "touch cloak",
+        onstart = function() send('touch cloak', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          if not conf.aillusion or not svo.pflags.c then
+            defences.lost('cloak')
+          end
+        end
+      }
+    },
+  
+    nightsight = {
+      physical = {
+        balanceless_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.nightsight and
+            ((sys.deffing and defdefup[defs.mode].nightsight) or (conf.keepup and defkeepup[defs.mode].nightsight)) and
+            not codepaste.balanceful_defs_codepaste() and
+            sys.canoutr and
+            not affs.prone and
+            not svo.doingaction'nightsight'
+            and (not svo.haveskillset('metamorphosis') or ((not affs.cantmorph and not svo.doingaction'waitingformorph' and sk.morphsforskill.nightsight) or defc.dragonform))) or false
+        end,
+  
+        oncompleted = function() defences.got('nightsight') end,
+  
+        action = "nightsight on",
+        onstart = function()
+  if not svo.haveskillset('metamorphosis') then
+          send("nightsight on", conf.commandecho)
+  else
+          if not defc.dragonform and (not conf.transmorph and sk.inamorph() and not sk.inamorphfor'nightsight') then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          elseif not defc.dragonform and not sk.inamorphfor'nightsight' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph "..sk.morphsforskill.nightsight[1], conf.commandecho)
+            if not conf.truemorph then svo.doaction(svo.dict.waitingformorph.waitingfor) end
+          elseif defc.dragonform or sk.inamorphfor'nightsight' then
+            send("nightsight on", conf.commandecho)
+          end
+  end
+        end
+      },
+    },
+    shield = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].shield and not defc.shield) or (conf.keepup and defkeepup[defs.mode].shield and not defc.shield)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not (affs.mangledleftarm and affs.mangledlrightarm) and not affs.prone) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('shield')
+          if defkeepup[defs.mode].shield and conf.oldts then
+            defs.keepup('shield', false)
+          end
+        end,
+  
+        actions = {"touch shield", "angel aura"},
+        onstart = function()
+  if svo.haveskillset('spirituality') then
+          if defc.dragonform or not defc.summon or stats.currentwillpower &lt;= 10 then
+            send("touch shield", conf.commandecho)
+          else
+            send("angel aura", conf.commandecho)
+          end
+  else
+          send("touch shield", conf.commandecho)
+  end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('shield') end
+      }
+    },
+    sstosvoa = {
+      addiction = 'addiction',
+      aeon = 'aeon',
+      agoraphobia = 'agoraphobia',
+      airfisted = 'galed',
+      amnesia = 'amnesia',
+      anorexia = 'anorexia',
+      asthma = 'asthma',
+      blackout = 'blackout',
+      blindness = false,
+      bound = 'bound',
+      brokenleftarm = 'crippledleftarm',
+      brokenleftleg = 'crippledleftleg',
+      brokenrightarm = 'crippledrightarm',
+      brokenrightleg = 'crippledrightleg',
+      bruisedribs = false,
+      burning = 'ablaze',
+      cadmuscurse = 'cadmus',
+      calcifiedskull = 'calcifiedskull',
+      calcifiedtorso = 'calcifiedtorso',
+      claustrophobia = 'claustrophobia',
+      clumsiness = 'clumsiness',
+      concussion = 'seriousconcussion',
+      conflagration = false,
+      confusion = 'confusion',
+      corruption = 'corrupted',
+      crackedribs = 'crackedribs',
+      crushedthroat = 'crushedthroat',
+      daeggerimpale = false,
+      damagedhead = 'mildconcussion',
+      damagedleftarm = 'mangledleftarm',
+      damagedleftleg = 'mangledleftleg',
+      damagedrightarm = 'mangledrightarm',
+      damagedrightleg = 'mangledrightleg',
+      darkshade = 'darkshade',
+      dazed = false,
+      dazzled = false,
+      deadening = 'deadening',
+      deafness = false,
+      deepsleep = 'sleep',
+      degenerate = 'degenerate',
+      dehydrated = 'dehydrated',
+      dementia = 'dementia',
+      demonstain = 'stain',
+      depression = 'depression',
+      deteriorate = 'deteriorate',
+      disloyalty = 'disloyalty',
+      disrupted = 'disrupt',
+      dissonance = 'dissonance',
+      dizziness = 'dizziness',
+      enlightenment = false,
+      enmesh = false,
+      ensorcelled = 'ensorcelled',
+      entangled = 'roped',
+      entropy = false,
+      epilepsy = 'epilepsy',
+      fear = 'fear',
+      flamefisted = 'burning',
+      flushings = 'flushings',
+      frozen = 'frozen',
+      generosity = 'generosity',
+      guilt = 'guilt',
+      haemophilia = 'haemophilia',
+      hallucinations = 'hallucinations',
+      hamstrung = 'hamstring',
+      hatred = 'hatred',
+      healthleech = 'healthleech',
+      heartseed = 'heartseed',
+      hecatecurse = 'hecate',
+      hellsight = 'hellsight',
+      hindered = false,
+      homunculusmercury = false,
+      horror = 'horror',
+      hypersomnia = 'hypersomnia',
+      hypochondria = 'hypochondria',
+      hypothermia = 'hypothermia',
+      icefisted = 'icing',
+      impaled = 'impale',
+      impatience = 'impatience',
+      indifference = 'indifference',
+      inquisition = 'inquisition',
+      insomnia = false,
+      internalbleeding = false,
+      isolation = false,
+      itching = 'itching',
+      justice = 'justice',
+      kaisurge = false,
+      laceratedthroat = 'laceratedthroat',
+      lapsingconsciousness = false,
+      latched = 'latched',
+      lethargy = 'lethargy',
+      loneliness = 'loneliness',
+      lovers = 'inlove',
+      manaleech = 'manaleech',
+      mangledhead = 'seriousconcussion',
+      mangledleftarm = 'mutilatedleftarm',
+      mangledleftleg = 'mutilatedleftleg',
+      mangledrightarm = 'mutilatedrightarm',
+      mangledrightleg = 'mutilatedrightleg',
+      masochism = 'masochism',
+      mildtrauma = 'mildtrauma',
+      mindclamp = false,
+      mycalium = 'mycalium',
+      nausea = 'illness',
+      numbedleftarm = 'numbedleftarm',
+      numbedrightarm = 'numbedrightarm',
+      pacified = 'pacifism',
+      palpatarfeed = 'palpatar',
+      paralysis = 'paralysis',
+      paranoia = 'paranoia',
+      parasite = 'parasite',
+      peace = 'peace',
+      penitence = false,
+      petrified = false,
+      phlogisticated = 'phlogistication',
+      pinshot = 'pinshot',
+      prone = 'prone',
+      pressure = 'pressure',
+      pyramides = 'pyramides',
+      rebbies = 'rebbies',
+      recklessness = 'recklessness',
+      retribution = 'retribution',
+      revealed = false,
+      sandfever = 'sandfever',
+      scalded = 'scalded',
+      scrambledbrains = false,
+      scytherus = 'relapsing',
+      selarnia = 'selarnia',
+      sensitivity = 'sensitivity',
+      serioustrauma = 'serioustrauma',
+      shadowmadness = 'shadowmadness',
+      shivering = 'shivering',
+      shyness = 'shyness',
+      silver = false,
+      skullfractures = 'skullfractures',
+      slashedthroat = 'slashedthroat',
+      sleeping = 'sleep',
+      slickness = 'slickness',
+      slimeobscure = 'ninkharsag',
+      spiritburn = 'spiritburn',
+      stupidity = 'stupidity',
+      stuttering = 'stuttering',
+      temperedcholeric = 'cholerichumour',
+      temperedmelancholic = 'melancholichumour',
+      temperedphlegmatic = 'phlegmatichumour',
+      temperedsanguine = 'sanguinehumour',
+      tenderskin = 'tenderskin',
+      timeflux = 'timeflux',
+      timeloop = 'timeloop',
+      tension = 'tension',
+      torntendons = 'torntendons',
+      transfixation = 'transfixed',
+      trueblind = false,
+      unconsciousness = 'unconsciousness',
+      unweavingbody = 'unweavingbody',
+      unweavingmind = 'unweavingmind',
+      unweavingspirit = 'unweavingspirit',
+      vertigo = 'vertigo',
+      vinewreathed = false,
+      vitiated = false,
+      vitrified = 'vitrification',
+      voidfisted = 'voided',
+      voyria = 'voyria',
+      weakenedmind = 'rixil',
+      weariness = 'weakness',
+      webbed = 'webbed',
+      whisperingmadness = 'madness',
+      wristfractures = 'wristfractures'
+    },
+    sstosvod = {
+      acrobatics = 'acrobatics',
+      accursedresolve = 'accursedresolve',
+      affinity = 'affinity',
+      aiming = false,
+      airpocket = 'waterbubble',
+      alertness = 'alertness',
+      antiforce = 'gaiartha',
+      arctar = 'arctar',
+      aria = 'aria',
+      arrowcatching = 'arrowcatch',
+      astralform = 'astralform',
+      astronomy = 'empower',
+      balancing = 'balancing',
+      barkskin = 'barkskin',
+      basking = 'bask',
+      bedevilaura = 'bedevil',
+      belltattoo = 'bell',
+      blackwind = false,
+      blademastery = 'mastery',
+      blessingofthegods = false,
+      blindness = 'blind',
+      blocking = 'block',
+      bloodquell = 'ukhia',
+      bloodshield = false,
+      blur = 'blur',
+      boartattoo = false,
+      bodyaugment = 'mainaas',
+      bodyblock = 'bodyblock',
+      boostedregeneration = 'boosting',
+      brains = 'brains',
+      bulk = 'bulk',
+      chameleon = 'chameleon',
+      chargeshield = 'chargeshield',
+      circulate = 'circulate',
+      clinging = 'clinging',
+      cloak = 'cloak',
+      coldresist = 'coldresist',
+      consciousness = 'consciousness',
+      constitution = 'constitution',
+      croonmirror = false,
+      curseward = 'curseward',
+      dawnhand = 'dawnhand',
+      deafness = 'deaf',
+      deathaura = 'deathaura',
+      deathsight = 'deathsight',
+      deflect = 'deflect',
+      deliverance = false,
+      demonarmour = 'armour',
+      demonfury = false,
+      density = 'mass',
+      devilmark = 'devilmark',
+      devour = 'devour',
+      diamondskin = 'diamondskin',
+      disassociate = false,
+      distortedaura = 'distortedaura',
+      disperse = 'disperse',
+      dodging = 'dodging',
+      dragonarmour = 'dragonarmour',
+      dragonbreath = 'dragonbreath',
+      drunkensailor = 'drunkensailor',
+      durability = 'tsuura',
+      earthshield = 'earthblessing',
+      eavesdropping = 'eavesdrop',
+      electricresist = 'electricresist',
+      elusiveness = 'elusiveness',
+      enduranceblessing = 'enduranceblessing',
+      enhancedform = false,
+      evadeblock = 'evadeblock',
+      evasion = false,
+      extispicy = 'extispicy',
+      eyes = 'eyes',
+      fangbarrier = 'sileris',
+      fervour = 'fervour',
+      firefly = false,
+      fireresist = 'fireresist',
+      firstaid = 'firstaid',
+      flailingstaff = 'flail',
+      fleetness = 'fleetness',
+      frenzied = false,
+      frostshield = 'frostblessing',
+      fury = false,
+      ghost = 'ghost',
+      golgothagrace = 'golgotha',
+      gripping = 'grip',
+      groundwatch = 'groundwatch',
+      harmony = 'harmony',
+      haste = false,
+      heads = 'heads',
+      heartsfury = 'heartsfury',
+      heldbreath = 'breath',
+      heresy = 'heresy',
+      hiding = 'hiding',
+      hypersense = 'hypersense',
+      hypersight = 'hypersight',
+      immunity = 'immunity',
+      insomnia = 'insomnia',
+      inspiration = 'inspiration',
+      insuflate = false,
+      insulation = false,
+      ironform = false,
+      ironwill = 'qamad',
+      joints = 'joints',
+      kaiboost = 'kaiboost',
+      kaitrance = 'trance',
+      kola = 'kola',
+      lament = false,
+      lay = 'lay',
+      leechlogograph = 'traceleech',
+      levitating = 'levitation',
+      lifegiver = false,
+      lifesteal = false,
+      lifevision = 'lifevision',
+      lipreading = 'lipread',
+      magicresist = 'magicresist',
+      megalithtattoo = false,
+      mercury = 'mercury',
+      metawake = 'metawake',
+      mindcloak = 'mindcloak',
+      mindnet = 'mindnet',
+      mindseye = 'mindseye',
+      mindtelesense = 'mindtelesense',
+      moontattoo = false,
+      morph = false,
+      mouths = 'mouths',
+      mosstattoo = false,
+      nightsight = 'nightsight',
+      numbness = 'numb',
+      oxtattoo = false,
+      pacing = 'pacing',
+      panacea = 'panacea',
+      phased = 'phase',
+      pinchblock = 'pinchblock',
+      poisonresist = 'venom',
+      preachblessing = false,
+      precision = 'trusad',
+      prismatic = 'lyre',
+      projectiles = 'projectiles',
+      promosurcoat = false,
+      putrefaction = 'putrefaction',
+      rebounding = 'rebounding',
+      reflections = 'reflection',
+      reflexes = false,
+      regeneration = 'regeneration',
+      resistance = 'resistance',
+      retaliation = 'retaliationstrike',
+      retribution = 'retributionvow',
+      satiation = 'satiation',
+      scales = 'scales',
+      scholasticism = 'myrrh',
+      scouting = 'scout',
+      secondsight = 'secondsight',
+      selfishness = 'selfishness',
+      shadowveil = 'shadowveil',
+      shield = 'shield',
+      shieldlogograph = 'traceshield',
+      shikudoform = false,
+      shinbinding = 'bind',
+      shinclarity = 'clarity',
+      shinrejoinder = false,
+      shintrance = 'shintrance',
+      shipwarning = 'shipwarning',
+      skywatch = 'skywatch',
+      slippery = 'slipperiness',
+      softfocusing = 'softfocus',
+      songbird = 'songbird',
+      soulcage = 'soulcage',
+      speed = 'speed',
+      spinning = 'spinning',
+      spinningstaff = false,
+      spiritbonded = 'bonding',
+      spiritwalk = false,
+      splitmind = 'splitmind',
+      standingfirm = 'sturdiness',
+      starburst = 'starburst',
+      stealth = 'stealth',
+      stonefist = 'stonefist',
+      stoneskin = 'stoneskin',
+      sulphur = 'sulphur',
+      swiftcurse = 'swiftcurse',
+      tekurastance = false,
+      telesense = 'telesense',
+      temperance = 'frost',
+      tentacles = 'tentacles',
+      thermalshield = 'thermalblessing',
+      thirdeye = 'thirdeye',
+      tin = 'tin',
+      tongues = 'tongues',
+      toughness = 'toughness',
+      treewatch = 'treewatch',
+      truestare = 'truestare',
+      tumors = 'tumors',
+      tune = 'tune',
+      twoartsstance = false,
+      unbowed = 'unbowed',
+      unnamablepresence = 'unnamablepresence',
+      vengeance = 'vengeance',
+      venomsacks = 'venomsacks',
+      vigilance = 'vigilance',
+      vigour = 'vigour',
+      viridian = 'viridian',
+      vitality = 'vitality',
+      ward = false,
+      waterwalking = 'waterwalk',
+      weakvigour = false,
+      weathering = 'weathering',
+      weaving = 'weaving',
+      wildgrowth = 'wildgrowth',
+      willpowerblessing = 'willpowerblessing',
+      xporb = false,
+    },
+    svotossa = {},
+    svotossd = {}
+  } -- end of dict
+  
+  if svo.haveskillset('subterfuge') then
+    svo.dict.sstosvod.shroud = 'cloaking'
+  else
+    svo.dict.sstosvod.shroud = 'shroud'
+  end
+  
+  if svo.haveskillset('weaponmastery') then
+    svo.dict.prone.misc.actions = {'stand', "recover footing"}
+  else
+    svo.dict.prone.misc.action = 'stand'
+  end
+  
+  -- undeffable since serverside can't morph to get a specific defence up
+  if svo.haveskillset('metamorphosis') then
+    svo.dict.nightsight.physical.undeffable = true
+  end
+  
+  if svo.haveskillset('shindo') then
+    svo.dict.deaf.misc = {
+      def = true,
+  
+      isadvisable = function()
+        return (not defc.deaf and conf.shindodeaf and not defc.dragonform and ((sys.deffing and defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf)) and not svo.doingaction('waitingondeaf')) or false
+      end,
+  
+      oncompleted = function()
+        svo.doaction(svo.dict.waitingondeaf.waitingfor)
+      end,
+  
+      action = 'deaf',
+      onstart = function()
+        send('deaf', conf.commandecho)
+      end
+    }
+  end
+  if svo.haveskillset('kaido') then
+    svo.dict.deaf.misc = {
+      def = true,
+  
+      isadvisable = function()
+        return (not defc.deaf and conf.kaidodeaf and not defc.dragonform and ((sys.deffing and defdefup[defs.mode].deaf) or (conf.keepup and defkeepup[defs.mode].deaf)) and not svo.doingaction('waitingondeaf')) or false
+      end,
+  
+      oncompleted = function()
+        svo.doaction(svo.dict.waitingondeaf.waitingfor)
+      end,
+  
+      action = 'deaf',
+      onstart = function()
+        send('deaf', conf.commandecho)
+      end
+    }
+  end
+  if svo.haveskillset('shindo') then
+    svo.dict.blind.misc = {
+        def = true,
+  
+        isadvisable = function()
+          return (conf.shindoblind and not defc.dragonform and ((sys.deffing and defdefup[defs.mode].blind and not defc.blind) or (conf.keepup and defkeepup[defs.mode].blind and not defc.blind)) and not svo.doingaction'waitingonblind') or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.waitingonblind.waitingfor)
+        end,
+  
+        action = 'blind',
+        onstart = function() send('blind', conf.commandecho) end
+      }
+  end
+  if svo.haveskillset('kaido') then
+    svo.dict.blind.misc = {
+        def = true,
+  
+        isadvisable = function()
+          return (conf.kaidoblind and not defc.dragonform and ((sys.deffing and defdefup[defs.mode].blind and not defc.blind) or (conf.keepup and defkeepup[defs.mode].blind and not defc.blind)) and not svo.doingaction'waitingonblind') or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.waitingonblind.waitingfor)
+        end,
+  
+        action = 'blind',
+        onstart = function() send('blind', conf.commandecho) end
+      }
+  end
+  
+  
+  -- skillset-specific defences
+  if svo.haveskillset('necromancy') then
+    svo.dict.lifevision = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.lifevision and ((sys.deffing and defdefup[defs.mode].lifevision) or (conf.keepup and defkeepup[defs.mode].lifevision)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.prone and stats.currentmana &gt;= 600) or false
+        end,
+  
+        oncompleted = function() defences.got('lifevision') end,
+  
+        action = 'lifevision',
+        onstart = function() send('lifevision', conf.commandecho) end
+      }
+    }
+  end
+  
+  
+  if svo.haveskillset('zeal') then
+    svo.dict.frostblessing = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.frostblessing and ((sys.deffing and defdefup[defs.mode].frostblessing) or (conf.keepup and defkeepup[defs.mode].frostblessing)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and bals.prayer == true and stats.currentmana &gt;= 750) or false
+        end,
+  
+        oncompleted = function() 
+          if conf.benediction then 
+            defences.got('frostblessing') defences.got('thermalblessing') defences.got('earthblessing') defences.got('willpowerblessing') defences.got('enduranceblessing') svo.lostbal_prayer()
+          else 
+            defences.got('frostblessing') svo.lostbal_prayer() 
+          end
+        end,
+  
+        action = "recite void me",
+  
+        onstart = function() 
+          if conf.benediction then 
+            send('recite benediction me', conf.commandecho)
+          else 
+            send('recite void me', conf.commandecho) 
+          end
+        end
+      }
+    }
+    svo.dict.willpowerblessing = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.willpowerblessing and ((sys.deffing and defdefup[defs.mode].willpowerblessing) or (conf.keepup and defkeepup[defs.mode].willpowerblessing)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and bals.prayer == true and stats.currentmana &gt;= 750) or false
+        end,
+  
+        oncompleted = function() 
+          if conf.benediction then 
+            defences.got('frostblessing') defences.got('thermalblessing') defences.got('earthblessing') defences.got('willpowerblessing') defences.got('enduranceblessing') svo.lostbal_prayer()
+          else 
+            defences.got('willpowerblessing') svo.lostbal_prayer() 
+          end
+        end,
+  
+        action = "recite will me",
+  
+        onstart = function() 
+          if conf.benediction then 
+            send('recite benediction me', conf.commandecho)
+          else 
+            send('recite will me', conf.commandecho) 
+          end 
+        end
+      }
+    }
+    svo.dict.thermalblessing = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.thermalblessing and ((sys.deffing and defdefup[defs.mode].thermalblessing) or (conf.keepup and defkeepup[defs.mode].thermalblessing)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and bals.prayer == true and stats.currentmana &gt;= 750) or false
+        end,
+  
+        oncompleted = function() 
+          if conf.benediction then 
+            defences.got('frostblessing') defences.got('thermalblessing') defences.got('earthblessing') defences.got('willpowerblessing') defences.got('enduranceblessing') svo.lostbal_prayer()
+          else 
+            defences.got('thermalblessing') svo.lostbal_prayer() 
+          end
+        end,
+  
+        action = "recite fire me",
+  
+        onstart = function() 
+          if conf.benediction then 
+            send('recite benediction me', conf.commandecho)
+          else 
+            send('recite fire me', conf.commandecho) 
+          end
+        end
+      }
+    }
+    svo.dict.earthblessing = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.earthblessing and ((sys.deffing and defdefup[defs.mode].earthblessing) or (conf.keepup and defkeepup[defs.mode].earthblessing)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and bals.prayer == true and stats.currentmana &gt;= 750) or false
+        end,
+  
+        oncompleted = function() 
+          if conf.benediction then 
+            defences.got('frostblessing') defences.got('thermalblessing') defences.got('earthblessing') defences.got('willpowerblessing') defences.got('enduranceblessing') svo.lostbal_prayer()
+          else 
+            defences.got('earthblessing') svo.lostbal_prayer() 
+          end
+        end,
+  
+        action = "recite protection me",
+  
+        onstart = function() 
+          if conf.benediction then 
+            send('recite benediction me', conf.commandecho)
+          else 
+            send('recite protection me', conf.commandecho) 
+          end
+        end
+      }
+    }
+    svo.dict.enduranceblessing = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.enduranceblessing and ((sys.deffing and defdefup[defs.mode].enduranceblessing) or (conf.keepup and defkeepup[defs.mode].enduranceblessing)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and bals.prayer == true and stats.currentmana &gt;= 750) or false
+        end,
+  
+        oncompleted = function() 
+          if conf.benediction then 
+            defences.got('frostblessing') defences.got('thermalblessing') defences.got('earthblessing') defences.got('willpowerblessing') defences.got('enduranceblessing') svo.lostbal_prayer()
+          else 
+            defences.got('enduranceblessing') svo.lostbal_prayer() 
+          end
+        end,
+  
+        action = "recite endurance me",
+        onstart = function() 
+          if conf.benediction then 
+            send('recite benediction me', conf.commandecho)
+          else 
+            send('recite endurance me', conf.commandecho) 
+          end
         end
       }
     }
   end
-  svo.dict.boundearth = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((((sys.deffing and defdefup[defs.mode].boundearth and not defc.boundearth) or (conf.keepup and defkeepup[defs.mode].boundearth and not defc.boundearth))) or (conf.keepup and defkeepup[defs.mode].boundearth and not defc.boundearth)) and not codepaste.balanceful_defs_codepaste() and defc.earth) or false
-      end,
-
-      oncompleted = function()
-        defences.got('boundearth')
-        if defc.boundair and defc.boundearth and defc.boundwater and not defc.boundspirit and (svo.haveskillset('weatherweaving') or defc.boundfire) then
-          defences.got('bindall')
+  
+  if svo.haveskillset('spirituality') then
+    svo.dict.mace = {
+      physical = {
+        unpauselater = false,
+        balanceful_act = true, -- it is balanceless, but this causes it to be bundled with a balanceful action - not desired
+        def = true,
+        undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].mace and not defc.mace) or (conf.keepup and defkeepup[defs.mode].mace and not defc.mace)) and not svo.doingaction('waitingformace') and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.waitingformace.waitingfor)
+        end,
+  
+        alreadyhave = function()
+          svo.dict.waitingformace.waitingfor.oncompleted()
+          send("wield mace", conf.commandecho)
+        end,
+  
+        action = "summon mace",
+        onstart = function()
+        -- user commands catching needs this check
+          if not (bals.balance and bals.equilibrium) then return end
+  
+          send("summon mace", conf.commandecho)
+  
+          if not conf.paused then
+            svo.dict.mace.physical.unpauselater = true
+            conf.paused = true; raiseEvent("svo config changed", 'paused')
+            echo"\n" svo.echof("Temporarily pausing to summon the mace.")
+          end
         end
-      end,
-
-      action = "bind earth",
-      onstart = function() send('bind earth', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('boundearth')
-        defences.lost('bindall')
-      end
+      },
+      gone = {
+        oncompleted = function() defences.lost('mace') end,
+      }
     }
-  }
-  svo.dict.fortifyall = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((((sys.deffing and defdefup[defs.mode].fortifyall and not defc.fortifyall) or (conf.keepup and defkeepup[defs.mode].fortifyall and not defc.fortifyall))) or (conf.keepup and defkeepup[defs.mode].fortifyall and not defc.fortifyall)) and not codepaste.balanceful_defs_codepaste() and stats.currentmana &gt;= 600 and defc.air and defc.earth and defc.water and not defc.spirit and (svo.haveskillset('weatherweaving') or defc.fire)) or false
-      end,
-
-      oncompleted = function() defences.got('fortifyall') end,
-
-      action = "fortify all",
-      onstart = function() send('fortify all', conf.commandecho) end
+    svo.dict.waitingformace = {
+      waitingfor = {
+        customwait = 3,
+  
+        oncompleted = function()
+          defences.got('mace')
+  
+          if conf.paused and svo.dict.mace.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+  
+            svo.echof("Obtained mace, unpausing.")
+          end
+          svo.dict.mace.physical.unpauselater = false
+        end,
+  
+        cancelled = function()
+          if conf.paused and svo.dict.mace.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            svo.echof("Oops, summoning interrupted. Unpausing.")
+          end
+          svo.dict.mace.physical.unpauselater = false
+        end,
+  
+        ontimeout = function()
+          if conf.paused and svo.dict.mace.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            svo.echof("Hm... doesn't seem the mace summon is happening. Going to try again.")
+          end
+          svo.dict.mace.physical.unpauselater = false
+        end,
+  
+        onstart = function() end
+      }
     }
-  }
-  svo.dict.fortifiedair = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((((sys.deffing and defdefup[defs.mode].fortifiedair and not defc.fortifiedair) or (conf.keepup and defkeepup[defs.mode].fortifiedair and not defc.fortifiedair))) or (conf.keepup and defkeepup[defs.mode].fortifiedair and not defc.fortifiedair)) and not codepaste.balanceful_defs_codepaste() and defc.air) or false
-      end,
-
-      oncompleted = function()
-        defences.got('fortifiedair')
-        if defc.fortifiedair and defc.fortifiedearth and defc.fortifiedwaterand and not defc.fortifiedspirit and (svo.haveskillset('weatherweaving') or defc.fortifiedfire) then
-          defences.got('fortifyall')
-        end
-      end,
-
-      action = "fortify air",
-      onstart = function() send('fortify air', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('fortifiedair')
-        defences.lost('fortifyall')
-      end
+    svo.dict.sacrifice = {
+      description = "tracks whenever you've sent the angel sacrifice command - so an illusion on angel sacrifice won't trick the system into clearing all affs",
+      physical = {
+        balanceless_act = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        oncompleted = function() end,
+  
+        action = "angel sacrifice",
+        onstart = function() send('angel sacrifice', conf.commandecho) end
+      }
     }
-  }
-  svo.dict.fortifiedwater = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((((sys.deffing and defdefup[defs.mode].fortifiedwater and not defc.fortifiedwater) or (conf.keepup and defkeepup[defs.mode].fortifiedwater and not defc.fortifiedwater))) or (conf.keepup and defkeepup[defs.mode].fortifiedwater and not defc.fortifiedwater)) and not codepaste.balanceful_defs_codepaste() and defc.water) or false
-      end,
-
-      oncompleted = function()
-        defences.got('fortifiedwater')
-        if defc.fortifiedair and defc.fortifiedearth and defc.fortifiedwater and not defc.fortifiedspirit and (svo.haveskillset('weatherweaving') or defc.fortifiedfire) then
-          defences.got('fortifyall')
-        end
-      end,
-
-      action = "fortify water",
-      onstart = function() send('fortify water', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('fortifiedwater')
-        defences.lost('fortifyall')
-      end
-    }
-  }
-  if not svo.haveskillset('weatherweaving') then
-    svo.dict.fortifiedfire = {
+    svo.dict.summon = {
       physical = {
         balanceful_act = true, def = true, undeffable = true,
-
+  
         isadvisable = function()
-          return (((((sys.deffing and defdefup[defs.mode].fortifiedfire and not defc.fortifiedfire) or (conf.keepup and defkeepup[defs.mode].fortifiedfire and not defc.fortifiedfire))) or (conf.keepup and defkeepup[defs.mode].fortifiedfire and not defc.fortifiedfire)) and not codepaste.balanceful_defs_codepaste() and defc.fire) or false
+          return (not defc.summon and ((sys.deffing and defdefup[defs.mode].summon) or (conf.keepup and defkeepup[defs.mode].summon)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
         end,
-
+  
+        oncompleted = function() defences.got('summon') end,
+  
+        action = "angel summon",
+        onstart = function() send('angel summon', conf.commandecho) end
+      }
+    }
+    svo.dict.empathy = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.empathy and ((sys.deffing and defdefup[defs.mode].empathy) or (conf.keepup and defkeepup[defs.mode].empathy)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and defc.summon) or false
+        end,
+  
+        oncompleted = function() defences.got('empathy') end,
+  
+        action = "angel empathy on",
+        onstart = function() send('angel empathy on', conf.commandecho) end
+      }
+    }
+    svo.dict.watch = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.watch and ((sys.deffing and defdefup[defs.mode].watch) or (conf.keepup and defkeepup[defs.mode].watch)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and defc.summon) or false
+        end,
+  
+        oncompleted = function() defences.got('watch') end,
+  
+        action = "angel watch on",
+        onstart = function() send('angel watch on', conf.commandecho) end
+      }
+    }
+    svo.dict.care = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.care and ((sys.deffing and defdefup[defs.mode].care) or (conf.keepup and defkeepup[defs.mode].care)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and defc.summon) or false
+        end,
+  
+        oncompleted = function() defences.got('care') end,
+  
+        action = "angel care on",
+        onstart = function() send('angel care on', conf.commandecho) end
+      }
+    }
+  end
+  
+  if svo.haveskillset('shindo') then
+    svo.dict.phoenix = {
+      description = "tracks whenever you've sent the shindo phoenix command - so an illusion on shindo phoenix won't trick the system into clearing all affs",
+      physical = {
+        balanceful_act = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        oncompleted = function() end,
+  
+        action = "shin phoenix",
+        onstart = function() send('shin phoenix', conf.commandecho) end
+      }
+    }
+  end
+  
+  if svo.haveskillset('twoarts') then
+    svo.dict.doya = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].doya and not defc.doya) or (conf.keepup and defkeepup[defs.mode].doya and not defc.doya)) and not defc.thyr and not defc.mir and not defc.arash and not defc.sanya and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
         oncompleted = function()
-          defences.got('fortifiedfire')
-          if defc.fortifiedair and defc.fortifiedfire and defc.fortifiedearth and defc.fortifiedwater and not defc.fortifiedspirit then
-            defences.got('fortifyall')
+          for _, stance in ipairs{'doya', 'thyr', 'mir', 'arash', 'sanya'} do
+            defences.lost(stance)
+          end
+  
+          defences.got('doya')
+        end,
+  
+        action = 'doya',
+        onstart = function() send('doya', conf.commandecho) end
+      },
+    }
+    svo.dict.thyr = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].thyr and not defc.thyr) or (conf.keepup and defkeepup[defs.mode].thyr)) and not defc.doya and not defc.thyr and not defc.mir and not defc.arash and not defc.sanya and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function()
+          for _, stance in ipairs{'doya', 'thyr', 'mir', 'arash', 'sanya'} do
+            defences.lost(stance)
+          end
+  
+          defences.got('thyr')
+        end,
+  
+        action = 'thyr',
+        onstart = function() send('thyr', conf.commandecho) end
+      },
+    }
+    svo.dict.mir = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].mir and not defc.mir) or (conf.keepup and defkeepup[defs.mode].mir)) and not defc.doya and not defc.thyr and not defc.mir and not defc.arash and not defc.sanya and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function()
+          for _, stance in ipairs{'doya', 'thyr', 'mir', 'arash', 'sanya'} do
+            defences.lost(stance)
+          end
+  
+          defences.got('mir')
+        end,
+  
+        action = 'mir',
+        onstart = function() send('mir', conf.commandecho) end
+      },
+    }
+    svo.dict.arash = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].arash and not defc.arash) or (conf.keepup and defkeepup[defs.mode].arash)) and not defc.doya and not defc.thyr and not defc.mir and not defc.arash and not defc.sanya and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function()
+          for _, stance in ipairs{'doya', 'thyr', 'mir', 'arash', 'sanya'} do
+            defences.lost(stance)
+          end
+  
+          defences.got('arash')
+        end,
+  
+        action = 'arash',
+        onstart = function() send('arash', conf.commandecho) end
+      },
+    }
+    svo.dict.sanya = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].sanya and not defc.sanya) or (conf.keepup and defkeepup[defs.mode].sanya)) and not defc.doya and not defc.thyr and not defc.mir and not defc.arash and not defc.sanya and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function()
+          for _, stance in ipairs{'doya', 'thyr', 'mir', 'arash', 'sanya'} do
+            defences.lost(stance)
+          end
+  
+          defences.got('sanya')
+        end,
+  
+        action = 'sanya',
+        onstart = function() send('sanya', conf.commandecho) end
+      },
+    }
+  end
+  
+  if svo.haveskillset('metamorphosis') then
+    svo.dict.affinity = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
+  
+        isadvisable = function()
+          return (not defc.affinity and ((sys.deffing and defdefup[defs.mode].affinity) or (conf.keepup and defkeepup[defs.mode].affinity)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not svo.doingaction('waitingformorph') and not affs.prone) or false
+        end,
+  
+        oncompleted = function() defences.got('affinity') end,
+  
+        action = "embrace spirit",
+        onstart = function()
+          if sk.inamorph() then
+            send("embrace spirit", conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+  
+            if sk.skillmorphs.wyvern then
+              send("morph wyvern", conf.commandecho)
+            else
+              send("morph "..sk.morphsforskill.nightsight[1], conf.commandecho)
+            end
+            if  not conf.truemorph then
+              svo.doaction(svo.dict.waitingformorph.waitingfor)
+            end
+          end
+        end
+      }
+    }
+    svo.dict.fitness = {
+      physical = {
+        balanceful_act = true,
+        undeffable = true, -- mark as undeffable since serverside can't morph
+  
+        isadvisable = function()
+          if not (not affs.weakness and not defc.dragonform and bals.fitness and not codepaste.balanceful_defs_codepaste() and (defc.wyvern or defc.wolf or defc.hyena or defc.jaguar or defc.cheetah or defc.elephant or defc.hydra) and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.fitness) then
+            return false
+          end
+  
+          for name, func in pairs(svo.fitness) do
+            if not me.disabledfitnessfunc[name] then
+              local s,m = pcall(func[1])
+              if s and m then return true end
+            end
           end
         end,
-
-        action = "fortify fire",
+  
+        oncompleted = function()
+          svo.rmaff('asthma')
+          svo.lostbal_fitness()
+        end,
+  
+        curedasthma = function() svo.rmaff('asthma') end,
+  
+        weakness = function()
+          svo.addaffdict(svo.dict.weakness)
+        end,
+  
+        allgood = function() svo.rmaff('asthma') end,
+  
+        actions = {'fitness'},
         onstart = function()
-          send("fortify fire", conf.commandecho)
+          if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'fitness' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          elseif not sk.inamorphfor'fitness' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph "..sk.morphsforskill.fitness[1], conf.commandecho)
+            if  not conf.truemorph then
+              svo.doaction(svo.dict.waitingformorph.waitingfor)
+            end
+          elseif sk.inamorphfor'fitness' then
+            send('fitness', conf.commandecho)
+          end
+        end
+      },
+    }
+    svo.dict.elusiveness = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
+  
+        isadvisable = function()
+          return (not defc.elusiveness and ((sys.deffing and defdefup[defs.mode].elusiveness) or (conf.keepup and defkeepup[defs.mode].elusiveness)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.elusiveness) or false
+        end,
+  
+        oncompleted = function() defences.got('elusiveness') end,
+  
+        action = "elusiveness on",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'elusiveness' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          elseif not sk.inamorphfor'elusiveness' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph "..sk.morphsforskill.elusiveness[1], conf.commandecho)
+            if  not conf.truemorph then
+              svo.doaction(svo.dict.waitingformorph.waitingfor)
+            end
+          elseif sk.inamorphfor'elusiveness' then
+            send("elusiveness on", conf.commandecho)
+          end
+        end
+      },
+    }
+    svo.dict.temperance = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
+  
+        isadvisable = function()
+          return (not defc.temperance and ((sys.deffing and defdefup[defs.mode].temperance) or (conf.keepup and defkeepup[defs.mode].temperance)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.temperance) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('temperance')
+          defences.got('frost')
+        end,
+  
+        action = 'temperance',
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'temperance' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          elseif not sk.inamorphfor'temperance' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph "..sk.morphsforskill.temperance[1], conf.commandecho)
+            if  not conf.truemorph then
+              svo.doaction(svo.dict.waitingformorph.waitingfor)
+            end
+          elseif sk.inamorphfor'temperance' then
+            send('temperance', conf.commandecho)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('frost') end
+      }
+    }
+    svo.dict.bonding = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
+  
+        isadvisable = function()
+          return (not defc.bonding and ((sys.deffing and defdefup[defs.mode].bonding) or (conf.keepup and defkeepup[defs.mode].bonding)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.inamorph()) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('bonding')
+        end,
+  
+        action = 'bond spirit',
+  
+        onstart = function() 
+  				if sk.inamorph() then
+  					send('bond spirit', conf.commandecho)
+  				else
+            if defc.flame then send("relax flame", conf.commandecho) end
+  
+            if sk.skillmorphs.wyvern then
+              send("morph wyvern", conf.commandecho)
+            else
+              send("morph "..sk.morphsforskill.nightsight[1], conf.commandecho)
+            end
+            if  not conf.truemorph then
+              svo.doaction(svo.dict.waitingformorph.waitingfor)
+            end
+          end
+  			end,
+  
+     		gone = {
+        	oncompleted = function() defences.lost('bonding') end
+      	}
+  		}
+    }
+    svo.dict.stealth = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
+  
+        isadvisable = function()
+          return (not defc.stealth and ((sys.deffing and defdefup[defs.mode].stealth) or (conf.keepup and defkeepup[defs.mode].stealth)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.stealth) or false
+        end,
+  
+        oncompleted = function() defences.got('stealth') end,
+  
+        action = "stealth on",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'stealth' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          elseif not sk.inamorphfor'stealth' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph "..sk.morphsforskill.stealth[1], conf.commandecho)
+            if  not conf.truemorph then
+              svo.doaction(svo.dict.waitingformorph.waitingfor)
+            end
+          elseif sk.inamorphfor'stealth' then
+            send("stealth on", conf.commandecho)
+          end
+        end
+      },
+    }
+    svo.dict.resistance = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
+  
+        isadvisable = function()
+          return (not defc.resistance and ((sys.deffing and defdefup[defs.mode].resistance) or (conf.keepup and defkeepup[defs.mode].resistance)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.resistance) or false
+        end,
+  
+        oncompleted = function() defences.got('resistance') end,
+  
+        action = 'resistance',
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'resistance' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          elseif not sk.inamorphfor'resistance' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph "..sk.morphsforskill.resistance[1], conf.commandecho)
+            if  not conf.truemorph then
+              svo.doaction(svo.dict.waitingformorph.waitingfor)
+            end
+          elseif sk.inamorphfor'resistance' then
+            send('resistance', conf.commandecho)
+          end
+        end
+      },
+    }
+    svo.dict.rest = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
+  
+        isadvisable = function()
+          return (not defc.rest and ((sys.deffing and defdefup[defs.mode].rest) or (conf.keepup and defkeepup[defs.mode].rest)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.rest) or false
+        end,
+  
+        oncompleted = function() defences.got('rest') end,
+  
+        action = 'rest',
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'rest' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          elseif not sk.inamorphfor'rest' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph "..sk.morphsforskill.rest[1], conf.commandecho)
+            if  not conf.truemorph then
+              svo.doaction(svo.dict.waitingformorph.waitingfor)
+            end
+          elseif sk.inamorphfor'rest' then
+            send('rest', conf.commandecho)
+          end
+        end
+      },
+    }
+    svo.dict.vitality = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
+  
+        isadvisable = function()
+          if (not defc.vitality and ((sys.deffing and defdefup[defs.mode].vitality) or (conf.keepup and defkeepup[defs.mode].vitality)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.vitality and not svo.doingaction'cantvitality') then
+  
+           if (stats.currenthealth &gt;= stats.maxhealth and stats.currentmana &gt;= stats.maxmana)
+            then
+              return true
+            elseif not sk.gettingfullstats then
+              svo.fullstats(true)
+              svo.echof("Getting fullstats for vitality now...")
+            end
+          end
+        end,
+  
+        oncompleted = function() defences.got('vitality') end,
+  
+        action = 'vitality',
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'vitality' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          elseif not sk.inamorphfor'vitality' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph "..sk.morphsforskill.vitality[1], conf.commandecho)
+            if  not conf.truemorph then
+              svo.doaction(svo.dict.waitingformorph.waitingfor)
+            end
+          elseif sk.inamorphfor'vitality' then
+            send('vitality', conf.commandecho)
+          end
         end
       },
       gone = {
         oncompleted = function()
-          defences.lost('fortifiedfire')
+          defences.lost('vitality')
+          if not svo.actions.cantvitality_waitingfor then svo.doaction(svo.dict.cantvitality.waitingfor) end
+        end
+      }
+    }
+    svo.dict.flame = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true, -- mark as undeffable since serverside can't morph
+  
+        isadvisable = function()
+          return (not defc.flame and ((sys.deffing and defdefup[defs.mode].flame) or (conf.keepup and defkeepup[defs.mode].flame)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and sk.morphsforskill.flame) or false
+        end,
+  
+        oncompleted = function() defences.got('flame') end,
+  
+        actions = {"summon flame", "summon fire", "ignite"},
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'flame' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          elseif not sk.inamorphfor'flame' then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph "..sk.morphsforskill.flame[1], conf.commandecho)
+            if  not conf.truemorph then
+              svo.doaction(svo.dict.waitingformorph.waitingfor)
+            end
+          elseif sk.inamorphfor'flame' then
+            send("summon flame", conf.commandecho)
+          end
+        end
+      },
+    }
+    svo.dict.waitingformorph = {
+  	unpauselater = false,
+  	waitingfor = {
+  		customwait = 4,
+  		
+  		oncompleted = function()
+  			if conf.paused and svo.dict.waitingformorph.unpauselater then
+  				conf.paused = false; raiseEvent("svo config changed", 'paused')
+  				echo"\n"
+  				svo.echof("Obtained morph, unpausing.")         
+  			end
+  			svo.dict.waitingformorph.unpauselater = false
+  		end,
+  		
+  		cancelled = function()
+  			if conf.paused and svo.dict.waitingformorph.unpauselater then
+  				conf.paused = false; raiseEvent("svo config changed", 'paused')
+  				echo"\n" svo.echof("Unpausing.")
+  			end
+  			svo.dict.waitingformorph.unpauselater = false
+  		
+  		end,
+  		
+  		ontimeout = function()
+  		 svo.dict.waitingformorph.waitingfor.cancelled()
+  		end,
+  		
+  		onstart = function()
+  			if not conf.truemorph then
+  				if not conf.paused then
+  					svo.dict.waitingformorph.unpauselater = true
+  					conf.paused = true; raiseEvent("svo config changed", 'paused')
+  					echo"\n" svo.echof("Temporarily pausing for morphing.")
+  				end
+  			else
+  				svo.dict.waitingformorph.oncompleted()
+  			end
+  		end,
+  	}
+    }
+    svo.dict.squirrel = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.squirrel and ((sys.deffing and defdefup[defs.mode].squirrel) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].squirrel)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('squirrel')
+        end,
+  
+        action = "morph squirrel",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph squirrel", conf.commandecho)
+          end 
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('squirrel') end,
+      }
+    }
+    svo.dict.wildcat = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.wildcat and ((sys.deffing and defdefup[defs.mode].wildcat) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].wildcat)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('wildcat')
+        end,
+  
+        action = "morph wildcat",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph wildcat", conf.commandecho)
+          end 
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('wildcat') end,
+      }
+    }
+    svo.dict.wolf = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.wolf and ((sys.deffing and defdefup[defs.mode].wolf) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].wolf)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('wolf')
+        end,
+  
+        action = "morph wolf",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph wolf", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('wolf') end,
+      }
+    }
+    svo.dict.turtle = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.turtle and ((sys.deffing and defdefup[defs.mode].turtle) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].turtle)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('turtle')
+        end,
+  
+        action = "morph turtle",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph turtle", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('turtle') end,
+      }
+    }
+    svo.dict.jackdaw = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.jackdaw and ((sys.deffing and defdefup[defs.mode].jackdaw) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].jackdaw)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('jackdaw')
+        end,
+  
+        action = "morph jackdaw",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph jackdaw", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('jackdaw') end,
+      }
+    }
+    svo.dict.cheetah = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.cheetah and ((sys.deffing and defdefup[defs.mode].cheetah) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].cheetah)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('cheetah')
+        end,
+  
+        action = "morph cheetah",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph cheetah", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('cheetah') end,
+      }
+    }
+    svo.dict.owl = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        
+        isadvisable = function()
+          return (not defc.owl and ((sys.deffing and defdefup[defs.mode].owl) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].owl)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('owl')
+        end,
+  
+        action = "morph owl",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph owl", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('owl') end,
+      }
+    }
+    svo.dict.hyena = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.hyena and ((sys.deffing and defdefup[defs.mode].hyena) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].hyena)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+            sk.clearmorphs()
+            defences.got('hyena')
+        end,
+  
+        action = "morph hyena",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph hyena", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+  		
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('hyena') end,
+      }
+    }
+    svo.dict.condor = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.condor and ((sys.deffing and defdefup[defs.mode].condor) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].condor)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('condor')
+        end,
+  
+        action = "morph condor",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph condor", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('condor') end,
+      }
+    }
+    svo.dict.gopher = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.gopher and ((sys.deffing and defdefup[defs.mode].gopher) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].gopher)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('gopher')
+        end,
+  
+        action = "morph gopher",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph gopher", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('gopher') end,
+      }
+    }
+    svo.dict.sloth = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.sloth and ((sys.deffing and defdefup[defs.mode].sloth) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].sloth)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('sloth')
+        end,
+  
+        action = "morph sloth",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph sloth", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('sloth') end,
+      }
+    }
+    svo.dict.bear = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.bear and ((sys.deffing and defdefup[defs.mode].bear) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].bear)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('bear')
+        end,
+  
+        action = "morph bear",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph bear", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('bear') end,
+      }
+    }
+    svo.dict.nightingale = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.nightingale and ((sys.deffing and defdefup[defs.mode].nightingale) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].nightingale)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('nightingale')
+        end,
+  
+        action = "morph nightingale",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph nightingale", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('nightingale') end,
+      }
+    }
+    svo.dict.elephant = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.elephant and ((sys.deffing and defdefup[defs.mode].elephant) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].elephant)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('elephant')
+        end,
+  
+        action = "morph elephant",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph elephant", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('elephant') end,
+      }
+    }
+    svo.dict.wolverine = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.wolverine and ((sys.deffing and defdefup[defs.mode].wolverine) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].wolverine)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('wolverine')
+        end,
+  
+        action = "morph wolverine",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph wolverine", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('wolverine') end,
+      }
+    }
+    svo.dict.eagle = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.eagle and ((sys.deffing and defdefup[defs.mode].eagle) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].eagle)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('eagle')
+        end,
+  
+        action = "morph eagle",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph eagle", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('eagle') end,
+      }
+    }
+    svo.dict.gorilla = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.gorilla and ((sys.deffing and defdefup[defs.mode].gorilla) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].gorilla)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('gorilla')
+        end,
+  
+        action = "morph gorilla",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph gorilla", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('gorilla') end,
+      }
+    }
+    svo.dict.icewyrm = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.icewyrm and ((sys.deffing and defdefup[defs.mode].icewyrm) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].icewyrm)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('icewyrm')
+        end,
+  
+        action = "morph icewyrm",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph icewyrm", conf.commandecho)
+          end
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('icewyrm') end,
+      }
+    }
+  end
+  
+  if svo.haveskillset('swashbuckling') then
+    svo.dict.drunkensailor = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return ((sys.deffing and defdefup[defs.mode].drunkensailor and not defc.drunkensailor) or (conf.keepup and defkeepup[defs.mode].drunkensailor and not defc.drunkensailor) and not defc.heartsfury and not svo.doingaction'drunkensailor' and not affs.paralysis) or false
+        end,
+  
+        oncompleted = function() defences.got('drunkensailor') end,
+  
+        action = 'drunkensailor',
+        onstart = function() send('drunkensailor', conf.commandecho) end
+      },
+    }
+    svo.dict.heartsfury = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return ((sys.deffing and defdefup[defs.mode].heartsfury and not defc.heartsfury) or (conf.keepup and defkeepup[defs.mode].heartsfury and not defc.heartsfury) and not defc.drunkensailor and not svo.doingaction'heartsfury' and not affs.paralysis) or false
+        end,
+  
+        oncompleted = function() defences.got('heartsfury') end,
+  
+        action = 'heartsfury',
+        onstart = function() send('heartsfury', conf.commandecho) end
+      },
+    }
+  end
+  
+  if svo.haveskillset('voicecraft') then
+    svo.dict.lay = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].lay and not defc.lay) or (conf.keepup and defkeepup[defs.mode].lay and not defc.lay)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'lay' and bals.voice) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('lay')
+          svo.lostbal_voice()
+        end,
+  
+        action = "sing lay",
+        onstart = function() send('sing lay', conf.commandecho) end
+      },
+    }
+    svo.dict.tune = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].tune and not defc.tune) or (conf.keepup and defkeepup[defs.mode].tune and not defc.tune)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'tune' and bals.voice) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('tune')
+          svo.lostbal_voice()
+        end,
+  
+        action = "sing tune",
+        onstart = function() send('sing tune', conf.commandecho) end
+      },
+    }
+    svo.dict.aria = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].aria and not defc.aria) or (conf.keepup and defkeepup[defs.mode].aria and not defc.aria)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'aria' and bals.voice) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('aria')
+          svo.lostbal_voice()
+        end,
+        applycure = {'epidermal'},
+        action = 'sing aria at me',
+        onstart = function()
+          if defc.deaf or affs.deafaff then svo.apply(svo.dict.aria.salve, ' to ears', conf.commandecho) end
+          send('sing aria at me', conf.commandecho)   
+        end
+      },
+    }
+  end
+  
+  if svo.haveskillset('occultism') then
+    svo.dict.astralform = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.astralform and ((sys.deffing and defdefup[defs.mode].astralform) or (conf.keepup and defkeepup[defs.mode].astralform)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('astralform')
+          defences.lost('riding')
+        end,
+  
+        action = 'astralform',
+        onstart = function() send('astralform', conf.commandecho) end
+      }
+    }
+  end
+  
+  if svo.haveskillset('elementalism') or svo.haveskillset('weatherweaving') then
+    svo.dict.simultaneity = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+         return (not defc.simultaneity and ((sys.deffing and defdefup[defs.mode].simultaneity) or (conf.keepup and defkeepup[defs.mode].simultaneity)) and not codepaste.balanceful_defs_codepaste() and stats.currentmana &gt;= 1000) or false
+        end,
+  
+        oncompleted = function() defences.got('simultaneity') end,
+  
+        action = 'simultaneity',
+        onstart = function() send('simultaneity', conf.commandecho) end
+      }
+    }
+    svo.dict.air = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+         return (not defc.air and ((sys.deffing and defdefup[defs.mode].air) or (conf.keepup and defkeepup[defs.mode].air)) and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('air')
+          if defc.air and defc.earth and defc.water and not defc.spirit
+          and (svo.haveskillset('weatherweaving') or defc.fire) then
+            defences.got('simultaneity')
+          end
+        end,
+  
+        action = "channel air",
+        onstart = function() send('channel air', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('air')
+          defences.lost('simultaneity')
+        end
+      }
+    }
+    svo.dict.water = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+         return (not defc.water and ((sys.deffing and defdefup[defs.mode].water) or (conf.keepup and defkeepup[defs.mode].water)) and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('water')
+          if defc.air and defc.earth and defc.water and not defc.spirit
+          and (svo.haveskillset('weatherweaving') or defc.fire) then
+            defences.got('simultaneity')
+          end
+        end,
+  
+        action = "channel water",
+        onstart = function() send('channel water', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('water')
+          defences.lost('simultaneity')
+        end
+      }
+    }
+    svo.dict.earth = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+         return (not defc.earth and ((sys.deffing and defdefup[defs.mode].earth) or (conf.keepup and defkeepup[defs.mode].earth)) and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('earth')
+          if defc.air and defc.earth and defc.water and not defc.spirit
+          and (svo.haveskillset('weatherweaving') or defc.fire) then
+            defences.got('simultaneity')
+          end
+        end,
+  
+        action = "channel earth",
+        onstart = function() send('channel earth', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('earth')
+          defences.lost('simultaneity')
+        end
+      }
+    }
+  if not svo.haveskillset('weatherweaving') then
+    svo.dict.fire = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+         return (not defc.fire and ((sys.deffing and defdefup[defs.mode].fire) or (conf.keepup and defkeepup[defs.mode].fire)) and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('fire')
+          if defc.air and defc.fire and defc.earth and defc.water and not defc.spirit then
+            defences.got('simultaneity')
+          end
+        end,
+  
+        action = "channel fire",
+        onstart = function() send('channel fire', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('fire')
+          defences.lost('simultaneity')
+        end
+      }
+    }
+  end
+    svo.dict.bindall = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((((sys.deffing and defdefup[defs.mode].bindall and not defc.bindall) or (conf.keepup and defkeepup[defs.mode].bindall and not defc.bindall))) or (conf.keepup and defkeepup[defs.mode].bindall and not defc.bindall)) and not codepaste.balanceful_defs_codepaste() and stats.currentmana &gt;= 750 and defc.air and defc.earth and defc.water and not defc.spirit
+          and (svo.haveskillset('weatherweaving') or defc.fire)) or false
+        end,
+  
+        oncompleted = function() defences.got('bindall') end,
+  
+        action = "bind all",
+        onstart = function() send('bind all', conf.commandecho) end
+      }
+    }
+    svo.dict.boundair = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((((sys.deffing and defdefup[defs.mode].boundair and not defc.boundair) or (conf.keepup and defkeepup[defs.mode].boundair and not defc.boundair))) or (conf.keepup and defkeepup[defs.mode].boundair and not defc.boundair)) and not codepaste.balanceful_defs_codepaste() and defc.air) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('boundair')
+          if defc.boundair and defc.boundearth and defc.boundwater and not defc.boundspirit and (svo.haveskillset('weatherweaving') or defc.boundfire) then
+            defences.got('bindall')
+          end
+        end,
+  
+        action = "bind air",
+        onstart = function() send('bind air', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('boundair')
+          defences.lost('bindall')
+        end
+      }
+    }
+    svo.dict.boundwater = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((((sys.deffing and defdefup[defs.mode].boundwater and not defc.boundwater) or (conf.keepup and defkeepup[defs.mode].boundwater and not defc.boundwater))) or (conf.keepup and defkeepup[defs.mode].boundwater and not defc.boundwater)) and not codepaste.balanceful_defs_codepaste() and defc.water) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('boundwater')
+          if defc.boundair and defc.boundearth and defc.boundwater and not defc.boundspirit and (svo.haveskillset('weatherweaving') or defc.boundfire) then
+            defences.got('bindall')
+          end
+        end,
+  
+        action = "bind water",
+        onstart = function() send('bind water', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('boundwater')
+          defences.lost('bindall')
+        end
+      }
+    }
+    if not svo.haveskillset('weatherweaving') then
+      svo.dict.boundfire = {
+        physical = {
+          balanceful_act = true, def = true, undeffable = true,
+  
+          isadvisable = function()
+            return (((((sys.deffing and defdefup[defs.mode].boundfire and not defc.boundfire) or (conf.keepup and defkeepup[defs.mode].boundfire and not defc.boundfire))) or (conf.keepup and defkeepup[defs.mode].boundfire and not defc.boundfire)) and not codepaste.balanceful_defs_codepaste() and defc.fire) or false
+          end,
+  
+          oncompleted = function()
+            defences.got('boundfire')
+            if defc.boundair and defc.boundfire and defc.boundearth and defc.boundwater and not defc.boundspirit then
+              defences.got('bindall')
+            end
+          end,
+  
+          action = "bind fire",
+          onstart = function()
+            send("bind fire", conf.commandecho)
+          end
+        },
+        gone = {
+          oncompleted = function()
+            defences.lost('boundfire')
+            defences.lost('bindall')
+          end
+        }
+      }
+    end
+    svo.dict.boundearth = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((((sys.deffing and defdefup[defs.mode].boundearth and not defc.boundearth) or (conf.keepup and defkeepup[defs.mode].boundearth and not defc.boundearth))) or (conf.keepup and defkeepup[defs.mode].boundearth and not defc.boundearth)) and not codepaste.balanceful_defs_codepaste() and defc.earth) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('boundearth')
+          if defc.boundair and defc.boundearth and defc.boundwater and not defc.boundspirit and (svo.haveskillset('weatherweaving') or defc.boundfire) then
+            defences.got('bindall')
+          end
+        end,
+  
+        action = "bind earth",
+        onstart = function() send('bind earth', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('boundearth')
+          defences.lost('bindall')
+        end
+      }
+    }
+    svo.dict.fortifyall = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((((sys.deffing and defdefup[defs.mode].fortifyall and not defc.fortifyall) or (conf.keepup and defkeepup[defs.mode].fortifyall and not defc.fortifyall))) or (conf.keepup and defkeepup[defs.mode].fortifyall and not defc.fortifyall)) and not codepaste.balanceful_defs_codepaste() and stats.currentmana &gt;= 600 and defc.air and defc.earth and defc.water and not defc.spirit and (svo.haveskillset('weatherweaving') or defc.fire)) or false
+        end,
+  
+        oncompleted = function() defences.got('fortifyall') end,
+  
+        action = "fortify all",
+        onstart = function() send('fortify all', conf.commandecho) end
+      }
+    }
+    svo.dict.fortifiedair = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((((sys.deffing and defdefup[defs.mode].fortifiedair and not defc.fortifiedair) or (conf.keepup and defkeepup[defs.mode].fortifiedair and not defc.fortifiedair))) or (conf.keepup and defkeepup[defs.mode].fortifiedair and not defc.fortifiedair)) and not codepaste.balanceful_defs_codepaste() and defc.air) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('fortifiedair')
+          if defc.fortifiedair and defc.fortifiedearth and defc.fortifiedwaterand and not defc.fortifiedspirit and (svo.haveskillset('weatherweaving') or defc.fortifiedfire) then
+            defences.got('fortifyall')
+          end
+        end,
+  
+        action = "fortify air",
+        onstart = function() send('fortify air', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('fortifiedair')
+          defences.lost('fortifyall')
+        end
+      }
+    }
+    svo.dict.fortifiedwater = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((((sys.deffing and defdefup[defs.mode].fortifiedwater and not defc.fortifiedwater) or (conf.keepup and defkeepup[defs.mode].fortifiedwater and not defc.fortifiedwater))) or (conf.keepup and defkeepup[defs.mode].fortifiedwater and not defc.fortifiedwater)) and not codepaste.balanceful_defs_codepaste() and defc.water) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('fortifiedwater')
+          if defc.fortifiedair and defc.fortifiedearth and defc.fortifiedwater and not defc.fortifiedspirit and (svo.haveskillset('weatherweaving') or defc.fortifiedfire) then
+            defences.got('fortifyall')
+          end
+        end,
+  
+        action = "fortify water",
+        onstart = function() send('fortify water', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('fortifiedwater')
+          defences.lost('fortifyall')
+        end
+      }
+    }
+    if not svo.haveskillset('weatherweaving') then
+      svo.dict.fortifiedfire = {
+        physical = {
+          balanceful_act = true, def = true, undeffable = true,
+  
+          isadvisable = function()
+            return (((((sys.deffing and defdefup[defs.mode].fortifiedfire and not defc.fortifiedfire) or (conf.keepup and defkeepup[defs.mode].fortifiedfire and not defc.fortifiedfire))) or (conf.keepup and defkeepup[defs.mode].fortifiedfire and not defc.fortifiedfire)) and not codepaste.balanceful_defs_codepaste() and defc.fire) or false
+          end,
+  
+          oncompleted = function()
+            defences.got('fortifiedfire')
+            if defc.fortifiedair and defc.fortifiedfire and defc.fortifiedearth and defc.fortifiedwater and not defc.fortifiedspirit then
+              defences.got('fortifyall')
+            end
+          end,
+  
+          action = "fortify fire",
+          onstart = function()
+            send("fortify fire", conf.commandecho)
+          end
+        },
+        gone = {
+          oncompleted = function()
+            defences.lost('fortifiedfire')
+            defences.lost('fortifyall')
+          end
+        }
+      }
+    end
+    svo.dict.fortifiedearth = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((((sys.deffing and defdefup[defs.mode].fortifiedearth and not defc.fortifiedearth) or (conf.keepup and defkeepup[defs.mode].fortifiedearth and not defc.fortifiedearth))) or (conf.keepup and defkeepup[defs.mode].fortifiedearth and not defc.fortifiedearth)) and not codepaste.balanceful_defs_codepaste() and defc.earth) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('fortifiedearth')
+          if defc.fortifiedair and defc.fortifiedearth and defc.fortifiedwater and not defc.fortifiedspirit and (svo.haveskillset('weatherweaving') or defc.fortifiedfire) then
+            defences.got('fortifyall')
+          end
+        end,
+  
+        action = "fortify earth",
+        onstart = function() send('fortify earth', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('fortifiedearth')
           defences.lost('fortifyall')
         end
       }
     }
   end
-  svo.dict.fortifiedearth = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((((sys.deffing and defdefup[defs.mode].fortifiedearth and not defc.fortifiedearth) or (conf.keepup and defkeepup[defs.mode].fortifiedearth and not defc.fortifiedearth))) or (conf.keepup and defkeepup[defs.mode].fortifiedearth and not defc.fortifiedearth)) and not codepaste.balanceful_defs_codepaste() and defc.earth) or false
-      end,
-
-      oncompleted = function()
-        defences.got('fortifiedearth')
-        if defc.fortifiedair and defc.fortifiedearth and defc.fortifiedwater and not defc.fortifiedspirit and (svo.haveskillset('weatherweaving') or defc.fortifiedfire) then
-          defences.got('fortifyall')
+  
+  if svo.haveskillset('elementalism') then
+    svo.dict.waterweird = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+         return (not defc.waterweird and ((sys.deffing and defdefup[defs.mode].waterweird) or (conf.keepup and defkeepup[defs.mode].waterweird)) and not codepaste.balanceful_defs_codepaste() and defc.water) or false
+        end,
+  
+        oncompleted = function() defences.got('waterweird') end,
+  
+        action = "cast waterweird at me",
+        onstart = function() send('cast waterweird at me', conf.commandecho) end
+      }
+    }
+    svo.dict.chargeshield = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.chargeshield and ((sys.deffing and defdefup[defs.mode].chargeshield) or (conf.keepup and defkeepup[defs.mode].chargeshield)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone and defc.air) or false
+        end,
+  
+        oncompleted = function() defences.got('chargeshield') end,
+  
+        action = "cast chargeshield at me",
+        onstart = function() send('cast chargeshield at me', conf.commandecho) end
+      }
+    }
+    svo.dict.stonefist = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+         return (not defc.stonefist and ((sys.deffing and defdefup[defs.mode].stonefist) or (conf.keepup and defkeepup[defs.mode].stonefist)) and not codepaste.balanceful_defs_codepaste() and defc.earth) or false
+        end,
+  
+        oncompleted = function() defences.got('stonefist') end,
+  
+        action = "cast stonefist",
+        onstart = function() send('cast stonefist', conf.commandecho) end
+      }
+    }
+    svo.dict.stoneskin = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+         return (not defc.stoneskin and ((sys.deffing and defdefup[defs.mode].stoneskin) or (conf.keepup and defkeepup[defs.mode].stoneskin)) and not codepaste.balanceful_defs_codepaste() and defc.earth) or false
+        end,
+  
+        oncompleted = function() defences.got('stoneskin') end,
+  
+        action = "cast stoneskin",
+        onstart = function() send('cast stoneskin', conf.commandecho) end
+      }
+    }
+    svo.dict.diamondskin = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+         return (not defc.diamondskin and ((sys.deffing and defdefup[defs.mode].diamondskin) or (conf.keepup and defkeepup[defs.mode].diamondskin)) and not codepaste.balanceful_defs_codepaste() and defc.earth and defc.water and defc.fire) or false
+        end,
+  
+        oncompleted = function() defences.got('diamondskin') end,
+  
+        action = "cast diamondskin",
+        onstart = function() send('cast diamondskin', conf.commandecho) end
+      }
+    }
+  end
+  if svo.haveskillset('elementalism') or svo.haveskillset('weatherweaving') then
+    svo.dict.reflection = {
+      gamename = 'reflections',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+         return (not defc.reflection and ((sys.deffing and defdefup[defs.mode].reflection) or (conf.keepup and defkeepup[defs.mode].reflection)) and not codepaste.balanceful_defs_codepaste() and defc.air and not affs.prone) or false
+        end,
+  
+        oncompleted = function() defences.got('reflection') end,
+  
+        action = "cast reflection at me",
+        onstart = function() send('cast reflection at me', conf.commandecho) end
+      }
+    }
+  end
+  
+  if svo.haveskillset('apostasy') then
+    svo.dict.baalzadeen = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.baalzadeen and ((sys.deffing and defdefup[defs.mode].baalzadeen) or (conf.keepup and defkeepup[defs.mode].baalzadeen)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
+  
+        end,
+  
+        oncompleted = function() defences.got('baalzadeen') end,
+  
+        action = "summon baalzadeen",
+        onstart = function() send('summon baalzadeen', conf.commandecho) end
+      }
+    }
+    svo.dict.armour = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.armour and ((sys.deffing and defdefup[defs.mode].armour) or (conf.keepup and defkeepup[defs.mode].armour)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone and defc.baalzadeen) or false
+        end,
+  
+        oncompleted = function() defences.got('armour') end,
+  
+        action = "demon armour",
+        onstart = function() send('demon armour', conf.commandecho) end
+      }
+    }
+    svo.dict.syphon = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.syphon and ((sys.deffing and defdefup[defs.mode].syphon) or (conf.keepup and defkeepup[defs.mode].syphon)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone and defc.baalzadeen) or false
+        end,
+  
+        oncompleted = function() defences.got('syphon') end,
+  
+        action = "demon syphon",
+        onstart = function() send('demon syphon', conf.commandecho) end
+      }
+    }
+    svo.dict.mask = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.mask and ((sys.deffing and defdefup[defs.mode].mask) or (conf.keepup and defkeepup[defs.mode].mask)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone and defc.baalzadeen) or false
+        end,
+  
+        oncompleted = function() defences.got('mask') end,
+  
+        action = 'mask',
+        onstart = function() send('mask', conf.commandecho) end
+      }
+    }
+  end
+  
+  if svo.haveskillset('weatherweaving') then
+    svo.dict.circulate = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+         return (not defc.circulate and ((sys.deffing and defdefup[defs.mode].circulate) or (conf.keepup and defkeepup[defs.mode].circulate)) and not codepaste.balanceful_defs_codepaste() and defc.air and defc.earth) or false
+        end,
+  
+        oncompleted = function() defences.got('circulate') end,
+  
+        action = "cast circulate",
+        onstart = function() send('cast circulate', conf.commandecho) end
+      }
+    }
+  end
+  
+  
+  
+  
+  
+  
+  if svo.haveskillset('kaido') then
+    svo.dict.boosting = {
+      gamename = 'boostedregeneration',
+      physical = {
+        balanceless_act = true, def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].boosting and not defc.boosting) or (conf.keepup and defkeepup[defs.mode].boosting and not defc.boosting)) and not codepaste.balanceful_defs_codepaste() and defc.regeneration) or false
+        end,
+  
+        oncompleted = function() defences.got('boosting') end,
+  
+        action = "boost regeneration",
+        onstart = function() send('boost regeneration', conf.commandecho) end
+      }
+    }
+    svo.dict.kaiboost = {
+      physical = {
+        balanceless_act = true, def = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].kaiboost and not defc.kaiboost) or (conf.keepup and defkeepup[defs.mode].kaiboost and not defc.kaiboost)) and not codepaste.balanceful_defs_codepaste() and stats.kai &gt;= 11 and not svo.doingaction'kaiboost') or false
+        end,
+  
+        oncompleted = function() defences.got('kaiboost') end,
+  
+        action = "kai boost",
+        onstart = function() send('kai boost', conf.commandecho) end
+      }
+    }
+    svo.dict.vitality = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          if (not defc.vitality and not defc.numb and ((sys.deffing and defdefup[defs.mode].vitality) or (conf.keepup and defkeepup[defs.mode].vitality)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'cantvitality') then
+  
+            if (stats.currenthealth &gt;= stats.maxhealth and stats.currentmana &gt;= stats.maxmana) then
+              return true
+            elseif not sk.gettingfullstats then
+              svo.fullstats(true, false, true)
+              svo.echof("Getting fullstats for vitality now...")
+            end
+          end
+        end,
+  
+        oncompleted = function() defences.got('vitality') end,
+  
+        action = 'vitality',
+        onstart = function() send('vitality', conf.commandecho) end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('vitality')
+          if not svo.actions.cantvitality_waitingfor then svo.doaction(svo.dict.cantvitality.waitingfor) end
         end
-      end,
-
-      action = "fortify earth",
-      onstart = function() send('fortify earth', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('fortifiedearth')
-        defences.lost('fortifyall')
-      end
+      }
     }
-  }
-end
-
-if svo.haveskillset('elementalism') then
-  svo.dict.waterweird = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-       return (not defc.waterweird and ((sys.deffing and defdefup[defs.mode].waterweird) or (conf.keepup and defkeepup[defs.mode].waterweird)) and not codepaste.balanceful_defs_codepaste() and defc.water) or false
-      end,
-
-      oncompleted = function() defences.got('waterweird') end,
-
-      action = "cast waterweird at me",
-      onstart = function() send('cast waterweird at me', conf.commandecho) end
+  end
+  
+  
+  
+  if svo.haveskillset('tarot') then
+    svo.dict.devil = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.devil and ((sys.deffing and defdefup[defs.mode].devil) or (conf.keepup and defkeepup[defs.mode].devil)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
+        end,
+  
+        oncompleted = function() defences.got('devil') end,
+  
+        action = "fling devil at ground",
+        onstart = function()
+          sendAll("outd 1 devil","fling devil at ground","ind 1 devil", conf.commandecho)
+        end
+      }
     }
-  }
-  svo.dict.chargeshield = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.chargeshield and ((sys.deffing and defdefup[defs.mode].chargeshield) or (conf.keepup and defkeepup[defs.mode].chargeshield)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone and defc.air) or false
-      end,
-
-      oncompleted = function() defences.got('chargeshield') end,
-
-      action = "cast chargeshield at me",
-      onstart = function() send('cast chargeshield at me', conf.commandecho) end
+  end
+  
+  if svo.haveskillset('shikudo') then
+    svo.dict.grip = {
+      gamename = 'gripping',
+      physical = {
+        balanceless_act = true, def = true,
+        action = 'grip',
+  
+        isadvisable = function()
+          return (
+            not defc.grip
+            and (
+              (sys.deffing and defdefup[defs.mode].grip)
+              or (conf.keepup and defkeepup[defs.mode].grip)
+            )
+            and me.path == 'shikudo'
+            and not codepaste.balanceful_defs_codepaste()
+            and sys.canoutr
+            and not affs.paralysis
+            and not affs.prone
+          ) or false
+        end,
+  
+        oncompleted = function() defences.got('grip') end,
+  
+        onstart = function() send('grip', conf.commandecho) end
+      }
     }
-  }
-  svo.dict.stonefist = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-       return (not defc.stonefist and ((sys.deffing and defdefup[defs.mode].stonefist) or (conf.keepup and defkeepup[defs.mode].stonefist)) and not codepaste.balanceful_defs_codepaste() and defc.earth) or false
-      end,
-
-      oncompleted = function() defences.got('stonefist') end,
-
-      action = "cast stonefist",
-      onstart = function() send('cast stonefist', conf.commandecho) end
+    svo.dict.tykonos = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = "adopt tykonos form",
+        isadvisable = function() return shikudo_ability_isadvisable('tykonos') end,
+        oncompleted = function() return shikudo_form_oncompleted('tykonos') end,
+  
+        onstart = function() send('adopt tykonos form', conf.commandecho) end
+      },
     }
-  }
-  svo.dict.stoneskin = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-       return (not defc.stoneskin and ((sys.deffing and defdefup[defs.mode].stoneskin) or (conf.keepup and defkeepup[defs.mode].stoneskin)) and not codepaste.balanceful_defs_codepaste() and defc.earth) or false
-      end,
-
-      oncompleted = function() defences.got('stoneskin') end,
-
-      action = "cast stoneskin",
-      onstart = function() send('cast stoneskin', conf.commandecho) end
+    svo.dict.willow = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = "adopt willow form",
+        isadvisable = function() return shikudo_ability_isadvisable('willow') end,
+        oncompleted = function() return shikudo_form_oncompleted('willow') end,
+  
+        onstart = function() send('adopt willow form', conf.commandecho) end
+      },
     }
-  }
-  svo.dict.diamondskin = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-       return (not defc.diamondskin and ((sys.deffing and defdefup[defs.mode].diamondskin) or (conf.keepup and defkeepup[defs.mode].diamondskin)) and not codepaste.balanceful_defs_codepaste() and defc.earth and defc.water and defc.fire) or false
-      end,
-
-      oncompleted = function() defences.got('diamondskin') end,
-
-      action = "cast diamondskin",
-      onstart = function() send('cast diamondskin', conf.commandecho) end
+    svo.dict.rain = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = "adopt rain form",
+        isadvisable = function() return shikudo_ability_isadvisable('rain') end,
+        oncompleted = function() return shikudo_form_oncompleted('rain') end,
+  
+        onstart = function() send('adopt rain form', conf.commandecho) end
+      },
     }
-  }
-end
-if svo.haveskillset('elementalism') or svo.haveskillset('weatherweaving') then
-  svo.dict.reflection = {
-    gamename = 'reflections',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-       return (not defc.reflection and ((sys.deffing and defdefup[defs.mode].reflection) or (conf.keepup and defkeepup[defs.mode].reflection)) and not codepaste.balanceful_defs_codepaste() and defc.air and not affs.prone) or false
-      end,
-
-      oncompleted = function() defences.got('reflection') end,
-
-      action = "cast reflection at me",
-      onstart = function() send('cast reflection at me', conf.commandecho) end
+    svo.dict.oak = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = "adopt oak form",
+        isadvisable = function() return shikudo_ability_isadvisable('oak') end,
+        oncompleted = function() return shikudo_form_oncompleted('oak') end,
+  
+        onstart = function() send('adopt oak form', conf.commandecho) end
+      },
     }
-  }
-end
-
-if svo.haveskillset('apostasy') then
-  svo.dict.baalzadeen = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.baalzadeen and ((sys.deffing and defdefup[defs.mode].baalzadeen) or (conf.keepup and defkeepup[defs.mode].baalzadeen)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
-
-      end,
-
-      oncompleted = function() defences.got('baalzadeen') end,
-
-      action = "summon baalzadeen",
-      onstart = function() send('summon baalzadeen', conf.commandecho) end
+    svo.dict.gaital = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = "adopt gaital form",
+        isadvisable = function() return shikudo_ability_isadvisable('gaital') end,
+        oncompleted = function() return shikudo_form_oncompleted('gaital') end,
+  
+        onstart = function() send('adopt gaital form', conf.commandecho) end
+      },
     }
-  }
-  svo.dict.armour = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.armour and ((sys.deffing and defdefup[defs.mode].armour) or (conf.keepup and defkeepup[defs.mode].armour)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone and defc.baalzadeen) or false
-      end,
-
-      oncompleted = function() defences.got('armour') end,
-
-      action = "demon armour",
-      onstart = function() send('demon armour', conf.commandecho) end
+    svo.dict.maelstrom = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = "adopt maelstrom form",
+        isadvisable = function() return shikudo_ability_isadvisable('maelstrom') end,
+        oncompleted = function() return shikudo_form_oncompleted('maelstrom') end,
+  
+        onstart = function() send('adopt maelstrom form', conf.commandecho) end
+      },
     }
-  }
-  svo.dict.syphon = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.syphon and ((sys.deffing and defdefup[defs.mode].syphon) or (conf.keepup and defkeepup[defs.mode].syphon)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone and defc.baalzadeen) or false
-      end,
-
-      oncompleted = function() defences.got('syphon') end,
-
-      action = "demon syphon",
-      onstart = function() send('demon syphon', conf.commandecho) end
+  end
+  
+  if svo.haveskillset('tekura') then
+    svo.dict.bodyblock = {
+      physical = {
+        balanceful_act = true, def = true,
+        isadvisable = function() return tekura_ability_isadvisable('bodyblock') end,
+        action = 'bdb',
+  
+        oncompleted = function() defences.got('bodyblock') end,
+  
+        onstart = function() send('bdb', conf.commandecho) end
+      },
     }
-  }
-  svo.dict.mask = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.mask and ((sys.deffing and defdefup[defs.mode].mask) or (conf.keepup and defkeepup[defs.mode].mask)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone and defc.baalzadeen) or false
-      end,
-
-      oncompleted = function() defences.got('mask') end,
-
-      action = 'mask',
-      onstart = function() send('mask', conf.commandecho) end
+    svo.dict.evadeblock = {
+      physical = {
+        balanceful_act = true, def = true,
+        action = 'evb',
+        isadvisable = function() return tekura_ability_isadvisable('evadeblock') end,
+  
+        oncompleted = function() defences.got('evadeblock') end,
+  
+        onstart = function() send('evb', conf.commandecho) end
+      },
     }
-  }
-end
-
-if svo.haveskillset('weatherweaving') then
-  svo.dict.circulate = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-       return (not defc.circulate and ((sys.deffing and defdefup[defs.mode].circulate) or (conf.keepup and defkeepup[defs.mode].circulate)) and not codepaste.balanceful_defs_codepaste() and defc.air and defc.earth) or false
-      end,
-
-      oncompleted = function() defences.got('circulate') end,
-
-      action = "cast circulate",
-      onstart = function() send('cast circulate', conf.commandecho) end
+    svo.dict.pinchblock = {
+      physical = {
+        balanceful_act = true, def = true,
+        action = 'pnb',
+        isadvisable = function() return tekura_ability_isadvisable('pinchblock') end,
+  
+        oncompleted = function() defences.got('pinchblock') end,
+  
+        onstart = function() send('pnb', conf.commandecho) end
+      },
     }
-  }
-end
-
-
-
-
-
-
-if svo.haveskillset('kaido') then
-  svo.dict.boosting = {
-    gamename = 'boostedregeneration',
-    physical = {
-      balanceless_act = true, def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].boosting and not defc.boosting) or (conf.keepup and defkeepup[defs.mode].boosting and not defc.boosting)) and not codepaste.balanceful_defs_codepaste() and defc.regeneration) or false
-      end,
-
-      oncompleted = function() defences.got('boosting') end,
-
-      action = "boost regeneration",
-      onstart = function() send('boost regeneration', conf.commandecho) end
+    svo.dict.horse = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = 'hrs',
+        isadvisable = function() return tekura_ability_isadvisable('horse') end,
+        oncompleted = function() return tekura_stance_oncompleted('horse') end,
+  
+        onstart = function() send('hrs', conf.commandecho) end
+      },
     }
-  }
-  svo.dict.kaiboost = {
-    physical = {
-      balanceless_act = true, def = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].kaiboost and not defc.kaiboost) or (conf.keepup and defkeepup[defs.mode].kaiboost and not defc.kaiboost)) and not codepaste.balanceful_defs_codepaste() and stats.kai &gt;= 11 and not svo.doingaction'kaiboost') or false
-      end,
-
-      oncompleted = function() defences.got('kaiboost') end,
-
-      action = "kai boost",
-      onstart = function() send('kai boost', conf.commandecho) end
+    svo.dict.eagle = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = 'egs',
+        isadvisable = function() return tekura_ability_isadvisable('eagle') end,
+        oncompleted = function() return tekura_stance_oncompleted('eagle') end,
+  
+        onstart = function() send('egs', conf.commandecho) end
+      },
     }
-  }
-  svo.dict.vitality = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        if (not defc.vitality and not defc.numb and ((sys.deffing and defdefup[defs.mode].vitality) or (conf.keepup and defkeepup[defs.mode].vitality)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'cantvitality') then
-
-          if (stats.currenthealth &gt;= stats.maxhealth and stats.currentmana &gt;= stats.maxmana) then
-            return true
-          elseif not sk.gettingfullstats then
-            svo.fullstats(true, false, true)
-            svo.echof("Getting fullstats for vitality now...")
+    svo.dict.cat = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = 'cts',
+        isadvisable = function() return tekura_ability_isadvisable('cat') end,
+        oncompleted = function() return tekura_stance_oncompleted('cat') end,
+  
+        onstart = function() send('cts', conf.commandecho) end
+      },
+    }
+    svo.dict.bear = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = 'brs',
+        isadvisable = function() return tekura_ability_isadvisable('bear') end,
+        oncompleted = function() return tekura_stance_oncompleted('bear') end,
+  
+        onstart = function() send('brs', conf.commandecho) end
+      },
+    }
+    svo.dict.rat = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = 'rts',
+        isadvisable = function() return tekura_ability_isadvisable('rat') end,
+        oncompleted = function() return tekura_stance_oncompleted('rat') end,
+  
+        onstart = function() send('rts', conf.commandecho) end
+      },
+    }
+    svo.dict.scorpion = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = 'scs',
+        isadvisable = function() return tekura_ability_isadvisable('scorpion') end,
+        oncompleted = function() return tekura_stance_oncompleted('scorpion') end,
+  
+        onstart = function() send('scs', conf.commandecho) end
+      },
+    }
+    svo.dict.dragon = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        action = 'drs',
+        isadvisable = function() return tekura_ability_isadvisable('dragon') end,
+        oncompleted = function() return tekura_stance_oncompleted('dragon') end,
+  
+        onstart = function() send('drs', conf.commandecho) end
+      },
+    }
+  end
+  
+  
+  
+  if svo.haveskillset('venom') then
+    svo.dict.shrugging = {
+      physical = {
+        balanceless_act = true,
+  
+        isadvisable = function()
+          if not next(affs) or not bals.shrugging or affs.sleep or not conf.shrugging or affs.stun or affs.unconsciousness or affs.weakness or codepaste.nonstdcure() or defc.dragonform then return false end
+  
+          for name, func in pairs(svo.shrugging) do
+            if not me.disabledshruggingfunc[name] then
+              local s,m = pcall(func[1])
+              if s and m then return true end
+            end
+          end
+        end,
+  
+        oncompleted = function (number)
+          if number then
+            -- empty
+            if number+1 == getLineNumber() then
+              empty.shrugging()
+            end
+          end
+          signals.after_lifevision_processing:unblock(cnrl.checkwarning)
+  
+          svo.lostbal_shrugging()
+        end,
+  
+        action = 'shrugging',
+  			onstart = function()
+  				if svo.conf.serverside then
+  				  send('curing queue add shrugging', conf.commandecho) 
+  				else
+        		send('shrugging', conf.commandecho) 
+  				end
+  			end,
+  
+        offbal = function() svo.lostbal_shrugging() end
+      }
+    }
+  end
+  
+  if svo.haveskillset('alchemy') then
+    svo.dict.extispicy = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.extispicy and ((sys.deffing and defdefup[defs.mode].extispicy) or (conf.keepup and defkeepup[defs.mode].extispicy)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
+        end,
+  
+        oncompleted = function() defences.got('extispicy') end,
+  
+        norat = function()
+          if svo.ignore.extispicy then return end
+  
+          svo.ignore.extispicy = true
+  
+          if sys.deffing then
+            echo'\n' svo.echof("Looks like we have no rat - going to skip extispicy in this defup.")
+  
+            signals.donedefup:connect(function()
+              svo.ignore.extispicy = nil
+            end, "donedefup ignore extispicy")
+          else
+            echo'\n' svo.echof("Looks like we have no rat for keepup - placing extispicy on ignore.")
+          end
+        end,
+  
+        action = "dissect rat",
+        onstart = function() send('dissect rat', conf.commandecho) end
+      }
+    }
+  end
+  
+  if svo.haveskillset('skirmishing') then
+    svo.dict.spinning = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].spinning and not defc.spinning) or (conf.keepup and defkeepup[defs.mode].spinning and not defc.spinning)) and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function() defences.got('spinning') end,
+  
+        actions = {"spin trident", "spin spear"},
+  
+        onstart = function()
+          send("spin "..conf.weapon, conf.commandecho)
+        end
+      }
+    }
+  end
+  
+  if svo.haveskillset('propagation') then
+    svo.dict.barkskin = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+         return (not defc.barkskin and ((sys.deffing and defdefup[defs.mode].barkskin) or (conf.keepup and defkeepup[defs.mode].barkskin)) and not codepaste.balanceful_defs_codepaste() and defc.earth) or false
+        end,
+  
+        oncompleted = function() defences.got('barkskin') end,
+  
+        action = 'barkskin',
+        onstart = function() send('barkskin', conf.commandecho) end
+      }
+    }
+    svo.dict.viridian = {
+      physical = {
+        unpauselater = false,
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].viridian and not defc.viridian) or (conf.keepup and defkeepup[defs.mode].viridian and not defc.viridian)) and not svo.doingaction('waitingforviridian') and not codepaste.balanceful_defs_codepaste()) or false
+        end,
+  
+        oncompleted = function (def)
+          if def and not defc.viridian then defences.got('viridian')
+          else svo.doaction(svo.dict.waitingforviridian.waitingfor) end
+        end,
+  
+        alreadyhave = function()
+          svo.dict.waitingforviridian.waitingfor.oncompleted()
+        end,
+  
+        indoors = function()
+          if conf.paused and svo.dict.viridian.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            echo"\n" svo.echof("Unpaused - you must be outside to cast Viridian.")
+          end
+          svo.dict.viridian.physical.unpauselater = false
+          defences.got('viridian')
+        end,
+  
+        notonland = function()
+          if conf.paused and svo.dict.viridian.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            echo"\n" svo.echof("You must be in contact with the earth in order to call upon the might of the Viridian.")
+          end
+          svo.dict.viridian.physical.unpauselater = false
+          defences.got('viridian')
+        end,
+  
+        actions = {"assume viridian", "assume viridian staff"},
+        onstart = function()
+          if defc.flail then
+            send("assume viridian staff", conf.commandecho)
+          else
+            send("assume viridian", conf.commandecho)
+          end
+  
+          if not conf.paused then
+            svo.dict.viridian.physical.unpauselater = true
+            conf.paused = true; raiseEvent("svo config changed", 'paused')
+            echo"\n" svo.echof("Temporarily pausing for viridian.")
           end
         end
-      end,
-
-      oncompleted = function() defences.got('vitality') end,
-
-      action = 'vitality',
-      onstart = function() send('vitality', conf.commandecho) end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('vitality')
-        if not svo.actions.cantvitality_waitingfor then svo.doaction(svo.dict.cantvitality.waitingfor) end
-      end
+      },
+      gone = {
+        oncompleted = function() defences.lost('viridian') end,
+      }
     }
-  }
-end
-
-
-
-if svo.haveskillset('tarot') then
-  svo.dict.devil = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.devil and ((sys.deffing and defdefup[defs.mode].devil) or (conf.keepup and defkeepup[defs.mode].devil)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
-      end,
-
-      oncompleted = function() defences.got('devil') end,
-
-      action = "fling devil at ground",
-      onstart = function()
-        sendAll("outd 1 devil","fling devil at ground","ind 1 devil", conf.commandecho)
-      end
+    svo.dict.waitingforviridian = {
+      waitingfor = {
+        customwait = 20,
+  
+        oncompleted = function()
+          defences.got('viridian')
+          svo.dict.riding.gone.oncompleted()
+  
+          if conf.paused and svo.dict.viridian.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+  
+            echo"\n"
+            svo.echof("Obtained viridian, unpausing.")
+          end
+          svo.dict.viridian.physical.unpauselater = false
+        end,
+  
+        cancelled = function()
+          if conf.paused and svo.dict.viridian.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            echo"\n" svo.echof("Unpausing.")
+          end
+          svo.dict.viridian.physical.unpauselater = false
+        end,
+  
+        ontimeout = function()
+          svo.dict.waitingforviridian.waitingfor.cancelled()
+        end,
+  
+        onstart = function() end,
+      }
     }
-  }
-end
-
-if svo.haveskillset('shikudo') then
-  svo.dict.grip = {
-    gamename = 'gripping',
-    physical = {
-      balanceless_act = true, def = true,
-      action = 'grip',
-
-      isadvisable = function()
-        return (
-          not defc.grip
-          and (
-            (sys.deffing and defdefup[defs.mode].grip)
-            or (conf.keepup and defkeepup[defs.mode].grip)
-          )
-          and me.path == 'shikudo'
-          and not codepaste.balanceful_defs_codepaste()
-          and sys.canoutr
-          and not affs.paralysis
-          and not affs.prone
-        ) or false
-      end,
-
-      oncompleted = function() defences.got('grip') end,
-
-      onstart = function() send('grip', conf.commandecho) end
+  end
+  
+  if svo.haveskillset('groves') then
+    svo.dict.flail = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+        isadvisable = function()
+          return (((sys.deffing and defdefup[defs.mode].flail and not defc.flail) or (conf.keepup and defkeepup[defs.mode].flail and not defc.flail)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
+        end,
+  
+        oncompleted = function() defences.got('flail') end,
+  
+        action = "flail quarterstaff",
+  
+        onstart = function()
+          send('wield quarterstaff', conf.commandecho)
+          send('flail quarterstaff', conf.commandecho)
+        end
+      }
     }
-  }
-  svo.dict.tykonos = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = "adopt tykonos form",
-      isadvisable = function() return shikudo_ability_isadvisable('tykonos') end,
-      oncompleted = function() return shikudo_form_oncompleted('tykonos') end,
-
-      onstart = function() send('adopt tykonos form', conf.commandecho) end
-    },
-  }
-  svo.dict.willow = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = "adopt willow form",
-      isadvisable = function() return shikudo_ability_isadvisable('willow') end,
-      oncompleted = function() return shikudo_form_oncompleted('willow') end,
-
-      onstart = function() send('adopt willow form', conf.commandecho) end
-    },
-  }
-  svo.dict.rain = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = "adopt rain form",
-      isadvisable = function() return shikudo_ability_isadvisable('rain') end,
-      oncompleted = function() return shikudo_form_oncompleted('rain') end,
-
-      onstart = function() send('adopt rain form', conf.commandecho) end
-    },
-  }
-  svo.dict.oak = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = "adopt oak form",
-      isadvisable = function() return shikudo_ability_isadvisable('oak') end,
-      oncompleted = function() return shikudo_form_oncompleted('oak') end,
-
-      onstart = function() send('adopt oak form', conf.commandecho) end
-    },
-  }
-  svo.dict.gaital = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = "adopt gaital form",
-      isadvisable = function() return shikudo_ability_isadvisable('gaital') end,
-      oncompleted = function() return shikudo_form_oncompleted('gaital') end,
-
-      onstart = function() send('adopt gaital form', conf.commandecho) end
-    },
-  }
-  svo.dict.maelstrom = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = "adopt maelstrom form",
-      isadvisable = function() return shikudo_ability_isadvisable('maelstrom') end,
-      oncompleted = function() return shikudo_form_oncompleted('maelstrom') end,
-
-      onstart = function() send('adopt maelstrom form', conf.commandecho) end
-    },
-  }
-end
-
-if svo.haveskillset('tekura') then
-  svo.dict.bodyblock = {
-    physical = {
-      balanceful_act = true, def = true,
-      isadvisable = function() return tekura_ability_isadvisable('bodyblock') end,
-      action = 'bdb',
-
-      oncompleted = function() defences.got('bodyblock') end,
-
-      onstart = function() send('bdb', conf.commandecho) end
-    },
-  }
-  svo.dict.evadeblock = {
-    physical = {
-      balanceful_act = true, def = true,
-      action = 'evb',
-      isadvisable = function() return tekura_ability_isadvisable('evadeblock') end,
-
-      oncompleted = function() defences.got('evadeblock') end,
-
-      onstart = function() send('evb', conf.commandecho) end
-    },
-  }
-  svo.dict.pinchblock = {
-    physical = {
-      balanceful_act = true, def = true,
-      action = 'pnb',
-      isadvisable = function() return tekura_ability_isadvisable('pinchblock') end,
-
-      oncompleted = function() defences.got('pinchblock') end,
-
-      onstart = function() send('pnb', conf.commandecho) end
-    },
-  }
-  svo.dict.horse = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = 'hrs',
-      isadvisable = function() return tekura_ability_isadvisable('horse') end,
-      oncompleted = function() return tekura_stance_oncompleted('horse') end,
-
-      onstart = function() send('hrs', conf.commandecho) end
-    },
-  }
-  svo.dict.eagle = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = 'egs',
-      isadvisable = function() return tekura_ability_isadvisable('eagle') end,
-      oncompleted = function() return tekura_stance_oncompleted('eagle') end,
-
-      onstart = function() send('egs', conf.commandecho) end
-    },
-  }
-  svo.dict.cat = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = 'cts',
-      isadvisable = function() return tekura_ability_isadvisable('cat') end,
-      oncompleted = function() return tekura_stance_oncompleted('cat') end,
-
-      onstart = function() send('cts', conf.commandecho) end
-    },
-  }
-  svo.dict.bear = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = 'brs',
-      isadvisable = function() return tekura_ability_isadvisable('bear') end,
-      oncompleted = function() return tekura_stance_oncompleted('bear') end,
-
-      onstart = function() send('brs', conf.commandecho) end
-    },
-  }
-  svo.dict.rat = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = 'rts',
-      isadvisable = function() return tekura_ability_isadvisable('rat') end,
-      oncompleted = function() return tekura_stance_oncompleted('rat') end,
-
-      onstart = function() send('rts', conf.commandecho) end
-    },
-  }
-  svo.dict.scorpion = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = 'scs',
-      isadvisable = function() return tekura_ability_isadvisable('scorpion') end,
-      oncompleted = function() return tekura_stance_oncompleted('scorpion') end,
-
-      onstart = function() send('scs', conf.commandecho) end
-    },
-  }
-  svo.dict.dragon = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      action = 'drs',
-      isadvisable = function() return tekura_ability_isadvisable('dragon') end,
-      oncompleted = function() return tekura_stance_oncompleted('dragon') end,
-
-      onstart = function() send('drs', conf.commandecho) end
-    },
-  }
-end
-
-
-
-if svo.haveskillset('venom') then
-  svo.dict.shrugging = {
-    physical = {
-      balanceless_act = true,
-
-      isadvisable = function()
-        if not next(affs) or not bals.shrugging or affs.sleep or not conf.shrugging or affs.stun or affs.unconsciousness or affs.weakness or codepaste.nonstdcure() or defc.dragonform then return false end
-
-        for name, func in pairs(svo.shrugging) do
-          if not me.disabledshruggingfunc[name] then
-            local s,m = pcall(func[1])
-            if s and m then return true end
+    svo.dict.lyre = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.lyre and not svo.doingaction('lyre') and ((sys.deffing and defdefup[defs.mode].lyre) or (conf.keepup and defkeepup[defs.mode].lyre)) and not svo.will_take_balance() and not conf.lyre_step and not affs.prone) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('lyre')
+  
+          if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
+        end,
+  
+        ontimeout = function()
+          if conf.paused and not defc.lyre then
+            svo.echof("Lyre strum didn't happen - unpausing.")
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            svo.make_gnomes_work()
+          end
+        end,
+  
+        onkill = function()
+          if conf.paused and not defc.lyre then
+            svo.echof("Lyre strum cancelled - unpausing.")
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+          end
+        end,
+  
+        action = "evoke barrier",
+        onstart = function()
+          sys.sendonceonly = true
+  
+          -- small fix to make 'lyc' work and be in-order (as well as use batching)
+          local send = send
+          -- record in systemscommands, so it doesn't get killed later on in the controller and loop
+          if conf.batch then send = function(what, ...) svo.sendc(what, ...) sk.systemscommands[what] = true end end
+  
+          if not defc.dragonform and (not conf.lyrecmd or conf.lyrecmd == "evoke barrier") then
+            send("evoke barrier", conf.commandecho)
+          else
+            send(tostring(conf.lyrecmd), conf.commandecho)
+          end
+          sys.sendonceonly = false
+  
+          if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('lyre')
+  
+          -- as a special case for handling the following scenario:
+          --[[(focus)
+            Your prismatic barrier dissolves into nothing.
+            You focus your mind intently on curing your mental maladies.
+            Food is no longer repulsive to you. (7.548s)
+            H: 3294 (50%), M: 4911 (89%) 28725e, 10294w 89.3% ex|cdk- 19:24:04.719(sip health|eat bayberry|outr bayberry|eat
+            irid|outr irid)(+324h, 5.0%, -291m, 5.3%)
+            You begin to weave a melody of magical, heart-rending beauty and a beautiful barrier of prismatic light surrounds you.
+            (p) H: 3294 (50%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:04.897
+            Your prismatic barrier dissolves into nothing.
+            You take a drink from a purple heartwood vial.
+            The elixir heals and soothes you.
+            H: 4767 (73%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:05.247(+1473h, 22.7%)
+            You eat some bayberry bark.
+            Your eyes dim as you lose your sight.
+          ]]
+          -- we want to kill lyre going up when it goes down and you're off balance, because you won't get it up off-bal
+  
+          -- but don't kill it if it is in lifevision - meaning we're going to get it:
+          --[[
+            (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
+            Your prismatic barrier dissolves into nothing.
+            You strum a Lasallian lyre, and a prismatic barrier forms around you.
+            (svo): Lyre strum cancelled - unpausing.
+            (x) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}
+            You have recovered equilibrium. (3.887s)
+            (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
+            Your prismatic barrier dissolves into nothing.
+            You strum a Lasallian lyre, and a prismatic barrier forms around you.
+            (svo): Lyre strum cancelled - unpausing.
+          ]]
+  
+          if not (bals.balance and bals.equilibrium) and svo.actions.lyre_physical and not svo.lifevision.l.lyre_physical then svo.killaction(svo.dict.lyre.physical) end
+  
+          -- unpause should we lose the lyre def for some reason - but not while we're doing lyc
+          -- since we'll lose the lyre def and it'll come up right away
+          if conf.lyre and conf.paused and not svo.actions.lyre_physical then conf.paused = false; raiseEvent("svo config changed", 'paused') end
+        end,
+      }
+    }
+    svo.dict.rejuvenate = {
+      description = "auto pauses/unpauses the system when you're rejuvenating the forests",
+      physical = {
+        unpauselater = false,
+        balanceful_act = true,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        oncompleted = function()
+          svo.doaction(svo.dict.waitingforrejuvenate.waitingfor)
+        end,
+  
+        action = 'rejuvenate',
+        onstart = function()
+        -- user commands catching needs this check
+          if not (bals.balance and bals.equilibrium) then return end
+  
+          send('rejuvenate', conf.commandecho)
+  
+          if not conf.paused then
+            svo.dict.rejuvenate.physical.unpauselater = true
+            conf.paused = true; raiseEvent("svo config changed", 'paused')
+            echo"\n" svo.echof("Temporarily pausing to summon the rejuvenate.")
           end
         end
-      end,
-
-      oncompleted = function (number)
-        if number then
-          -- empty
-          if number+1 == getLineNumber() then
-            empty.shrugging()
+      }
+    }
+    svo.dict.waitingforrejuvenate = {
+      waitingfor = {
+        customwait = 30,
+  
+        oncompleted = function()
+          if conf.paused and svo.dict.rejuvenate.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+  
+            svo.echof("Finished rejuvenating, unpausing.")
           end
-        end
-        signals.after_lifevision_processing:unblock(cnrl.checkwarning)
-
-        svo.lostbal_shrugging()
-      end,
-
-      action = 'shrugging',
-			onstart = function()
-				if svo.conf.serverside then
-				  send('curing queue add shrugging', conf.commandecho) 
-				else
-      		send('shrugging', conf.commandecho) 
-				end
-			end,
-
-      offbal = function() svo.lostbal_shrugging() end
+          svo.dict.rejuvenate.physical.unpauselater = false
+        end,
+  
+        cancelled = function()
+          if conf.paused and svo.dict.rejuvenate.physical.unpauselater then
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            svo.echof("Oops, interrupted rejuvenation. Unpausing.")
+          end
+          svo.dict.rejuvenate.physical.unpauselater = false
+        end,
+  
+        ontimeout = function()
+          svo.dict.waitingforrejuvenate.waitingfor.cancelled()
+        end,
+  
+        onstart = function() end
+      }
     }
-  }
-end
-
-if svo.haveskillset('alchemy') then
-  svo.dict.extispicy = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.extispicy and ((sys.deffing and defdefup[defs.mode].extispicy) or (conf.keepup and defkeepup[defs.mode].extispicy)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
-      end,
-
-      oncompleted = function() defences.got('extispicy') end,
-
-      norat = function()
-        if svo.ignore.extispicy then return end
-
-        svo.ignore.extispicy = true
-
-        if sys.deffing then
-          echo'\n' svo.echof("Looks like we have no rat - going to skip extispicy in this defup.")
-
-          signals.donedefup:connect(function()
-            svo.ignore.extispicy = nil
-          end, "donedefup ignore extispicy")
-        else
-          echo'\n' svo.echof("Looks like we have no rat for keepup - placing extispicy on ignore.")
-        end
-      end,
-
-      action = "dissect rat",
-      onstart = function() send('dissect rat', conf.commandecho) end
-    }
-  }
-end
-
-if svo.haveskillset('skirmishing') then
-  svo.dict.spinning = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].spinning and not defc.spinning) or (conf.keepup and defkeepup[defs.mode].spinning and not defc.spinning)) and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function() defences.got('spinning') end,
-
-      actions = {"spin trident", "spin spear"},
-
-      onstart = function()
-        send("spin "..conf.weapon, conf.commandecho)
-      end
-    }
-  }
-end
-
-if svo.haveskillset('propagation') then
-  svo.dict.barkskin = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-       return (not defc.barkskin and ((sys.deffing and defdefup[defs.mode].barkskin) or (conf.keepup and defkeepup[defs.mode].barkskin)) and not codepaste.balanceful_defs_codepaste() and defc.earth) or false
-      end,
-
-      oncompleted = function() defences.got('barkskin') end,
-
-      action = 'barkskin',
-      onstart = function() send('barkskin', conf.commandecho) end
-    }
-  }
-  svo.dict.viridian = {
-    physical = {
-      unpauselater = false,
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].viridian and not defc.viridian) or (conf.keepup and defkeepup[defs.mode].viridian and not defc.viridian)) and not svo.doingaction('waitingforviridian') and not codepaste.balanceful_defs_codepaste()) or false
-      end,
-
-      oncompleted = function (def)
-        if def and not defc.viridian then defences.got('viridian')
-        else svo.doaction(svo.dict.waitingforviridian.waitingfor) end
-      end,
-
-      alreadyhave = function()
-        svo.dict.waitingforviridian.waitingfor.oncompleted()
-      end,
-
-      indoors = function()
-        if conf.paused and svo.dict.viridian.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          echo"\n" svo.echof("Unpaused - you must be outside to cast Viridian.")
-        end
-        svo.dict.viridian.physical.unpauselater = false
-        defences.got('viridian')
-      end,
-
-      notonland = function()
-        if conf.paused and svo.dict.viridian.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          echo"\n" svo.echof("You must be in contact with the earth in order to call upon the might of the Viridian.")
-        end
-        svo.dict.viridian.physical.unpauselater = false
-        defences.got('viridian')
-      end,
-
-      actions = {"assume viridian", "assume viridian staff"},
-      onstart = function()
-        if defc.flail then
-          send("assume viridian staff", conf.commandecho)
-        else
-          send("assume viridian", conf.commandecho)
-        end
-
-        if not conf.paused then
-          svo.dict.viridian.physical.unpauselater = true
-          conf.paused = true; raiseEvent("svo config changed", 'paused')
-          echo"\n" svo.echof("Temporarily pausing for viridian.")
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('viridian') end,
-    }
-  }
-  svo.dict.waitingforviridian = {
-    waitingfor = {
-      customwait = 20,
-
-      oncompleted = function()
-        defences.got('viridian')
-        svo.dict.riding.gone.oncompleted()
-
-        if conf.paused and svo.dict.viridian.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-
-          echo"\n"
-          svo.echof("Obtained viridian, unpausing.")
-        end
-        svo.dict.viridian.physical.unpauselater = false
-      end,
-
-      cancelled = function()
-        if conf.paused and svo.dict.viridian.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          echo"\n" svo.echof("Unpausing.")
-        end
-        svo.dict.viridian.physical.unpauselater = false
-      end,
-
-      ontimeout = function()
-        svo.dict.waitingforviridian.waitingfor.cancelled()
-      end,
-
-      onstart = function() end,
-    }
-  }
-end
-
-if svo.haveskillset('groves') then
-  svo.dict.flail = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-      isadvisable = function()
-        return (((sys.deffing and defdefup[defs.mode].flail and not defc.flail) or (conf.keepup and defkeepup[defs.mode].flail and not defc.flail)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and not affs.prone) or false
-      end,
-
-      oncompleted = function() defences.got('flail') end,
-
-      action = "flail quarterstaff",
-
-      onstart = function()
-        send('wield quarterstaff', conf.commandecho)
-        send('flail quarterstaff', conf.commandecho)
-      end
-    }
-  }
-  svo.dict.lyre = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.lyre and not svo.doingaction('lyre') and ((sys.deffing and defdefup[defs.mode].lyre) or (conf.keepup and defkeepup[defs.mode].lyre)) and not svo.will_take_balance() and not conf.lyre_step and not affs.prone) or false
-      end,
-
-      oncompleted = function()
-        defences.got('lyre')
-
-        if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
-      end,
-
-      ontimeout = function()
-        if conf.paused and not defc.lyre then
-          svo.echof("Lyre strum didn't happen - unpausing.")
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          svo.make_gnomes_work()
-        end
-      end,
-
-      onkill = function()
-        if conf.paused and not defc.lyre then
-          svo.echof("Lyre strum cancelled - unpausing.")
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-        end
-      end,
-
-      action = "evoke barrier",
-      onstart = function()
-        sys.sendonceonly = true
-
-        -- small fix to make 'lyc' work and be in-order (as well as use batching)
-        local send = send
-        -- record in systemscommands, so it doesn't get killed later on in the controller and loop
-        if conf.batch then send = function(what, ...) svo.sendc(what, ...) sk.systemscommands[what] = true end end
-
-        if not defc.dragonform and (not conf.lyrecmd or conf.lyrecmd == "evoke barrier") then
-          send("evoke barrier", conf.commandecho)
-        else
-          send(tostring(conf.lyrecmd), conf.commandecho)
-        end
-        sys.sendonceonly = false
-
-        if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('lyre')
-
-        -- as a special case for handling the following scenario:
-        --[[(focus)
-          Your prismatic barrier dissolves into nothing.
-          You focus your mind intently on curing your mental maladies.
-          Food is no longer repulsive to you. (7.548s)
-          H: 3294 (50%), M: 4911 (89%) 28725e, 10294w 89.3% ex|cdk- 19:24:04.719(sip health|eat bayberry|outr bayberry|eat
-          irid|outr irid)(+324h, 5.0%, -291m, 5.3%)
-          You begin to weave a melody of magical, heart-rending beauty and a beautiful barrier of prismatic light surrounds you.
-          (p) H: 3294 (50%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:04.897
-          Your prismatic barrier dissolves into nothing.
-          You take a drink from a purple heartwood vial.
-          The elixir heals and soothes you.
-          H: 4767 (73%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:05.247(+1473h, 22.7%)
-          You eat some bayberry bark.
-          Your eyes dim as you lose your sight.
-        ]]
-        -- we want to kill lyre going up when it goes down and you're off balance, because you won't get it up off-bal
-
-        -- but don't kill it if it is in lifevision - meaning we're going to get it:
-        --[[
-          (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
-          Your prismatic barrier dissolves into nothing.
-          You strum a Lasallian lyre, and a prismatic barrier forms around you.
-          (svo): Lyre strum cancelled - unpausing.
-          (x) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}
-          You have recovered equilibrium. (3.887s)
-          (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
-          Your prismatic barrier dissolves into nothing.
-          You strum a Lasallian lyre, and a prismatic barrier forms around you.
-          (svo): Lyre strum cancelled - unpausing.
-        ]]
-
-        if not (bals.balance and bals.equilibrium) and svo.actions.lyre_physical and not svo.lifevision.l.lyre_physical then svo.killaction(svo.dict.lyre.physical) end
-
-        -- unpause should we lose the lyre def for some reason - but not while we're doing lyc
-        -- since we'll lose the lyre def and it'll come up right away
-        if conf.lyre and conf.paused and not svo.actions.lyre_physical then conf.paused = false; raiseEvent("svo config changed", 'paused') end
-      end,
-    }
-  }
-  svo.dict.rejuvenate = {
-    description = "auto pauses/unpauses the system when you're rejuvenating the forests",
-    physical = {
-      unpauselater = false,
-      balanceful_act = true,
-
-      isadvisable = function()
-        return false
-      end,
-
-      oncompleted = function()
-        svo.doaction(svo.dict.waitingforrejuvenate.waitingfor)
-      end,
-
-      action = 'rejuvenate',
-      onstart = function()
-      -- user commands catching needs this check
-        if not (bals.balance and bals.equilibrium) then return end
-
-        send('rejuvenate', conf.commandecho)
-
-        if not conf.paused then
-          svo.dict.rejuvenate.physical.unpauselater = true
-          conf.paused = true; raiseEvent("svo config changed", 'paused')
-          echo"\n" svo.echof("Temporarily pausing to summon the rejuvenate.")
-        end
-      end
-    }
-  }
-  svo.dict.waitingforrejuvenate = {
-    waitingfor = {
-      customwait = 30,
-
-      oncompleted = function()
-        if conf.paused and svo.dict.rejuvenate.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-
-          svo.echof("Finished rejuvenating, unpausing.")
-        end
-        svo.dict.rejuvenate.physical.unpauselater = false
-      end,
-
-      cancelled = function()
-        if conf.paused and svo.dict.rejuvenate.physical.unpauselater then
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          svo.echof("Oops, interrupted rejuvenation. Unpausing.")
-        end
-        svo.dict.rejuvenate.physical.unpauselater = false
-      end,
-
-      ontimeout = function()
-        svo.dict.waitingforrejuvenate.waitingfor.cancelled()
-      end,
-
-      onstart = function() end
-    }
-  }
-end
-
--- override groves lyre, as druids can get 2 types of lyre (groves and nightingale)
-if svo.haveskillset('metamorphosis') then
-  svo.dict.lyre = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.lyre and ((sys.deffing and defdefup[defs.mode].lyre) or (conf.keepup and defkeepup[defs.mode].lyre)) and not svo.will_take_balance() and (not defc.dragonform or (not affs.cantmorph and sk.morphsforskill.lyre)) and not conf.lyre_step and not affs.prone) or false
-      end,
-
-      oncompleted = function()
-        defences.got('lyre')
-
-        if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
-      end,
-
-      ontimeout = function()
-        if conf.paused and not defc.lyre then
-          svo.echof("Lyre strum didn't happen - unpausing.")
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          svo.make_gnomes_work()
-        end
-      end,
-
-      onkill = function()
-        if conf.paused and not defc.lyre then
-          svo.echof("Lyre strum cancelled - unpausing.")
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-        end
-      end,
-
-      action = "sing melody",
-      onstart = function()
-        if not defc.dragonform and (not conf.lyrecmd or conf.lyrecmd == "sing melody") then
-          if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'lyre' then
-            if defc.flame then send("relax flame", conf.commandecho) end
-            send('human', conf.commandecho)
-          elseif not sk.inamorphfor'lyre' then
-            if defc.flame then send("relax flame", conf.commandecho) end
-            send("morph "..sk.morphsforskill.lyre[1], conf.commandecho)
-
-            if conf.transmorph then
+  end
+  
+  -- override groves lyre, as druids can get 2 types of lyre (groves and nightingale)
+  if svo.haveskillset('metamorphosis') then
+    svo.dict.lyre = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.lyre and ((sys.deffing and defdefup[defs.mode].lyre) or (conf.keepup and defkeepup[defs.mode].lyre)) and not svo.will_take_balance() and (not defc.dragonform or (not affs.cantmorph and sk.morphsforskill.lyre)) and not conf.lyre_step and not affs.prone) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('lyre')
+  
+          if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
+        end,
+  
+        ontimeout = function()
+          if conf.paused and not defc.lyre then
+            svo.echof("Lyre strum didn't happen - unpausing.")
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            svo.make_gnomes_work()
+          end
+        end,
+  
+        onkill = function()
+          if conf.paused and not defc.lyre then
+            svo.echof("Lyre strum cancelled - unpausing.")
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+          end
+        end,
+  
+        action = "sing melody",
+        onstart = function()
+          if not defc.dragonform and (not conf.lyrecmd or conf.lyrecmd == "sing melody") then
+            if not conf.transmorph and sk.inamorph() and not sk.inamorphfor'lyre' then
+              if defc.flame then send("relax flame", conf.commandecho) end
+              send('human', conf.commandecho)
+            elseif not sk.inamorphfor'lyre' then
+              if defc.flame then send("relax flame", conf.commandecho) end
+              send("morph "..sk.morphsforskill.lyre[1], conf.commandecho)
+  
+              if conf.transmorph then
+                sys.sendonceonly = true
+                send("sing melody", conf.commandecho)
+                sys.sendonceonly = false
+                if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
+              end
+            elseif sk.inamorphfor'lyre' then
               sys.sendonceonly = true
               send("sing melody", conf.commandecho)
               sys.sendonceonly = false
+  
               if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
             end
-          elseif sk.inamorphfor'lyre' then
+          else
+            -- small fix to make 'lyc' work and be in-order (as well as use batching)
+            local send = send
+          -- record in systemscommands, so it doesn't get killed later on in the controller and loop
+          if conf.batch then send = function(what, ...) svo.sendc(what, ...) sk.systemscommands[what] = true end end
+  
             sys.sendonceonly = true
-            send("sing melody", conf.commandecho)
+            send(tostring(conf.lyrecmd), conf.commandecho)
             sys.sendonceonly = false
-
+  
             if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
           end
-        else
-          -- small fix to make 'lyc' work and be in-order (as well as use batching)
-          local send = send
-        -- record in systemscommands, so it doesn't get killed later on in the controller and loop
-        if conf.batch then send = function(what, ...) svo.sendc(what, ...) sk.systemscommands[what] = true end end
-
-          sys.sendonceonly = true
-          send(tostring(conf.lyrecmd), conf.commandecho)
-          sys.sendonceonly = false
-
-          if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
         end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('lyre')
-
-        -- as a special case for handling the following scenario:
-        --[[(focus)
-          Your prismatic barrier dissolves into nothing.
-          You focus your mind intently on curing your mental maladies.
-          Food is no longer repulsive to you. (7.548s)
-          H: 3294 (50%), M: 4911 (89%) 28725e, 10294w 89.3% ex|cdk- 19:24:04.719(sip health|eat bayberry|outr bayberry|eat
-          irid|outr irid)(+324h, 5.0%, -291m, 5.3%)
-          You begin to weave a melody of magical, heart-rending beauty and a beautiful barrier of prismatic light surrounds you.
-          (p) H: 3294 (50%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:04.897
-          Your prismatic barrier dissolves into nothing.
-          You take a drink from a purple heartwood vial.
-          The elixir heals and soothes you.
-          H: 4767 (73%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:05.247(+1473h, 22.7%)
-          You eat some bayberry bark.
-          Your eyes dim as you lose your sight.
-        ]]
-        -- we want to kill lyre going up when it goes down and you're off balance, because you won't get it up off-bal
-
-        -- but don't kill it if it is in lifevision - meaning we're going to get it:
-        --[[
-          (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
-          Your prismatic barrier dissolves into nothing.
-          You strum a Lasallian lyre, and a prismatic barrier forms around you.
-          (svo): Lyre strum cancelled - unpausing.
-          (x) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}
-          You have recovered equilibrium. (3.887s)
-          (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
-          Your prismatic barrier dissolves into nothing.
-          You strum a Lasallian lyre, and a prismatic barrier forms around you.
-          (svo): Lyre strum cancelled - unpausing.
-        ]]
-
-        if not (bals.balance and bals.equilibrium) and svo.actions.lyre_physical and not svo.lifevision.l.lyre_physical then svo.killaction(svo.dict.lyre.physical) end
-
-        -- unpause should we lose the lyre def for some reason - but not while we're doing lyc
-        -- since we'll lose the lyre def and it'll come up right away
-        if conf.lyre and conf.paused and not svo.actions.lyre_physical then conf.paused = false; raiseEvent("svo config changed", 'paused') end
-      end,
-    }
-  }
-end
-
-if svo.haveskillset('domination') then
-  svo.dict.arctar = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.arctar and ((sys.deffing and defdefup[defs.mode].arctar) or (conf.keepup and defkeepup[defs.mode].arctar)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and bals.entities) or false
-      end,
-
-      oncompleted = function() defences.got('arctar') end,
-
-      action = "command orb",
-      onstart = function() send('command orb', conf.commandecho) end
-    }
-  }
-end
-if svo.haveskillset('shadowmancy') then
-  svo.dict.shadowcloak = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        local shadowcloak = me.getitem("a grim cloak")
-        if not defc.dragonform and not defc.shadowcloak and
-          ((sys.deffing and defdefup[defs.mode].shadowcloak)
-            or (conf.keepup and defkeepup[defs.mode].shadowcloak)
-            or (sys.deffing and defdefup[defs.mode].disperse)
-            or (conf.keepup and defkeepup[defs.mode].disperse)
-            or (sys.deffing and defdefup[defs.mode].shadowveil)
-            or (conf.keepup and defkeepup[defs.mode].shadowveil)
-            or (sys.deffing and defdefup[defs.mode].hiding)
-            or (conf.keepup and defkeepup[defs.mode].hiding))
-          and not codepaste.balanceful_defs_codepaste()
-          and not affs.paralysis
-          and not affs.prone and stats.mp then
-            if not shadowcloak then
-              if stats.mp &gt;= 100 then
-                return true
-              elseif not sk.gettingfullstats then
-                svo.fullstats(true)
-                svo.echof("Getting fullstats for Shadowcloak summoning...")
-              end
-            else
-              return true
-            end
-        end
-        return false
-      end,
-
-      oncompleted = function() defences.got('shadowcloak') end,
-
-      action = "shadow cloak",
-      onstart = function()
-        local shadowcloak = me.getitem("a grim cloak")
-        if not shadowcloak then
-          send("shadow cloak", conf.commandecho)
-        elseif not shadowcloak.attrib or not shadowcloak.attrib:find('w') then
-          send("wear " .. shadowcloak.id, conf.commandecho)
-        else
-      defences.got('shadowcloak')
-        end
-      end
-    }
-  }
-  svo.dict.disperse = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return not defc.dragonform and not defc.disperse and defc.shadowcloak and ((sys.deffing and defdefup[defs.mode].disperse) or (conf.keepup and defkeepup[defs.mode].disperse)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone
-      end,
-
-      oncompleted = function() defences.got('disperse') end,
-
-      action = "shadow disperse",
-      onstart = function() send('shadow disperse', conf.commandecho) end
-    }
-  }
-  svo.dict.shadowveil = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return not defc.dragonform and not defc.shadowveil and defc.shadowcloak and ((sys.deffing and defdefup[defs.mode].shadowveil) or (conf.keepup and defkeepup[defs.mode].shadowveil)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone
-      end,
-
-      oncompleted = function() defences.got('shadowveil') end,
-
-      action = "shadow veil",
-      onstart = function() send('shadow veil', conf.commandecho) end
-    }
-  }
-  svo.dict.hiding = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return not defc.dragonform and not defc.hiding and defc.shadowcloak and ((sys.deffing and defdefup[defs.mode].hiding) or (conf.keepup and defkeepup[defs.mode].hiding)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone
-      end,
-
-      oncompleted = function() defences.got('hiding') end,
-
-      action = "shadow veil",
-      onstart = function() send('shadow veil', conf.commandecho) end
-    }
-  }
-end
-if svo.haveskillset('aeonics') then
-  svo.dict.dilation = {
-    physical = {
-      age = 200, 
-      balanceless_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.dilation and ((sys.deffing and defdefup[defs.mode].dilation) or (conf.keepup and defkeepup[defs.mode].dilation)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'dilation' and (stats.age and (stats.age &gt; 0 and stats.age &lt;= 800))) or false
-      end,
-
-      oncompleted = function() defences.got('dilation') end,
-
-      actions = {"chrono dilation", "chrono dilation boost"},
-      onstart = function() send('chrono dilation boost', conf.commandecho) end
-    }
-  }
-    svo.dict.reflection = {
-    gamename = 'reflections',
-    physical = {
-      age = 500,
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-       return (not defc.reflection and ((sys.deffing and defdefup[defs.mode].reflection) or (conf.keepup and defkeepup[defs.mode].reflection)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and not affs.paralysis) or false
-      end,
-
-      oncompleted = function() defences.got('reflection') end,
-
-      actions = {"chrono images", "chrono images boost"},
-      onstart = function()
-        if not stats.age or stats.age &lt;= 1000-svo.dict.reflection.physical.age then
-          send('chrono images boost', conf.commandecho)
-        else
-          send('chrono images', conf.commandecho)
-        end
-      end
-    }
-  }
-  svo.dict.blur = {
-    physical = {
-      age = 180,
-      balanceful_act = true,
-      def = true,
-      
-      isadvisable = function ()
-        return (not defc.blur and ((sys.deffing and defdefup[defs.mode].blur) or (conf.keepup and defkeepup[defs.mode].blur)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and (not stats.age or stats.age &lt;= 820)) or false
-      end,
-
-      oncompleted = function ()
-        defences.got('blur')
-      end,
-
-      actions = {"chrono blur", "chrono blur boost"},
-      onstart = function ()
-        send('chrono blur boost', conf.commandecho)
-      end
-    }
-  } 
-end
-if svo.haveskillset('terminus') then
-  svo.dict.trusad = {
-    gamename = 'precision',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.trusad and ((sys.deffing and defdefup[defs.mode].trusad) or (conf.keepup and defkeepup[defs.mode].trusad)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
-      end,
-
-      oncompleted = function() defences.got('trusad') end,
-
-      action = "intone trusad",
-      onstart = function() send('intone trusad', conf.commandecho) end
-    }
-  }
-  svo.dict.tsuura = {
-    gamename = 'durability',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.tsuura and ((sys.deffing and defdefup[defs.mode].tsuura) or (conf.keepup and defkeepup[defs.mode].tsuura)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
-      end,
-
-      oncompleted = function() defences.got('tsuura') end,
-
-      action = "intone tsuura",
-      onstart = function() send('intone tsuura', conf.commandecho) end
-    }
-  }
-  svo.dict.ukhia = {
-    gamename = 'bloodquell',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.ukhia and ((sys.deffing and defdefup[defs.mode].ukhia) or (conf.keepup and defkeepup[defs.mode].ukhia)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
-      end,
-
-      oncompleted = function() defences.got('ukhia') end,
-
-      action = "intone ukhia",
-      onstart = function() send('intone ukhia', conf.commandecho) end
-    }
-  }
-  svo.dict.qamad = {
-    gamename = 'ironwill',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.qamad and ((sys.deffing and defdefup[defs.mode].qamad) or (conf.keepup and defkeepup[defs.mode].qamad)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
-      end,
-
-      oncompleted = function() defences.got('qamad') end,
-
-      action = "intone qamad",
-      onstart = function() send('intone qamad', conf.commandecho) end
-    }
-  }
-  svo.dict.mainaas = {
-    gamename = 'bodyaugment',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.mainaas and ((sys.deffing and defdefup[defs.mode].mainaas) or (conf.keepup and defkeepup[defs.mode].mainaas)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
-      end,
-
-      oncompleted = function() defences.got('mainaas') end,
-
-      action = "intone mainaas",
-      onstart = function() send('intone mainaas', conf.commandecho) end
-    }
-  }
-  svo.dict.gaiartha = {
-    gamename = 'antiforce',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.gaiartha and ((sys.deffing and defdefup[defs.mode].gaiartha) or (conf.keepup and defkeepup[defs.mode].gaiartha)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
-      end,
-
-      oncompleted = function() defences.got('gaiartha') end,
-
-      action = "intone gaiartha",
-      onstart = function() send('intone gaiartha', conf.commandecho) end
-    }
-  }
-  svo.dict.lyre = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.lyre and not svo.doingaction('lyre') and ((sys.deffing and defdefup[defs.mode].lyre) or (conf.keepup and defkeepup[defs.mode].lyre)) and not svo.will_take_balance() and not conf.lyre_step and not affs.prone and (defc.dragonform or (conf.lyrecmd and conf.lyrecmd ~= "intone kail") or bals.word)) or false
-      end,
-
-      oncompleted = function()
-        defences.got('lyre')
-
-        if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
-      end,
-
-      ontimeout = function()
-        if conf.paused and not defc.lyre then
-          svo.echof("Lyre strum didn't happen - unpausing.")
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-          svo.make_gnomes_work()
-        end
-      end,
-
-      onkill = function()
-        if conf.paused and not defc.lyre then
-          svo.echof("Lyre strum cancelled - unpausing.")
-          conf.paused = false; raiseEvent("svo config changed", 'paused')
-        end
-      end,
-
-      action = "intone kail",
-      onstart = function()
-        sys.sendonceonly = true
-
-        -- small fix to make 'lyc' work and be in-order (as well as use batching)
-        local send = send
-        -- record in systemscommands, so it doesn't get killed later on in the controller and loop
-        if conf.batch then send = function(what, ...) svo.sendc(what, ...) sk.systemscommands[what] = true end end
-
-        if not defc.dragonform and not conf.lyrecmd then
-          send("intone kail", conf.commandecho)
-        elseif conf.lyrecmd then
-          send(tostring(conf.lyrecmd), conf.commandecho)
-        else
-          send("strum lyre", conf.commandecho)
-        end
-        sys.sendonceonly = false
-
-        if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
-      end
-    },
-    gone = {
-      oncompleted = function()
-        defences.lost('lyre')
-
-        -- as a special case for handling the following scenario:
-        --[[(focus)
-          Your prismatic barrier dissolves into nothing.
-          You focus your mind intently on curing your mental maladies.
-          Food is no longer repulsive to you. (7.548s)
-          H: 3294 (50%), M: 4911 (89%) 28725e, 10294w 89.3% ex|cdk- 19:24:04.719(sip health|eat bayberry|outr bayberry|eat
-          irid|outr irid)(+324h, 5.0%, -291m, 5.3%)
-          You begin to weave a melody of magical, heart-rending beauty and a beautiful barrier of prismatic light surrounds you.
-          (p) H: 3294 (50%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:04.897
-          Your prismatic barrier dissolves into nothing.
-          You take a drink from a purple heartwood vial.
-          The elixir heals and soothes you.
-          H: 4767 (73%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:05.247(+1473h, 22.7%)
-          You eat some bayberry bark.
-          Your eyes dim as you lose your sight.
-        ]]
-        -- we want to kill lyre going up when it goes down and you're off balance, because you won't get it up off-bal
-
-        -- but don't kill it if it is in lifevision - meaning we're going to get it:
-        --[[
-          (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
-          Your prismatic barrier dissolves into nothing.
-          You strum a Lasallian lyre, and a prismatic barrier forms around you.
-          (svo): Lyre strum cancelled - unpausing.
-          (x) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}
-          You have recovered equilibrium. (3.887s)
-          (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
-          Your prismatic barrier dissolves into nothing.
-          You strum a Lasallian lyre, and a prismatic barrier forms around you.
-          (svo): Lyre strum cancelled - unpausing.
-        ]]
-
-        if not (bals.balance and bals.equilibrium) and svo.actions.lyre_physical and not svo.lifevision.l.lyre_physical then svo.killaction(svo.dict.lyre.physical) end
-
-        -- unpause should we lose the lyre def for some reason - but not while we're doing lyc
-        -- since we'll lose the lyre def and it'll come up right away
-        if conf.lyre and conf.paused and not svo.actions.lyre_physical then conf.paused = false; raiseEvent("svo config changed", 'paused') end
-      end,
-    }
-  }
-end
-
-if svo.me.class == 'Sentinel' then
-  svo.dict.basilisk = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.basilisk and ((sys.deffing and defdefup[defs.mode].basilisk) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].basilisk)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('basilisk')
-      end,
-
-      action = "morph basilisk",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph basilisk", conf.commandecho)
-        end 
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('basilisk') end,
-    }
-  }
-end
-if svo.me.class == 'Sentinel' then
-  svo.dict.jaguar = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.jaguar and ((sys.deffing and defdefup[defs.mode].jaguar) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].jaguar)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('jaguar')
-      end,
-
-      action = "morph jaguar",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph jaguar", conf.commandecho)
-        end 
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('jaguar') end,
-    }
-  }
-end
-if svo.me.class == 'Druid' then
-  svo.dict.wyvern = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.wyvern and ((sys.deffing and defdefup[defs.mode].wyvern) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].wyvern)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('wyvern')
-      end,
-
-      action = "morph wyvern",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph wyvern", conf.commandecho)
-        end 
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('wyvern') end,
-    }
-  }
-  svo.dict.hydra = {
-    physical = {
-      balanceful_act = true, def = true, undeffable = true,
-
-      isadvisable = function()
-        return (not defc.hydra and ((sys.deffing and defdefup[defs.mode].hydra) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].hydra)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
-      end,
-
-      oncompleted = function()
-        sk.clearmorphs()
-        defences.got('hydra')
-      end,
-
-      action = "morph hydra",
-      onstart = function()
-        if not conf.transmorph and sk.inamorph() then
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send('human', conf.commandecho)
-        else
-          if defc.flame then send("relax flame", conf.commandecho) end
-          send("morph hydra", conf.commandecho)
-        end 
-        if not conf.truemorph then
-          svo.doaction(svo.dict.waitingformorph.waitingfor)
-        end
-      end
-    },
-    gone = {
-      oncompleted = function() defences.lost('hydra') end,
-    }
-  }
-end
-if svo.haveskillset('kaido') then
-  svo.dict.transmute = {
-    physical = {
-      balanceless_act = true,
-
-      isadvisable = function()
-        return (conf.transmute ~= 'none' and not defc.dragonform and (stats.currenthealth &lt; sys.transmuteamount or (sk.gettingfullstats and stats.currenthealth &lt; stats.maxhealth)) and not svo.doingaction'healhealth' and not svo.doingaction'transmute' and not codepaste.balanceful_codepaste() and svo.can_usemana() and (not affs.prone or svo.doingaction'prone')) or false
-      end,
-			
-      oncompleted = function()	
-      end,
-			
-      onstart = function()
-        local necessary_amount = (not sk.gettingfullstats and math.ceil(sys.transmuteamount - stats.currenthealth) or (stats.maxhealth - stats.currenthealth))
-        local available_mana = math.floor(stats.currentmana - sys.manause)
-
-        -- compute just how much of the necessary amount can we transmute given our available mana, and a 1:1 health gain/mana loss mapping
-        necessary_amount = (available_mana &gt; necessary_amount) and necessary_amount or available_mana
-          send("transmute "..necessary_amount, conf.commandecho)
-      end
-    }
-  }
-end
-if svo.haveskillset('voicecraft') then
-  svo.dict.dwinnu = {
-    misc = {
-      isadvisable = function()
-        return (conf.dwinnu and bals.voice and (affs.webbed or affs.roped) and codepaste.writhe() and not affs.paralysis and not defc.dragonform) or false
-      end,
-
-      oncompleted = function()
-        svo.rmaff{'webbed', 'roped'}
-        svo.lostbal_voice()
-      end,
-
-      action = "chant dwinnu",
-      onstart = function() send('chant dwinnu', conf.commandecho) end
-    },
-  }
-end
-
-if svo.haveskillset('discipline') or svo.haveskillset('malignity') or svo.haveskillset('valour') or svo.haveskillset('dominion')  then
-  svo.dict.rage = {
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        if not (conf.rage and bals.rage and (affs.inlove or affs.justice or affs.generosity or affs.pacifism or affs.peace) and not defc.dragonform and svo.can_usemana()) then return false end
-
-        for name, func in pairs(svo.rage) do
-          if not me.disabledragefunc[name] then
-            local s,m = pcall(func[1])
-            if s and m then return true end
-          end
-        end
-      end,
-
-      oncompleted = function() svo.lostbal_rage() end,
-
-      empty = function()
-        svo.rmaff{'inlove', 'justice', 'generosity', 'pacifism', 'peace'}
-        svo.lostbal_rage()
-      end,
-
-      action = 'rage',
-      onstart = function() send('rage', conf.commandecho) end
-    },
-  }
-end
-if svo.haveskillset('metamorphosis') then
-  svo.dict.cantmorph = {
-    waitingfor = {
-      customwait = 30,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-      ontimeout = function()
-        svo.rmaff('cantmorph')
-        echo"\n"svo.echof("We can probably morph again now.")
-      end,
-
-      oncompleted = function() svo.rmaff('cantmorph') end
-    },
-    aff = {
-      oncompleted = function()
-        svo.addaffdict(svo.dict.cantmorph)
-      end
-    },
-    gone = {
-      oncompleted = function() svo.rmaff('cantmorph') end,
-    }
-  }
-end
-if svo.haveskillset('metamorphosis') or svo.haveskillset('kaido') then
-  svo.dict.cantvitality = {
-    waitingfor = {
-      customwait = 122,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-      ontimeout = function()
-        if not defc.vitality then
-          echo"\n"svo.echof("We can vitality again now.")
-          svo.make_gnomes_work()
-        end
-      end,
-
-      oncompleted = function()
-        svo.dict.cantvitality.waitingfor.ontimeout()
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.killaction(svo.dict.cantvitality.waitingfor)
-      end
-    }
-  }
-end
-if svo.haveskillset('weaponmastery') then
-  svo.dict.footingattack = {
-    description = "Tracks attacks suitable for use with balanceless recover footing",
-    happened = {
-      oncompleted = function()
-        sk.didfootingattack = true
-      end
-    }
-  }
-end
-if svo.haveskillset('aeonics') then
-  svo.dict.age = {
-    happened = {
-      onstart = function() end,
-
-      oncompleted = function(amount)
-        if amount &gt; 1400 then
-          svo.ignore_illusion("Age went over the possible max")
-          stats.age = 0
-        elseif amount == 0 then
-          if svo.dict.age.happened.timer then killTimer(svo.dict.age.happened.timer) end
-          stats.age = 0
-          svo.dict.age.happened.timer = nil
-        else
-          if svo.dict.age.happened.timer then killTimer(svo.dict.age.happened.timer) end
-          svo.dict.age.happened.timer = tempTimer(6 + svo.getping(), function()
-            svo.ignore_illusion("Age tick timed out")
-            stats.age = 0
-          end)
-          stats.age = amount
-        end
-      end
-    }
-  }
-end
-if svo.haveskillset('discipline') or svo.haveskillset('malignity') or svo.haveskillset('valour') or svo.haveskillset('dominion') or svo.haveskillset('striking') or svo.haveskillset('kaido') then
-  svo.dict.fitness = {
-    physical = {
-      balanceful_act = true,
-      uncurable = true,
-
-      isadvisable = function()
-        if not (not affs.weakness and not defc.dragonform and bals.fitness and not codepaste.balanceful_defs_codepaste()) then
-          return false
-        end
-
-        for name, func in pairs(svo.fitness) do
-          if not me.disabledfitnessfunc[name] then
-            local s,m = pcall(func[1])
-            if s and m then return true end
-          end
-        end
-      end,
-
-      oncompleted = function()
-        svo.rmaff('asthma')
-        svo.lostbal_fitness()
-      end,
-
-      curedasthma = function()
-        svo.rmaff('asthma')
-        svo.lostbal_fitness()
-      end,
-
-      weakness = function()
-        svo.addaffdict(svo.dict.weakness)
-
-      end,
-
-      allgood = function() svo.rmaff('asthma') end,
-
-      actions = {'fitness'},
-      onstart = function() send('fitness', conf.commandecho) end
-    },
-  }
-end
-if svo.haveskillset('devotion') then
-  svo.dict.bloodsworntoggle = {
-    misc = {
-      uncurable = true,
-
-      isadvisable = function()
-        return (defc.bloodsworn and conf.bloodswornoff and stats.currenthealth &lt;= sys.bloodswornoff and not svo.doingaction'bloodsworntoggle' and not defc.dragonform) or false
-      end,
-
-      oncompleted = function() defences.lost('bloodsworn') end,
-
-      action = "bloodsworn off",
-      onstart = function() send('bloodsworn off', conf.commandecho) end
-    }
-  }
-end
-
-if svo.haveskillset('ignition') then
-  svo.dict.torch = {
-    physical = {
-      balanceful_act = true,
-      def = true,
-      undeffable = true,
-      
-        isadvisable = function ()
-        return (not defc.torch and ((sys.deffing and defdefup[defs.mode].torch) or (conf.keepup and defkeepup[defs.mode].torch)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
-      end,
-      
-        oncompleted = function ()
-          svo.rmaff('ablaze')
-          defences.got('torch')
-        end,
-        
-      actions = {"manifest torch"},
-      onstart = function ()
-        send('manifest torch', conf.commandecho)
-      end
-      }
-    }
-    end
-    
-if svo.haveskillset('memorium') then
-  svo.dict.traceshield = {
-  gamename = 'shieldlogograph',
-    physical = {
-      balanceful_act = true,
-      def = true,
-      
-        isadvisable = function ()
-        return (defc.bloodiedknife and not defc.traceshield and ((sys.deffing and defdefup[defs.mode].traceshield) or (conf.keepup and defkeepup[defs.mode].traceshield)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
-      end,
-      
-        oncompleted = function ()
-          defences.got('traceshield')
-        end,
-        
-      actions = {"trace shield me"},
-      onstart = function ()
-        send('trace shield me', conf.commandecho)
-      end
-      }
-    }
-    
-    svo.dict.traceleech = {
-    gamename = 'leechlogograph',
-    physical = {
-      balanceful_act = true,
-      def = true,
-      
-        isadvisable = function ()
-        return (defc.bloodiedknife and not defc.traceleech and ((sys.deffing and defdefup[defs.mode].traceleech) or (conf.keepup and defkeepup[defs.mode].traceleech)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
-      end,
-      
-        oncompleted = function ()
-          defences.got('traceleech')
-        end,
-        
-      actions = {"trace leech me"},
-      onstart = function ()
-        send('trace leech me', conf.commandecho)
-      end
-      }
-    }
-    
-  svo.dict.bloodiedknife = {
-    physical = {
-      balanceful_act = true,
-      def = true,
-      undeffable = true,
-      
-        isadvisable = function ()
-        return (not defc.bloodiedknife and ((sys.deffing and defdefup[defs.mode].bloodiedknife) or (conf.keepup and defkeepup[defs.mode].bloodiedknife)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
-      end,
-      
-        oncompleted = function ()
-          defences.got('bloodiedknife')
-        end,
-        
-      actions = {"crux let me"},
-      onstart = function ()
-        send('crux let me', conf.commandecho)
-      end
-      }
-    }
-    end
-
-if svo.haveskillset('charnel') then
-  svo.dict.accursedresolve = {
-    physical = {
-      balanceful_act = true,
-      def = true,
-      
-        isadvisable = function ()
-        return (not defc.accursedresolve and ((sys.deffing and defdefup[defs.mode].accursedresolve) or (conf.keepup and defkeepup[defs.mode].accursedresolve)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
-      end,
-      
-        oncompleted = function ()
-          defences.got('accursedresolve')
-        end,
-        
-      actions = {"accursed resolve"},
-      onstart = function ()
-        send('accursed resolve', conf.commandecho)
-      end
-      }
-    }
-    end
-if svo.haveskillset('subterfuge') then
-  svo.dict.lipread  = {
-    gamename = 'lipreading',
-    physical = {
-      balanceful_act = true, def = true,
-      isadvisable = function()
-        return (not defc.dragonform and not defc.lipread and ((sys.deffing and defdefup[defs.mode].lipread) or (conf.keepup and defkeepup[defs.mode].lipread)) and (defc.mindseye or (not defc.blind and not affs.blindaff)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
-      end,
-      oncompleted = function () defences.got('lipread') end,
-      action = 'lipread',
-      onstart = function () send('lipread', conf.commandecho) end
-    }
-  }
-end
-if svo.haveskillset('anathema') then
-  svo.dict.mouths = {
-    gamename = 'mouths',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.mouths and ((sys.deffing and defdefup[defs.mode].mouths) or (conf.keepup and defkeepup[defs.mode].mouths)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
-      end,
-
-      oncompleted = function() defences.got('mouths') end,
-
-      action = "mutate mouths",
-      onstart = function() send('mutate mouths', conf.commandecho) 
-	  end
-    }
-  }
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('lyre')
   
-  svo.dict.bulk = {
-    gamename = 'bulk',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.bulk and ((sys.deffing and defdefup[defs.mode].bulk) or (conf.keepup and defkeepup[defs.mode].bulk)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
-      end,
-
-      oncompleted = function() defences.got('bulk') end,
-
-      action = "mutate bulk",
-      onstart = function()
-        send('mutate bulk', conf.commandecho) 
-	    end
-    }
-  }
+          -- as a special case for handling the following scenario:
+          --[[(focus)
+            Your prismatic barrier dissolves into nothing.
+            You focus your mind intently on curing your mental maladies.
+            Food is no longer repulsive to you. (7.548s)
+            H: 3294 (50%), M: 4911 (89%) 28725e, 10294w 89.3% ex|cdk- 19:24:04.719(sip health|eat bayberry|outr bayberry|eat
+            irid|outr irid)(+324h, 5.0%, -291m, 5.3%)
+            You begin to weave a melody of magical, heart-rending beauty and a beautiful barrier of prismatic light surrounds you.
+            (p) H: 3294 (50%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:04.897
+            Your prismatic barrier dissolves into nothing.
+            You take a drink from a purple heartwood vial.
+            The elixir heals and soothes you.
+            H: 4767 (73%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:05.247(+1473h, 22.7%)
+            You eat some bayberry bark.
+            Your eyes dim as you lose your sight.
+          ]]
+          -- we want to kill lyre going up when it goes down and you're off balance, because you won't get it up off-bal
   
-  svo.dict.eyes = {
-    gamename = 'eyes',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.eyes and ((sys.deffing and defdefup[defs.mode].eyes) or (conf.keepup and defkeepup[defs.mode].eyes)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
-      end,
-
-      oncompleted = function() defences.got('eyes') end,
-
-      action = "mutate eyes",
-      onstart = function()
-        send('mutate eyes', conf.commandecho) 
-	    end
-    }
-  }  
-
-  svo.dict.joints = {
-    gamename = 'joints',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.joints and ((sys.deffing and defdefup[defs.mode].joints) or (conf.keepup and defkeepup[defs.mode].joints)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
-      end,
-
-      oncompleted = function() defences.got('joints') end,
-
-      action = "mutate joints",
-      onstart = function()
-        send('mutate joints', conf.commandecho) 
-	    end
-    }
-  }
-
-  svo.dict.tentacles = {
-    gamename = 'tentacles',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.tentacles and ((sys.deffing and defdefup[defs.mode].tentacles) or (conf.keepup and defkeepup[defs.mode].tentacles)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
-      end,
-
-      oncompleted = function() defences.got('tentacles') end,
-
-      action = "mutate tentacles",
-      onstart = function()
-        send('mutate tentacles', conf.commandecho) 
-	    end
-    }
-  }
+          -- but don't kill it if it is in lifevision - meaning we're going to get it:
+          --[[
+            (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
+            Your prismatic barrier dissolves into nothing.
+            You strum a Lasallian lyre, and a prismatic barrier forms around you.
+            (svo): Lyre strum cancelled - unpausing.
+            (x) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}
+            You have recovered equilibrium. (3.887s)
+            (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
+            Your prismatic barrier dissolves into nothing.
+            You strum a Lasallian lyre, and a prismatic barrier forms around you.
+            (svo): Lyre strum cancelled - unpausing.
+          ]]
   
-  svo.dict.unnamablepresence = {
-    gamename = 'unnamablepresence',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.unnamablepresence and ((sys.deffing and defdefup[defs.mode].unnamablepresence) or (conf.keepup and defkeepup[defs.mode].unnamablepresence)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
-      end,
-
-      oncompleted = function() defences.got('unnamablepresence') end,
-
-      action = "unnamable presence",
-      onstart = function()
-        send('unnamable presence', conf.commandecho) 
-	    end
-    }
-  }
-
-  svo.dict.devour = {
-    gamename = 'devour',
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        return (not defc.dragonform and not defc.devour and ((sys.deffing and defdefup[defs.mode].devour) or (conf.keepup and defkeepup[defs.mode].devour)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and (defc.mouths and defc.tentacles) and bals.anathema) or false
-      end,
-
-      oncompleted = function() defences.got('devour') end,
-
-      action = "unnamable devour",
-      onstart = function()
-        send('unnamable devour', conf.commandecho) 
-	    end
-    }
-  }
+          if not (bals.balance and bals.equilibrium) and svo.actions.lyre_physical and not svo.lifevision.l.lyre_physical then svo.killaction(svo.dict.lyre.physical) end
   
+          -- unpause should we lose the lyre def for some reason - but not while we're doing lyc
+          -- since we'll lose the lyre def and it'll come up right away
+          if conf.lyre and conf.paused and not svo.actions.lyre_physical then conf.paused = false; raiseEvent("svo config changed", 'paused') end
+        end,
+      }
+    }
   end
   
- if svo.haveskillset('excision') then
-  svo.dict.unbowed = {
-    physical = {
-      balanceful_act = true, def = true,
-
-      isadvisable = function()
-        if (not defc.unbowed and ((sys.deffing and defdefup[defs.mode].unbowed) or (conf.keepup and defkeepup[defs.mode].unbowed)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'cantunbowed') then
-
-         if (stats.currenthealth &gt;= stats.maxhealth and stats.currentmana &gt;= stats.maxmana)
-          then
-            return true
-          elseif not sk.gettingfullstats then
-            svo.fullstats(true)
-            svo.echof("Getting fullstats for unbowed now...")
+  if svo.haveskillset('domination') then
+    svo.dict.arctar = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.arctar and ((sys.deffing and defdefup[defs.mode].arctar) or (conf.keepup and defkeepup[defs.mode].arctar)) and not codepaste.balanceful_defs_codepaste() and sys.canoutr and not affs.paralysis and bals.entities) or false
+        end,
+  
+        oncompleted = function() defences.got('arctar') end,
+  
+        action = "command orb",
+        onstart = function() send('command orb', conf.commandecho) end
+      }
+    }
+  end
+  if svo.haveskillset('shadowmancy') then
+    svo.dict.shadowcloak = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          local shadowcloak = me.getitem("a grim cloak")
+          if not defc.dragonform and not defc.shadowcloak and
+            ((sys.deffing and defdefup[defs.mode].shadowcloak)
+              or (conf.keepup and defkeepup[defs.mode].shadowcloak)
+              or (sys.deffing and defdefup[defs.mode].disperse)
+              or (conf.keepup and defkeepup[defs.mode].disperse)
+              or (sys.deffing and defdefup[defs.mode].shadowveil)
+              or (conf.keepup and defkeepup[defs.mode].shadowveil)
+              or (sys.deffing and defdefup[defs.mode].hiding)
+              or (conf.keepup and defkeepup[defs.mode].hiding))
+            and not codepaste.balanceful_defs_codepaste()
+            and not affs.paralysis
+            and not affs.prone and stats.mp then
+              if not shadowcloak then
+                if stats.mp &gt;= 100 then
+                  return true
+                elseif not sk.gettingfullstats then
+                  svo.fullstats(true)
+                  svo.echof("Getting fullstats for Shadowcloak summoning...")
+                end
+              else
+                return true
+              end
+          end
+          return false
+        end,
+  
+        oncompleted = function() defences.got('shadowcloak') end,
+  
+        action = "shadow cloak",
+        onstart = function()
+          local shadowcloak = me.getitem("a grim cloak")
+          if not shadowcloak then
+            send("shadow cloak", conf.commandecho)
+          elseif not shadowcloak.attrib or not shadowcloak.attrib:find('w') then
+            send("wear " .. shadowcloak.id, conf.commandecho)
+          else
+        defences.got('shadowcloak')
           end
         end
-      end,
-
-      oncompleted = function() defences.got('unbowed') end,
-
-      action = 'perform unbowed',
-      onstart = function() send('perform unbowed', conf.commandecho) end
-      },
-    gone = {
-      oncompleted = function()
-        defences.lost('unbowed')
-        if not svo.actions.cantunbowed_waitingfor then svo.doaction(svo.dict.cantunbowed.waitingfor) end
-      end
+      }
     }
-  }
-
-  svo.dict.cantunbowed = {
-    waitingfor = {
-      customwait = 122,
-
-      isadvisable = function()
-        return false
-      end,
-
-      onstart = function() end,
-      ontimeout = function()
-        if not defc.unbowed then
-          echo"\n"svo.echof("We can perform unbowed again now.")
-          svo.make_gnomes_work()
+    svo.dict.disperse = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return not defc.dragonform and not defc.disperse and defc.shadowcloak and ((sys.deffing and defdefup[defs.mode].disperse) or (conf.keepup and defkeepup[defs.mode].disperse)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone
+        end,
+  
+        oncompleted = function() defences.got('disperse') end,
+  
+        action = "shadow disperse",
+        onstart = function() send('shadow disperse', conf.commandecho) end
+      }
+    }
+    svo.dict.shadowveil = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return not defc.dragonform and not defc.shadowveil and defc.shadowcloak and ((sys.deffing and defdefup[defs.mode].shadowveil) or (conf.keepup and defkeepup[defs.mode].shadowveil)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone
+        end,
+  
+        oncompleted = function() defences.got('shadowveil') end,
+  
+        action = "shadow veil",
+        onstart = function() send('shadow veil', conf.commandecho) end
+      }
+    }
+    svo.dict.hiding = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return not defc.dragonform and not defc.hiding and defc.shadowcloak and ((sys.deffing and defdefup[defs.mode].hiding) or (conf.keepup and defkeepup[defs.mode].hiding)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone
+        end,
+  
+        oncompleted = function() defences.got('hiding') end,
+  
+        action = "shadow veil",
+        onstart = function() send('shadow veil', conf.commandecho) end
+      }
+    }
+  end
+  if svo.haveskillset('aeonics') then
+    svo.dict.dilation = {
+      physical = {
+        age = 200, 
+        balanceless_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.dilation and ((sys.deffing and defdefup[defs.mode].dilation) or (conf.keepup and defkeepup[defs.mode].dilation)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'dilation' and (stats.age and (stats.age &gt; 0 and stats.age &lt;= 800))) or false
+        end,
+  
+        oncompleted = function() defences.got('dilation') end,
+  
+        actions = {"chrono dilation", "chrono dilation boost"},
+        onstart = function() send('chrono dilation boost', conf.commandecho) end
+      }
+    }
+      svo.dict.reflection = {
+      gamename = 'reflections',
+      physical = {
+        age = 500,
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+         return (not defc.reflection and ((sys.deffing and defdefup[defs.mode].reflection) or (conf.keepup and defkeepup[defs.mode].reflection)) and not codepaste.balanceful_defs_codepaste() and not affs.prone and not affs.paralysis) or false
+        end,
+  
+        oncompleted = function() defences.got('reflection') end,
+  
+        actions = {"chrono images", "chrono images boost"},
+        onstart = function()
+          if not stats.age or stats.age &lt;= 1000-svo.dict.reflection.physical.age then
+            send('chrono images boost', conf.commandecho)
+          else
+            send('chrono images', conf.commandecho)
+          end
         end
-      end,
-
-      oncompleted = function()
-        svo.dict.cantunbowed.waitingfor.ontimeout()
-      end
-    },
-    gone = {
-      oncompleted = function()
-        svo.killaction(svo.dict.cantunbowed.waitingfor)
-      end
+      }
     }
-  }
-
-end --end of defs
-else
-  --Keep dict state intact upon loading/reloading the script
-  svo.dict = svo.old_dict
+    svo.dict.blur = {
+      physical = {
+        age = 180,
+        balanceful_act = true,
+        def = true,
+        
+        isadvisable = function ()
+          return (not defc.blur and ((sys.deffing and defdefup[defs.mode].blur) or (conf.keepup and defkeepup[defs.mode].blur)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and (not stats.age or stats.age &lt;= 820)) or false
+        end,
+  
+        oncompleted = function ()
+          defences.got('blur')
+        end,
+  
+        actions = {"chrono blur", "chrono blur boost"},
+        onstart = function ()
+          send('chrono blur boost', conf.commandecho)
+        end
+      }
+    } 
+  end
+  if svo.haveskillset('terminus') then
+    svo.dict.trusad = {
+      gamename = 'precision',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.trusad and ((sys.deffing and defdefup[defs.mode].trusad) or (conf.keepup and defkeepup[defs.mode].trusad)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
+        end,
+  
+        oncompleted = function() defences.got('trusad') end,
+  
+        action = "intone trusad",
+        onstart = function() send('intone trusad', conf.commandecho) end
+      }
+    }
+    svo.dict.tsuura = {
+      gamename = 'durability',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.tsuura and ((sys.deffing and defdefup[defs.mode].tsuura) or (conf.keepup and defkeepup[defs.mode].tsuura)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
+        end,
+  
+        oncompleted = function() defences.got('tsuura') end,
+  
+        action = "intone tsuura",
+        onstart = function() send('intone tsuura', conf.commandecho) end
+      }
+    }
+    svo.dict.ukhia = {
+      gamename = 'bloodquell',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.ukhia and ((sys.deffing and defdefup[defs.mode].ukhia) or (conf.keepup and defkeepup[defs.mode].ukhia)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
+        end,
+  
+        oncompleted = function() defences.got('ukhia') end,
+  
+        action = "intone ukhia",
+        onstart = function() send('intone ukhia', conf.commandecho) end
+      }
+    }
+    svo.dict.qamad = {
+      gamename = 'ironwill',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.qamad and ((sys.deffing and defdefup[defs.mode].qamad) or (conf.keepup and defkeepup[defs.mode].qamad)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
+        end,
+  
+        oncompleted = function() defences.got('qamad') end,
+  
+        action = "intone qamad",
+        onstart = function() send('intone qamad', conf.commandecho) end
+      }
+    }
+    svo.dict.mainaas = {
+      gamename = 'bodyaugment',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.mainaas and ((sys.deffing and defdefup[defs.mode].mainaas) or (conf.keepup and defkeepup[defs.mode].mainaas)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
+        end,
+  
+        oncompleted = function() defences.got('mainaas') end,
+  
+        action = "intone mainaas",
+        onstart = function() send('intone mainaas', conf.commandecho) end
+      }
+    }
+    svo.dict.gaiartha = {
+      gamename = 'antiforce',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.gaiartha and ((sys.deffing and defdefup[defs.mode].gaiartha) or (conf.keepup and defkeepup[defs.mode].gaiartha)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.word) or false
+        end,
+  
+        oncompleted = function() defences.got('gaiartha') end,
+  
+        action = "intone gaiartha",
+        onstart = function() send('intone gaiartha', conf.commandecho) end
+      }
+    }
+    svo.dict.lyre = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.lyre and not svo.doingaction('lyre') and ((sys.deffing and defdefup[defs.mode].lyre) or (conf.keepup and defkeepup[defs.mode].lyre)) and not svo.will_take_balance() and not conf.lyre_step and not affs.prone and (defc.dragonform or (conf.lyrecmd and conf.lyrecmd ~= "intone kail") or bals.word)) or false
+        end,
+  
+        oncompleted = function()
+          defences.got('lyre')
+  
+          if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
+        end,
+  
+        ontimeout = function()
+          if conf.paused and not defc.lyre then
+            svo.echof("Lyre strum didn't happen - unpausing.")
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+            svo.make_gnomes_work()
+          end
+        end,
+  
+        onkill = function()
+          if conf.paused and not defc.lyre then
+            svo.echof("Lyre strum cancelled - unpausing.")
+            conf.paused = false; raiseEvent("svo config changed", 'paused')
+          end
+        end,
+  
+        action = "intone kail",
+        onstart = function()
+          sys.sendonceonly = true
+  
+          -- small fix to make 'lyc' work and be in-order (as well as use batching)
+          local send = send
+          -- record in systemscommands, so it doesn't get killed later on in the controller and loop
+          if conf.batch then send = function(what, ...) svo.sendc(what, ...) sk.systemscommands[what] = true end end
+  
+          if not defc.dragonform and not conf.lyrecmd then
+            send("intone kail", conf.commandecho)
+          elseif conf.lyrecmd then
+            send(tostring(conf.lyrecmd), conf.commandecho)
+          else
+            send("strum lyre", conf.commandecho)
+          end
+          sys.sendonceonly = false
+  
+          if conf.lyre then conf.paused = true; raiseEvent("svo config changed", 'paused') end
+        end
+      },
+      gone = {
+        oncompleted = function()
+          defences.lost('lyre')
+  
+          -- as a special case for handling the following scenario:
+          --[[(focus)
+            Your prismatic barrier dissolves into nothing.
+            You focus your mind intently on curing your mental maladies.
+            Food is no longer repulsive to you. (7.548s)
+            H: 3294 (50%), M: 4911 (89%) 28725e, 10294w 89.3% ex|cdk- 19:24:04.719(sip health|eat bayberry|outr bayberry|eat
+            irid|outr irid)(+324h, 5.0%, -291m, 5.3%)
+            You begin to weave a melody of magical, heart-rending beauty and a beautiful barrier of prismatic light surrounds you.
+            (p) H: 3294 (50%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:04.897
+            Your prismatic barrier dissolves into nothing.
+            You take a drink from a purple heartwood vial.
+            The elixir heals and soothes you.
+            H: 4767 (73%), M: 4911 (89%) 28725e, 10194w 89.3% x|cdk- 19:24:05.247(+1473h, 22.7%)
+            You eat some bayberry bark.
+            Your eyes dim as you lose your sight.
+          ]]
+          -- we want to kill lyre going up when it goes down and you're off balance, because you won't get it up off-bal
+  
+          -- but don't kill it if it is in lifevision - meaning we're going to get it:
+          --[[
+            (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
+            Your prismatic barrier dissolves into nothing.
+            You strum a Lasallian lyre, and a prismatic barrier forms around you.
+            (svo): Lyre strum cancelled - unpausing.
+            (x) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}
+            You have recovered equilibrium. (3.887s)
+            (ex) 4600h|100%, 4000m|84%, 100w%, 100e%, (cdbkr)-  {9 Mayan 637}(strum lyre)
+            Your prismatic barrier dissolves into nothing.
+            You strum a Lasallian lyre, and a prismatic barrier forms around you.
+            (svo): Lyre strum cancelled - unpausing.
+          ]]
+  
+          if not (bals.balance and bals.equilibrium) and svo.actions.lyre_physical and not svo.lifevision.l.lyre_physical then svo.killaction(svo.dict.lyre.physical) end
+  
+          -- unpause should we lose the lyre def for some reason - but not while we're doing lyc
+          -- since we'll lose the lyre def and it'll come up right away
+          if conf.lyre and conf.paused and not svo.actions.lyre_physical then conf.paused = false; raiseEvent("svo config changed", 'paused') end
+        end,
+      }
+    }
+  end
+  
+  if svo.me.class == 'Sentinel' then
+    svo.dict.basilisk = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.basilisk and ((sys.deffing and defdefup[defs.mode].basilisk) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].basilisk)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('basilisk')
+        end,
+  
+        action = "morph basilisk",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph basilisk", conf.commandecho)
+          end 
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('basilisk') end,
+      }
+    }
+  end
+  if svo.me.class == 'Sentinel' then
+    svo.dict.jaguar = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.jaguar and ((sys.deffing and defdefup[defs.mode].jaguar) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].jaguar)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('jaguar')
+        end,
+  
+        action = "morph jaguar",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph jaguar", conf.commandecho)
+          end 
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('jaguar') end,
+      }
+    }
+  end
+  if svo.me.class == 'Druid' then
+    svo.dict.wyvern = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.wyvern and ((sys.deffing and defdefup[defs.mode].wyvern) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].wyvern)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('wyvern')
+        end,
+  
+        action = "morph wyvern",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph wyvern", conf.commandecho)
+          end 
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('wyvern') end,
+      }
+    }
+    svo.dict.hydra = {
+      physical = {
+        balanceful_act = true, def = true, undeffable = true,
+  
+        isadvisable = function()
+          return (not defc.hydra and ((sys.deffing and defdefup[defs.mode].hydra) or (not sys.deffing and conf.keepup and defkeepup[defs.mode].hydra)) and not codepaste.balanceful_defs_codepaste() and not affs.cantmorph and not svo.doingaction('waitingformorph') and codepaste.nonmorphdefs()) or false
+        end,
+  
+        oncompleted = function()
+          sk.clearmorphs()
+          defences.got('hydra')
+        end,
+  
+        action = "morph hydra",
+        onstart = function()
+          if not conf.transmorph and sk.inamorph() then
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send('human', conf.commandecho)
+          else
+            if defc.flame then send("relax flame", conf.commandecho) end
+            send("morph hydra", conf.commandecho)
+          end 
+          if not conf.truemorph then
+            svo.doaction(svo.dict.waitingformorph.waitingfor)
+          end
+        end
+      },
+      gone = {
+        oncompleted = function() defences.lost('hydra') end,
+      }
+    }
+  end
+  if svo.haveskillset('kaido') then
+    svo.dict.transmute = {
+      physical = {
+        balanceless_act = true,
+  
+        isadvisable = function()
+          return (conf.transmute ~= 'none' and not defc.dragonform and (stats.currenthealth &lt; sys.transmuteamount or (sk.gettingfullstats and stats.currenthealth &lt; stats.maxhealth)) and not svo.doingaction'healhealth' and not svo.doingaction'transmute' and not codepaste.balanceful_codepaste() and svo.can_usemana() and (not affs.prone or svo.doingaction'prone')) or false
+        end,
+  			
+        oncompleted = function()	
+        end,
+  			
+        onstart = function()
+          local necessary_amount = (not sk.gettingfullstats and math.ceil(sys.transmuteamount - stats.currenthealth) or (stats.maxhealth - stats.currenthealth))
+          local available_mana = math.floor(stats.currentmana - sys.manause)
+  
+          -- compute just how much of the necessary amount can we transmute given our available mana, and a 1:1 health gain/mana loss mapping
+          necessary_amount = (available_mana &gt; necessary_amount) and necessary_amount or available_mana
+            send("transmute "..necessary_amount, conf.commandecho)
+        end
+      }
+    }
+  end
+  if svo.haveskillset('voicecraft') then
+    svo.dict.dwinnu = {
+      misc = {
+        isadvisable = function()
+          return (conf.dwinnu and bals.voice and (affs.webbed or affs.roped) and codepaste.writhe() and not affs.paralysis and not defc.dragonform) or false
+        end,
+  
+        oncompleted = function()
+          svo.rmaff{'webbed', 'roped'}
+          svo.lostbal_voice()
+        end,
+  
+        action = "chant dwinnu",
+        onstart = function() send('chant dwinnu', conf.commandecho) end
+      },
+    }
+  end
+  
+  if svo.haveskillset('discipline') or svo.haveskillset('malignity') or svo.haveskillset('valour') or svo.haveskillset('dominion')  then
+    svo.dict.rage = {
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          if not (conf.rage and bals.rage and (affs.inlove or affs.justice or affs.generosity or affs.pacifism or affs.peace) and not defc.dragonform and svo.can_usemana()) then return false end
+  
+          for name, func in pairs(svo.rage) do
+            if not me.disabledragefunc[name] then
+              local s,m = pcall(func[1])
+              if s and m then return true end
+            end
+          end
+        end,
+  
+        oncompleted = function() svo.lostbal_rage() end,
+  
+        empty = function()
+          svo.rmaff{'inlove', 'justice', 'generosity', 'pacifism', 'peace'}
+          svo.lostbal_rage()
+        end,
+  
+        action = 'rage',
+        onstart = function() send('rage', conf.commandecho) end
+      },
+    }
+  end
+  if svo.haveskillset('metamorphosis') then
+    svo.dict.cantmorph = {
+      waitingfor = {
+        customwait = 30,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+        ontimeout = function()
+          svo.rmaff('cantmorph')
+          echo"\n"svo.echof("We can probably morph again now.")
+        end,
+  
+        oncompleted = function() svo.rmaff('cantmorph') end
+      },
+      aff = {
+        oncompleted = function()
+          svo.addaffdict(svo.dict.cantmorph)
+        end
+      },
+      gone = {
+        oncompleted = function() svo.rmaff('cantmorph') end,
+      }
+    }
+  end
+  if svo.haveskillset('metamorphosis') or svo.haveskillset('kaido') then
+    svo.dict.cantvitality = {
+      waitingfor = {
+        customwait = 122,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+        ontimeout = function()
+          if not defc.vitality then
+            echo"\n"svo.echof("We can vitality again now.")
+            svo.make_gnomes_work()
+          end
+        end,
+  
+        oncompleted = function()
+          svo.dict.cantvitality.waitingfor.ontimeout()
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.killaction(svo.dict.cantvitality.waitingfor)
+        end
+      }
+    }
+  end
+  if svo.haveskillset('weaponmastery') then
+    svo.dict.footingattack = {
+      description = "Tracks attacks suitable for use with balanceless recover footing",
+      happened = {
+        oncompleted = function()
+          sk.didfootingattack = true
+        end
+      }
+    }
+  end
+  if svo.haveskillset('aeonics') then
+    svo.dict.age = {
+      happened = {
+        onstart = function() end,
+  
+        oncompleted = function(amount)
+          if amount &gt; 1400 then
+            svo.ignore_illusion("Age went over the possible max")
+            stats.age = 0
+          elseif amount == 0 then
+            if svo.dict.age.happened.timer then killTimer(svo.dict.age.happened.timer) end
+            stats.age = 0
+            svo.dict.age.happened.timer = nil
+          else
+            if svo.dict.age.happened.timer then killTimer(svo.dict.age.happened.timer) end
+            svo.dict.age.happened.timer = tempTimer(6 + svo.getping(), function()
+              svo.ignore_illusion("Age tick timed out")
+              stats.age = 0
+            end)
+            stats.age = amount
+          end
+        end
+      }
+    }
+  end
+  if svo.haveskillset('discipline') or svo.haveskillset('malignity') or svo.haveskillset('valour') or svo.haveskillset('dominion') or svo.haveskillset('striking') or svo.haveskillset('kaido') then
+    svo.dict.fitness = {
+      physical = {
+        balanceful_act = true,
+        uncurable = true,
+  
+        isadvisable = function()
+          if not (not affs.weakness and not defc.dragonform and bals.fitness and not codepaste.balanceful_defs_codepaste()) then
+            return false
+          end
+  
+          for name, func in pairs(svo.fitness) do
+            if not me.disabledfitnessfunc[name] then
+              local s,m = pcall(func[1])
+              if s and m then return true end
+            end
+          end
+        end,
+  
+        oncompleted = function()
+          svo.rmaff('asthma')
+          svo.lostbal_fitness()
+        end,
+  
+        curedasthma = function()
+          svo.rmaff('asthma')
+          svo.lostbal_fitness()
+        end,
+  
+        weakness = function()
+          svo.addaffdict(svo.dict.weakness)
+  
+        end,
+  
+        allgood = function() svo.rmaff('asthma') end,
+  
+        actions = {'fitness'},
+        onstart = function() send('fitness', conf.commandecho) end
+      },
+    }
+  end
+  if svo.haveskillset('devotion') then
+    svo.dict.bloodsworntoggle = {
+      misc = {
+        uncurable = true,
+  
+        isadvisable = function()
+          return (defc.bloodsworn and conf.bloodswornoff and stats.currenthealth &lt;= sys.bloodswornoff and not svo.doingaction'bloodsworntoggle' and not defc.dragonform) or false
+        end,
+  
+        oncompleted = function() defences.lost('bloodsworn') end,
+  
+        action = "bloodsworn off",
+        onstart = function() send('bloodsworn off', conf.commandecho) end
+      }
+    }
+  end
+  
+  if svo.haveskillset('ignition') then
+    svo.dict.torch = {
+      physical = {
+        balanceful_act = true,
+        def = true,
+        undeffable = true,
+        
+          isadvisable = function ()
+          return (not defc.torch and ((sys.deffing and defdefup[defs.mode].torch) or (conf.keepup and defkeepup[defs.mode].torch)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
+        end,
+        
+          oncompleted = function ()
+            svo.rmaff('ablaze')
+            defences.got('torch')
+          end,
+          
+        actions = {"manifest torch"},
+        onstart = function ()
+          send('manifest torch', conf.commandecho)
+        end
+        }
+      }
+      end
+      
+  if svo.haveskillset('memorium') then
+    svo.dict.traceshield = {
+    gamename = 'shieldlogograph',
+      physical = {
+        balanceful_act = true,
+        def = true,
+        
+          isadvisable = function ()
+          return (defc.bloodiedknife and not defc.traceshield and ((sys.deffing and defdefup[defs.mode].traceshield) or (conf.keepup and defkeepup[defs.mode].traceshield)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
+        end,
+        
+          oncompleted = function ()
+            defences.got('traceshield')
+          end,
+          
+        actions = {"trace shield me"},
+        onstart = function ()
+          send('trace shield me', conf.commandecho)
+        end
+        }
+      }
+      
+      svo.dict.traceleech = {
+      gamename = 'leechlogograph',
+      physical = {
+        balanceful_act = true,
+        def = true,
+        
+          isadvisable = function ()
+          return (defc.bloodiedknife and not defc.traceleech and ((sys.deffing and defdefup[defs.mode].traceleech) or (conf.keepup and defkeepup[defs.mode].traceleech)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
+        end,
+        
+          oncompleted = function ()
+            defences.got('traceleech')
+          end,
+          
+        actions = {"trace leech me"},
+        onstart = function ()
+          send('trace leech me', conf.commandecho)
+        end
+        }
+      }
+      
+    svo.dict.bloodiedknife = {
+      physical = {
+        balanceful_act = true,
+        def = true,
+        undeffable = true,
+        
+          isadvisable = function ()
+          return (not defc.bloodiedknife and ((sys.deffing and defdefup[defs.mode].bloodiedknife) or (conf.keepup and defkeepup[defs.mode].bloodiedknife)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
+        end,
+        
+          oncompleted = function ()
+            defences.got('bloodiedknife')
+          end,
+          
+        actions = {"crux let me"},
+        onstart = function ()
+          send('crux let me', conf.commandecho)
+        end
+        }
+      }
+      end
+  
+  if svo.haveskillset('charnel') then
+    svo.dict.accursedresolve = {
+      physical = {
+        balanceful_act = true,
+        def = true,
+        
+          isadvisable = function ()
+          return (not defc.accursedresolve and ((sys.deffing and defdefup[defs.mode].accursedresolve) or (conf.keepup and defkeepup[defs.mode].accursedresolve)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
+        end,
+        
+          oncompleted = function ()
+            defences.got('accursedresolve')
+          end,
+          
+        actions = {"accursed resolve"},
+        onstart = function ()
+          send('accursed resolve', conf.commandecho)
+        end
+        }
+      }
+      end
+  if svo.haveskillset('subterfuge') then
+    svo.dict.lipread  = {
+      gamename = 'lipreading',
+      physical = {
+        balanceful_act = true, def = true,
+        isadvisable = function()
+          return (not defc.dragonform and not defc.lipread and ((sys.deffing and defdefup[defs.mode].lipread) or (conf.keepup and defkeepup[defs.mode].lipread)) and (defc.mindseye or (not defc.blind and not affs.blindaff)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone) or false
+        end,
+        oncompleted = function () defences.got('lipread') end,
+        action = 'lipread',
+        onstart = function () send('lipread', conf.commandecho) end
+      }
+    }
+  end
+  if svo.haveskillset('anathema') then
+    svo.dict.mouths = {
+      gamename = 'mouths',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.mouths and ((sys.deffing and defdefup[defs.mode].mouths) or (conf.keepup and defkeepup[defs.mode].mouths)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
+        end,
+  
+        oncompleted = function() defences.got('mouths') end,
+  
+        action = "mutate mouths",
+        onstart = function() send('mutate mouths', conf.commandecho) 
+  	  end
+      }
+    }
+    
+    svo.dict.bulk = {
+      gamename = 'bulk',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.bulk and ((sys.deffing and defdefup[defs.mode].bulk) or (conf.keepup and defkeepup[defs.mode].bulk)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
+        end,
+  
+        oncompleted = function() defences.got('bulk') end,
+  
+        action = "mutate bulk",
+        onstart = function()
+          send('mutate bulk', conf.commandecho) 
+  	    end
+      }
+    }
+    
+    svo.dict.eyes = {
+      gamename = 'eyes',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.eyes and ((sys.deffing and defdefup[defs.mode].eyes) or (conf.keepup and defkeepup[defs.mode].eyes)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
+        end,
+  
+        oncompleted = function() defences.got('eyes') end,
+  
+        action = "mutate eyes",
+        onstart = function()
+          send('mutate eyes', conf.commandecho) 
+  	    end
+      }
+    }  
+  
+    svo.dict.joints = {
+      gamename = 'joints',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.joints and ((sys.deffing and defdefup[defs.mode].joints) or (conf.keepup and defkeepup[defs.mode].joints)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
+        end,
+  
+        oncompleted = function() defences.got('joints') end,
+  
+        action = "mutate joints",
+        onstart = function()
+          send('mutate joints', conf.commandecho) 
+  	    end
+      }
+    }
+  
+    svo.dict.tentacles = {
+      gamename = 'tentacles',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.tentacles and ((sys.deffing and defdefup[defs.mode].tentacles) or (conf.keepup and defkeepup[defs.mode].tentacles)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
+        end,
+  
+        oncompleted = function() defences.got('tentacles') end,
+  
+        action = "mutate tentacles",
+        onstart = function()
+          send('mutate tentacles', conf.commandecho) 
+  	    end
+      }
+    }
+    
+    svo.dict.unnamablepresence = {
+      gamename = 'unnamablepresence',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.unnamablepresence and ((sys.deffing and defdefup[defs.mode].unnamablepresence) or (conf.keepup and defkeepup[defs.mode].unnamablepresence)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and bals.anathema) or false
+        end,
+  
+        oncompleted = function() defences.got('unnamablepresence') end,
+  
+        action = "unnamable presence",
+        onstart = function()
+          send('unnamable presence', conf.commandecho) 
+  	    end
+      }
+    }
+  
+    svo.dict.devour = {
+      gamename = 'devour',
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          return (not defc.dragonform and not defc.devour and ((sys.deffing and defdefup[defs.mode].devour) or (conf.keepup and defkeepup[defs.mode].devour)) and not codepaste.balanceful_defs_codepaste() and not affs.paralysis and not affs.prone and (defc.mouths and defc.tentacles) and bals.anathema) or false
+        end,
+  
+        oncompleted = function() defences.got('devour') end,
+  
+        action = "unnamable devour",
+        onstart = function()
+          send('unnamable devour', conf.commandecho) 
+  	    end
+      }
+    }
+    
+    end
+    
+   if svo.haveskillset('excision') then
+    svo.dict.unbowed = {
+      physical = {
+        balanceful_act = true, def = true,
+  
+        isadvisable = function()
+          if (not defc.unbowed and ((sys.deffing and defdefup[defs.mode].unbowed) or (conf.keepup and defkeepup[defs.mode].unbowed)) and not codepaste.balanceful_defs_codepaste() and not svo.doingaction'cantunbowed') then
+  
+           if (stats.currenthealth &gt;= stats.maxhealth and stats.currentmana &gt;= stats.maxmana)
+            then
+              return true
+            elseif not sk.gettingfullstats then
+              svo.fullstats(true)
+              svo.echof("Getting fullstats for unbowed now...")
+            end
+          end
+        end,
+  
+        oncompleted = function() defences.got('unbowed') end,
+  
+        action = 'perform unbowed',
+        onstart = function() send('perform unbowed', conf.commandecho) end
+        },
+      gone = {
+        oncompleted = function()
+          defences.lost('unbowed')
+          if not svo.actions.cantunbowed_waitingfor then svo.doaction(svo.dict.cantunbowed.waitingfor) end
+        end
+      }
+    }
+  
+    svo.dict.cantunbowed = {
+      waitingfor = {
+        customwait = 122,
+  
+        isadvisable = function()
+          return false
+        end,
+  
+        onstart = function() end,
+        ontimeout = function()
+          if not defc.unbowed then
+            echo"\n"svo.echof("We can perform unbowed again now.")
+            svo.make_gnomes_work()
+          end
+        end,
+  
+        oncompleted = function()
+          svo.dict.cantunbowed.waitingfor.ontimeout()
+        end
+      },
+      gone = {
+        oncompleted = function()
+          svo.killaction(svo.dict.cantunbowed.waitingfor)
+        end
+      }
+    }
+  
+  end --end of defs
 end
 -- shortcut function to help create a dict action for a defence
 -- 'which' is the Svof defence name, use the same name in the 'Defences' script

--- a/svo (install me in module manager).xml
+++ b/svo (install me in module manager).xml
@@ -7225,7 +7225,7 @@ end</script>
 		-- reset all serverside prios so serverside doesn't spam class-specific defences
 		-- it's a bug in the game that serverside still tries to put up defences you can't
     svo.sk.resetserversideprios()
-		
+		svo.dict = {}
     svo.systemloaded = false; svo_init_system()
     for defname,v in pairs(temp_defs) do
       svo.defences.got(defname)

--- a/svo (install, config, pipes, rift, parry, prios).xml
+++ b/svo (install, config, pipes, rift, parry, prios).xml
@@ -3963,11 +3963,13 @@ end
 
 do
   local oldCL = createLabel
+  --[[
   function createLabel(name, posX, posY, width, height, fillBackground)
     oldCL(name, 0, 0, 0, 0, fillBackground)
     moveWindow(name, posX, posY)
     resizeWindow(name, width, height)
   end
+  ]]
 end
 
 function svo.toggle_riftlabel(toggle)
@@ -4958,7 +4960,13 @@ function prio.import(name, echoback, report_errors, use_default)
   return true
 end
 
+--[[
 signals.saveconfig:connect(function ()
+  prio.export('current')
+end, 'save prios on quit')
+]]
+
+signals.saveconfig:add_pre_emit(function ()
   prio.export('current')
 end, 'save prios on quit')
 

--- a/svo (install, config, pipes, rift, parry, prios).xml
+++ b/svo (install, config, pipes, rift, parry, prios).xml
@@ -3963,13 +3963,6 @@ end
 
 do
   local oldCL = createLabel
-  --[[
-  function createLabel(name, posX, posY, width, height, fillBackground)
-    oldCL(name, 0, 0, 0, 0, fillBackground)
-    moveWindow(name, posX, posY)
-    resizeWindow(name, width, height)
-  end
-  ]]
 end
 
 function svo.toggle_riftlabel(toggle)
@@ -4959,12 +4952,6 @@ function prio.import(name, echoback, report_errors, use_default)
   svo.debugf("imported %s prio.", name)
   return true
 end
-
---[[
-signals.saveconfig:connect(function ()
-  prio.export('current')
-end, 'save prios on quit')
-]]
 
 signals.saveconfig:add_pre_emit(function ()
   prio.export('current')


### PR DESCRIPTION
Possible fix for prios resetting on class change or randomly through loading. It has been a bug for a long time and after some brainstorming and huge help from Irimon we think that this function was attempting to export at the same time svo was resetting prios to default as it loaded again which could be the reason why it randomly reset to default cause it was saving/loading the default configs again and again. Adding it to pre emit will ensure the export will always run first although it requires more testing to be sure it works.

Also includes a fix for the random moveWindow errors causing by createLabel function svo was attempting to use internally.