### PR TITLE
Fixes / QoL for Undead

### DIFF
--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -3235,6 +3235,10 @@ function ndb.downloaded_file(_, filename)
     if city ~= "(hidden)" then
         temp_name_list[1].city = (city ~= "(none)" and string.title(city) or "rogue")
     end
+    -- API returns 'underworld' for the Undead.
+    if city == 'underworld' then
+        temp_name_list[1].city = 'Undead'
+    end										
     -- house info isn't shown if you're logged in to the website for some people
     if not(house == "(hidden)" or house == "(none)") then
       temp_name_list[1].guild = string.title(house)
@@ -4783,6 +4787,10 @@ function ndb.ishashani(name)
   return #(db:fetch(ndb.db.people, {db:eq(ndb.db.people.city, 'Hashan'), db:eq(ndb.db.people.name, name)})) ~= 0
 end
 
+function ndb.isundead(name)
+  return #(db:fetch(ndb.db.people, {db:eq(ndb.db.people.city, 'Undead'), db:eq(ndb.db.people.name, name)})) ~= 0
+end
+				
 function ndb.isclass(name, class)
   name, class = name:title(), class:lower()
   return #(db:fetch(ndb.db.people, {db:eq(ndb.db.people.class, class), db:eq(ndb.db.people.name, name)})) ~= 0


### PR DESCRIPTION
NDB's manual honors does a request to the API for the information available there. The Undead's city is called 'underworld' there, so this gets persisted improperly after Honors, and until you correct it with a QWC, at which point the color registration fixes things. A potentially 'better' fix would be to just coalesce towards Underworld and update the QWC naming instead. 

I believe this discrepancy may also have been causing the issues with ndb.isenemy not working consistently on Undead.

Also adds an ndb.isundead function, identical to the existing ndb.is<city> functions.