### PR TITLE
Revert regex for issue #820

### DIFF
--- a/svo (namedb).xml
+++ b/svo (namedb).xml
@@ -1760,7 +1760,7 @@ temp_name_list[1].city = matches[3]</script>
 						<colorTriggerFgColor>#000000</colorTriggerFgColor>
 						<colorTriggerBgColor>#000000</colorTriggerBgColor>
 						<regexCodeList>
-							<string>^\w+ is an? (.+) in (.+)\.$</string>
+							<string>^\w+ is an? (\w+) in (\w+)\.$</string>
 						</regexCodeList>
 						<regexCodePropertyList>
 							<integer>1</integer>


### PR DESCRIPTION
This regex change was overly greedy, and causes us to assign people to the city of "the army of X" until qwc fixes it.

We could also just make the regex better, but I don't think capturing whether or not an undead is in the undead army is worthwhile?

Fixes #820 