### PR TITLE
feat: supporting mounting of urns

### DIFF
--- a/svo (aliases, triggers).xml
+++ b/svo (aliases, triggers).xml
@@ -55129,7 +55129,7 @@ svo.conf.ridingsteed = matches[3]
 send(command, false)</script>
 				<command></command>
 				<packageName></packageName>
-				<regex>^(vault|mount|board) (\w+)$</regex>
+				<regex>^(vault|mount|board) ((\/|\w)+)$</regex>
 			</Alias>
 			<Alias isActive="yes" isFolder="no">
 				<name>(b *) Block a dir</name>


### PR DESCRIPTION
Supporting new game syntax such as `vault urn/veles` for `mount`ing and `vault`ing, for the Shop of Wonders `A petite ceramic urn`.